### PR TITLE
feat(post):  #15 내 포스트 목록 조회 API에 페이지네이션 및 응답 포맷 추가

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/global/api/response/PagedResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/api/response/PagedResponse.java
@@ -1,0 +1,47 @@
+package com.keepgoing.keepgoing.global.api.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(description = "페이지네이션 응답")
+@JsonPropertyOrder({"contents", "page", "size", "totalElements", "totalPages", "last"})
+@Getter
+@Builder
+@AllArgsConstructor
+public class PagedResponse<T> {
+
+    @Schema(description = "현재 페이지의 데이터 목록")
+    private final List<T> contents;
+
+    @Schema(description = "현재 페이지 번호 (0부터 시작)")
+    private final int page;
+
+    @Schema(description = "페이지 크기")
+    private final int size;
+
+    @Schema(description = "전체 요소 개수")
+    private final long totalElements;
+
+    @Schema(description = "전체 페이지 수")
+    private final int totalPages;
+
+    @Schema(description = "마지막 페이지 여부")
+    private final boolean last;
+
+    public static <T> PagedResponse<T> of(Page<?> pageInfo, List<T> contents) {
+        return PagedResponse.<T>builder()
+                .contents(contents)
+                .page(pageInfo.getNumber())
+                .size(pageInfo.getSize())
+                .totalElements(pageInfo.getTotalElements())
+                .totalPages(pageInfo.getTotalPages())
+                .last(pageInfo.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -62,16 +63,11 @@ public class PostController {
      */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyPosts(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
     ) {
         Long authorId = 1L; // TODO: Security 붙으면 현재 로그인 유저로 교체
 
-        Pageable pageable = PageRequest.of(
-                page,
-                size,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
         Page<Post> postPage = postService.getMyPosts(authorId, pageable);
 
         List<PostResponse> contents = postPage.getContent().stream()

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepgoing.post.controller;
 
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
+import com.keepgoing.keepgoing.global.api.response.PagedResponse;
 import com.keepgoing.keepgoing.post.controller.dto.PostCreateRequest;
 import com.keepgoing.keepgoing.post.controller.dto.PostResponse;
 import com.keepgoing.keepgoing.post.controller.dto.PostUpdateRequest;
@@ -8,6 +9,10 @@ import com.keepgoing.keepgoing.post.domain.Post;
 import com.keepgoing.keepgoing.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -56,15 +61,26 @@ public class PostController {
      * 내가 쓴 포스트 목록 조회
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<List<PostResponse>>> getMyPosts() {
+    public ResponseEntity<ApiResponse<PagedResponse<PostResponse>>> getMyPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         Long authorId = 1L; // TODO: Security 붙으면 현재 로그인 유저로 교체
 
-        List<Post> posts = postService.getMyPosts(authorId);
-        List<PostResponse> responses = posts.stream()
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        Page<Post> postPage = postService.getMyPosts(authorId, pageable);
+
+        List<PostResponse> contents = postPage.getContent().stream()
                 .map(PostResponse::from)
                 .toList();
 
-        return ResponseEntity.ok(ApiResponse.success(responses));
+        PagedResponse<PostResponse> body = PagedResponse.of(postPage, contents);
+
+        return ResponseEntity.ok(ApiResponse.success(body));
     }
 
     /**

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -10,6 +10,7 @@ import com.keepgoing.keepgoing.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -23,6 +24,8 @@ import java.util.List;
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
 public class PostController {
+
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final PostService postService;
 
@@ -66,6 +69,13 @@ public class PostController {
             Pageable pageable
     ) {
         Long authorId = 1L; // TODO: Security 붙으면 현재 로그인 유저로 교체
+
+        int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
+        Pageable safePageable = PageRequest.of(
+                pageable.getPageNumber(),
+                safeSize,
+                pageable.getSort()
+        );
 
         Page<Post> postPage = postService.getMyPosts(authorId, pageable);
 

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -10,7 +10,6 @@ import com.keepgoing.keepgoing.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;

--- a/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
@@ -34,11 +34,11 @@ public class Post {
     private String title;
 
     @Lob
-    @Column(name = "content",nullable = false, columnDefinition = "MEDIUMTEXT")
+    @Column(name = "content", nullable = false, columnDefinition = "MEDIUMTEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "visibility",nullable = false, length = 20)
+    @Column(name = "visibility", nullable = false, length = 20)
     @Builder.Default
     private PostVisibility visibility = PostVisibility.PRIVATE;
 
@@ -112,8 +112,8 @@ public class Post {
     /**
      * 작성자 권한 검증
      */
-    public void validateAuthor(Long authorID) {
-        if (!isAuthor(authorID)) {
+    public void validateAuthor(Long authorId) {
+        if (!isAuthor(authorId)) {
             throw new BusinessException(ErrorCode.POST_ACCESS_DENIED);
         }
     }

--- a/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.keepgoing.keepgoing.post.repository;
 
 import com.keepgoing.keepgoing.post.domain.Post;
 import com.keepgoing.keepgoing.post.domain.PostVisibility;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,10 +17,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findById(Long id);
 
     /**
-     * authorId 로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
+     * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
      * */
     @EntityGraph(attributePaths = {"author"})
-    List<Post> findByAuthor_IdOrderByCreatedAtDesc(Long authorId);
+    Page<Post> findByAuthor_Id(Long authorId, Pageable pageable);
 
     /**
      * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -64,15 +64,6 @@ public class PostService {
         return postRepository.findByAuthor_Id(authorId, pageable);
     }
 
-    //  옛날 버전: 기존 컨트롤러/테스트가 쓰던 시그니처 (임시 어댑터)
-    public List<Post> getMyPosts(Long authorId) {
-        Page<Post> page = getMyPosts(
-                authorId,
-                PageRequest.of(0, Integer.MAX_VALUE, Sort.by(Sort.Direction.DESC, "createdAt"))
-        );
-        return page.getContent();
-    }
-
     /**
      * 포스트 수정
      */

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -9,13 +9,9 @@ import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -8,6 +8,10 @@ import com.keepgoing.keepgoing.post.repository.PostRepository;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,8 +60,17 @@ public class PostService {
      * 내가 쓴 포스트 목록 조회
      */
     @Transactional(readOnly = true)
+    public Page<Post> getMyPosts(Long authorId, Pageable pageable) {
+        return postRepository.findByAuthor_Id(authorId, pageable);
+    }
+
+    //  옛날 버전: 기존 컨트롤러/테스트가 쓰던 시그니처 (임시 어댑터)
     public List<Post> getMyPosts(Long authorId) {
-        return postRepository.findByAuthor_IdOrderByCreatedAtDesc(authorId);
+        Page<Post> page = getMyPosts(
+                authorId,
+                PageRequest.of(0, Integer.MAX_VALUE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+        return page.getContent();
     }
 
     /**

--- a/src/test/http/post-api.http
+++ b/src/test/http/post-api.http
@@ -21,6 +21,13 @@ GET http://localhost:8080/api/v1/posts/{{postId}}
 ### 3. GET /api/v1/posts/me – 내 글 목록 조회
 GET http://localhost:8080/api/v1/posts/me
 
+
+### 3-1. GET /api/v1/posts/me – 내 글 목록 1페이지(size=5) 조회
+GET http://localhost:8080/api/v1/posts/me?page=0&size=5
+
+### 3-2 GET /api/v1/posts/me – 내 글 목록 2페이지(size=5) 조회
+GET http://localhost:8080/api/v1/posts/me?page=1&size=5
+
 ### 4. PUT /api/v1/posts/{id} – 글 수정
 PUT http://localhost:8080/api/v1/posts/{{postId}}
 Content-Type: application/json

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -198,6 +198,44 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.data.contents[1].title").value("제목2"));
     }
 
+    @Test
+    @DisplayName("GET /api/v1/posts/me - size가 MAX_PAGE_SIZE보다 크면 상한으로 제한된다")
+    void getMyPosts_clampsPageSize() throws Exception {
+        // given
+        Long authorId = 1L;
+
+        User author = User.builder()
+                .id(authorId)
+                .email("test@example.com")
+                .name("테스트유저")
+                .build();
+
+        Post post = Post.create(
+                author,
+                "제목",
+                "내용",
+                PostVisibility.PUBLIC,
+                true
+        );
+
+        int requestedSize = 1000;
+        int expectedSize = 100; // MAX_PAGE_SIZE
+
+        Pageable clampedPageable = PageRequest.of(0, expectedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = new PageImpl<>(List.of(post), clampedPageable, 1);
+
+        given(postService.getMyPosts(eq(authorId), any(Pageable.class)))
+                .willReturn(postPage);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/posts/me")
+                        .param("page", "0")
+                        .param("size", String.valueOf(requestedSize)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.size").value(expectedSize)); // 100
+    }
+
     // ========== PUT ==========
 
     @Test

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -160,7 +161,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v1/posts/me - 내 게시글 목록 조회 성공")
+    @DisplayName("GET /api/v1/posts/me - 내 게시글 페이지네이션 조회 성공")
     void getMyPosts_success() throws Exception {
         // given
         Long authorId = 1L; // TODO: Security 붙으면 현재 로그인 유저로 교체
@@ -173,16 +174,30 @@ public class PostControllerTest {
 
         Post post1 = Post.create(author, "제목1", "내용1", PostVisibility.PRIVATE, true);
         Post post2 = Post.create(author, "제목2", "내용2", PostVisibility.PUBLIC, true);
+        var posts = List.of(post1, post2);
 
-        given(postService.getMyPosts(authorId)).willReturn(List.of(post1, post2));
+        // 페이지 정보 (0페이지, size=10, createdAt DESC 정렬)
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = new PageImpl<>(posts, pageable, posts.size());
+
+        // 서비스 호출 스텁: authorId + 어떤 Pageable 이 오든 postPage 반환
+        given(postService.getMyPosts(eq(authorId), any(Pageable.class)))
+                .willReturn(postPage);
 
         // when & then
-        mockMvc.perform(get("/api/v1/posts/me"))
+        mockMvc.perform(get("/api/v1/posts/me")
+                        .param("page", "0")
+                        .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].title").value("제목1"))
-                .andExpect(jsonPath("$.data[1].title").value("제목2"));
+                // 페이지네이션 구조 확인
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                // 실제 contents 목록 검증
+                .andExpect(jsonPath("$.data.contents.length()").value(2))
+                .andExpect(jsonPath("$.data.contents[0].title").value("제목1"))
+                .andExpect(jsonPath("$.data.contents[1].title").value("제목2"));
     }
 
     // ========== PUT ==========

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -140,7 +140,6 @@ public class PostControllerTest {
         mockMvc.perform(get("/api/v1/posts/{postId}", postId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-//                .andExpect(jsonPath("$.data.id").value(postId))
                 .andExpect(jsonPath("$.data.title").value("테스트 제목"));
     }
 

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -185,9 +185,7 @@ public class PostControllerTest {
                 .willReturn(postPage);
 
         // when & then
-        mockMvc.perform(get("/api/v1/posts/me")
-                        .param("page", "0")
-                        .param("size", "10"))
+        mockMvc.perform(get("/api/v1/posts/me"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 // 페이지네이션 구조 확인

--- a/src/test/java/com/keepgoing/keepgoing/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/repository/PostRepositoryTest.java
@@ -37,44 +37,100 @@ class PostRepositoryTest {
         user2 = userRepository.save(User.builder().email("user2@test.com").name("유저2").build());
     }
 
+    private Pageable sortedByCreatedAtDesc(int size) {
+        return PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    // ========== findByAuthor_Id ==========
+
     @Test
-    @DisplayName("findByAuthor_IdOrderByCreatedAtDesc: 특정 작성자의 게시글을 최신순으로 정렬하여 반환한다")
-    void findByAuthorId_OrderByCreatedAtDesc() {
+    @DisplayName("findByAuthor_Id: 특정 작성자의 게시글을 createdAt 내림차순으로 페이징 조회한다")
+    void findByAuthorId_returnsPostsSortedByCreatedAtDesc() {
         // given
         postRepository.save(Post.create(user1, "제목1-1", "내용", PostVisibility.PUBLIC, true));
 
-        //NOTE: createdAt 정렬 보장용 (나중에 id 정렬 등으로 리팩터링 후보)
-        try { Thread.sleep(10); } catch (InterruptedException e) {}
+        // NOTE: createdAt 정렬 보장용 (나중에 id 정렬 등으로 리팩터링 후보)
+        try { Thread.sleep(10); } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         postRepository.save(Post.create(user2, "제목2-1", "내용", PostVisibility.PUBLIC, true)); // 다른 유저의 글
-        try { Thread.sleep(10); } catch (InterruptedException e) {}
+        try { Thread.sleep(10); } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         postRepository.save(Post.create(user1, "제목1-2", "내용", PostVisibility.PUBLIC, true));
 
+        Pageable pageable = sortedByCreatedAtDesc(10);
+
         // when
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Post> page = postRepository.findByAuthor_Id(user1.getId(), pageable);
         List<Post> result = page.getContent();
 
         // then
+        assertThat(page.getTotalElements()).isEqualTo(2);
         assertThat(result).hasSize(2);
-        // createdAt이 보장되므로, 나중에 만든 "제목1-2"가 먼저 와야 함
-        assertThat(result.get(0).getTitle()).isEqualTo("제목1-2");
+        assertThat(result.get(0).getTitle()).isEqualTo("제목1-2"); // 최신
         assertThat(result.get(1).getTitle()).isEqualTo("제목1-1");
     }
 
     @Test
-    @DisplayName("findByAuthor_IdOrderByCreatedAtDesc: 작성자의 게시글이 없으면 빈 리스트를 반환한다")
-    void findByAuthorId_ReturnsEmptyList_WhenNoPosts() {
+    @DisplayName("findByAuthor_Id: 작성자의 게시글이 없으면 빈 리스트를 반환한다")
+    void findByAuthorId_returnsEmptyList_WhenNoPosts() {
         // given
         // user1이 작성한 글 없음
 
+        Pageable pageable = sortedByCreatedAtDesc(10);
+
         // when
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         List<Post> result = postRepository.findByAuthor_Id(user1.getId(), pageable)
                 .getContent();
 
         // then
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("findByAuthor_Id: soft delete 된 게시글은 조회되지 않는다")
+    void findByAuthorId_excludesSoftDeletedPosts() {
+        // given
+        Post post1 = postRepository.save(Post.create(user1, "살아있는 글", "내용", PostVisibility.PUBLIC, true));
+        Post post2 = postRepository.save(Post.create(user1, "삭제된 글", "내용", PostVisibility.PUBLIC, true));
+
+        // soft delete
+        post2.softDelete();
+        postRepository.save(post2); // 변경사항 반영
+
+        Pageable pageable = sortedByCreatedAtDesc(10);
+
+        // when
+        List<Post> result = postRepository.findByAuthor_Id(user1.getId(), pageable)
+                .getContent();
+
+        // then
+        assertThat(result)
+                .hasSize(1)
+                .extracting(Post::getTitle)
+                .containsExactly("살아있는 글");
+    }
+
+    // ========== findById ==========
+
+    @Test
+    @DisplayName("findById: findById는 author를 함께 로딩한다(@EntityGraph)")
+    void findById_loadsAuthorWithEntityGraph() {
+        // given
+        User author = user1;
+
+        Post saved = postRepository.save(Post.create(author, "title", "content", PostVisibility.PRIVATE, true));
+
+        // when
+        Post found = postRepository.findById(saved.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(found.getAuthor().getId()).isEqualTo(author.getId());
+    }
+
+    // ========== findByVisibilityOrderByCreatedAtDesc ==========
 
     @Test
     @DisplayName("findByVisibilityOrderByCreatedAtDesc: 공개 범위에 따라 필터링하고 최신순으로 정렬한다")
@@ -106,44 +162,5 @@ class PostRepositoryTest {
 
         // then
         assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("findByAuthor_IdOrderByCreatedAtDesc: soft delete 된 게시글은 조회되지 않는다")
-    void findByAuthorIdOrderByCreatedAtDesc_excludesSoftDeletedPosts() {
-        // given
-        Post post1 = postRepository.save(Post.create(user1, "살아있는 글", "내용", PostVisibility.PUBLIC, true));
-        Post post2 = postRepository.save(Post.create(user1, "삭제된 글", "내용", PostVisibility.PUBLIC, true));
-
-        // soft delete
-        post2.softDelete();
-        postRepository.save(post2); // 변경사항 반영
-
-        // when
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<Post> result = postRepository.findByAuthor_Id(user1.getId(), pageable)
-                .getContent();
-
-        // then
-        assertThat(result)
-                .hasSize(1)
-                .extracting(Post::getTitle)
-                .containsExactly("살아있는 글");
-    }
-
-    @Test
-    @DisplayName("findById는 author를 함께 로딩한다(@EntityGraph)")
-    void findById_loadsAuthorWithEntityGraph() {
-        // given
-        User author = user1;
-
-        Post saved = postRepository.save(Post.create(author, "title", "content", PostVisibility.PRIVATE, true));
-
-        // when
-        Post found = postRepository.findById(saved.getId())
-                .orElseThrow();
-
-        // then
-        assertThat(found.getAuthor().getId()).isEqualTo(author.getId());
     }
 }

--- a/src/test/java/com/keepgoing/keepgoing/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/repository/PostRepositoryTest.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -46,7 +50,9 @@ class PostRepositoryTest {
         postRepository.save(Post.create(user1, "제목1-2", "내용", PostVisibility.PUBLIC, true));
 
         // when
-        List<Post> result = postRepository.findByAuthor_IdOrderByCreatedAtDesc(user1.getId());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> page = postRepository.findByAuthor_Id(user1.getId(), pageable);
+        List<Post> result = page.getContent();
 
         // then
         assertThat(result).hasSize(2);
@@ -62,7 +68,9 @@ class PostRepositoryTest {
         // user1이 작성한 글 없음
 
         // when
-        List<Post> result = postRepository.findByAuthor_IdOrderByCreatedAtDesc(user1.getId());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Post> result = postRepository.findByAuthor_Id(user1.getId(), pageable)
+                .getContent();
 
         // then
         assertThat(result).isEmpty();
@@ -112,7 +120,9 @@ class PostRepositoryTest {
         postRepository.save(post2); // 변경사항 반영
 
         // when
-        List<Post> result = postRepository.findByAuthor_IdOrderByCreatedAtDesc(user1.getId());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Post> result = postRepository.findByAuthor_Id(user1.getId(), pageable)
+                .getContent();
 
         // then
         assertThat(result)

--- a/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
@@ -151,17 +151,17 @@ public class PostServiceTest {
         Post post1 = Post.create(author, "제목1", "내용1", PostVisibility.PRIVATE, true);
         Post post2 = Post.create(author, "제목2", "내용2", PostVisibility.PUBLIC, true);
 
-        given(postRepository.findByAuthor_IdOrderByCreatedAtDesc(authorId))
-                .willReturn(List.of(post1, post2));
+//        given(postRepository.findByAuthor_IdOrderByCreatedAtDesc(authorId))
+//                .willReturn(List.of(post1, post2));
 
         // when
-        List<Post> posts = postService.getMyPosts(authorId);
+//        List<Post> posts = postService.getMyPosts(authorId);
 
         // then
-        assertThat(posts).hasSize(2);
-        assertThat(posts.get(0).getTitle()).isEqualTo("제목1");
-        assertThat(posts.get(1).getTitle()).isEqualTo("제목2");
-        verify(postRepository).findByAuthor_IdOrderByCreatedAtDesc(authorId);
+//        assertThat(posts).hasSize(2);
+//        assertThat(posts.get(0).getTitle()).isEqualTo("제목1");
+//        assertThat(posts.get(1).getTitle()).isEqualTo("제목2");
+//        verify(postRepository).findByAuthor_IdOrderByCreatedAtDesc(authorId);
     }
 
     // ========== updatePost ==========

--- a/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,26 +142,40 @@ public class PostServiceTest {
     // ========== getMyPosts ==========
 
     @Test
-    @DisplayName("getMyPosts: 작성자 ID로 게시글 목록을 최신순으로 가져온다")
-    void getMyPosts_returnsList() {
+    @DisplayName("getMyPosts: 작성자 ID와 Pageable로 게시글 페이지를 가져온다")
+    void getMyPosts_returnsPage() {
         // given
         Long authorId = 1L;
         User author = createAuthor(authorId);
 
         Post post1 = Post.create(author, "제목1", "내용1", PostVisibility.PRIVATE, true);
         Post post2 = Post.create(author, "제목2", "내용2", PostVisibility.PUBLIC, true);
+        var posts = java.util.List.of(post1, post2);
 
-//        given(postRepository.findByAuthor_IdOrderByCreatedAtDesc(authorId))
-//                .willReturn(List.of(post1, post2));
+        Pageable pageable = PageRequest.of(
+                0,
+                10,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        Page<Post> postPage = new PageImpl<>(
+                posts,
+                pageable,
+                posts.size()
+        );
+
+        // 저장소가 페이지를 반환하는 동작을 스텁
+        given(postRepository.findByAuthor_Id(authorId, pageable))
+                .willReturn(postPage);
 
         // when
-//        List<Post> posts = postService.getMyPosts(authorId);
+        Page<Post> result = postService.getMyPosts(authorId, pageable);
 
         // then
-//        assertThat(posts).hasSize(2);
-//        assertThat(posts.get(0).getTitle()).isEqualTo("제목1");
-//        assertThat(posts.get(1).getTitle()).isEqualTo("제목2");
-//        verify(postRepository).findByAuthor_IdOrderByCreatedAtDesc(authorId);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("제목1");
+        assertThat(result.getContent().get(1).getTitle()).isEqualTo("제목2");
+        verify(postRepository).findByAuthor_Id(authorId, pageable);
     }
 
     // ========== updatePost ==========


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
- #15 

### ✨ 반영 브랜치
feat/15 -> develop

### 📝 변경 사항
- PostRepository
  - 기존 `List<Post> findByAuthor_IdOrderByCreatedAtDesc(Long authorId)` 대신
    `Page<Post> findByAuthor_Id(Long authorId, Pageable pageable)`를 사용해 페이지네이션 지원
  - 작성자 기준(createdAt DESC)으로 정렬된 페이지 결과를 반환하도록 구현
- PostService
  - `getMyPosts(Long authorId)` → `getMyPosts(Long authorId, Pageable pageable)` 시그니처로 변경
  - 내부에서 `postRepository.findByAuthor_Id(authorId, pageable)` 호출하도록 수정
  - 서비스는 `Page<Post>`를 그대로 반환하고, DTO 변환은 컨트롤러에서 담당하도록 역할 분리
- PostController
  - `GET /api/v1/posts/me`에 페이지네이션 적용
    - `@PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable` 사용
  - 서비스에서 받은 `Page<Post>`를 `List<PostResponse>`로 매핑 후
    `PagedResponse<PostResponse>`로 감싸 `ApiResponse<PagedResponse<PostResponse>>` 형태로 응답
  - 응답 필드 예시: `contents`, `page`, `size`, `totalElements`, `totalPages`, `last`
- 공용 페이징 응답 DTO
  - `global.api.response.PagedResponse<T>` 추가
  - `Page<?>` + `List<T>`를 받아서 페이징 메타데이터와 컨텐츠를 함께 내려주는 정적 팩토리 메서드 `of(Page<?> pageInfo, List<T> contents)` 제공
- 테스트 코드
  - `PostRepositoryTest`
    - `findByAuthor_Id`가 작성자 기준 + createdAt DESC 정렬로 페이징 조회하는지 검증
    - 게시글이 없을 때 빈 페이지, soft delete된 게시글이 제외되는지 테스트 추가
  - `PostServiceTest`
    - `PageImpl` + `Pageable`을 사용해 `getMyPosts`의 페이지네이션 동작 검증
  - `PostControllerTest`
    - `GET /api/v1/posts/me` 호출 시 `data.contents`, `data.page`, `data.size`, `data.totalElements` 등을 검증
    - `page/size` 파라미터 없이 호출했을 때 `@PageableDefault(page=0, size=10)`이 적용되는지 확인
- HTTP 시나리오(.http)
  - `GET /api/v1/posts/me`
  - `GET /api/v1/posts/me?page=1&size=5` 등 페이지네이션 요청 추가하고 응답 구조 수동 확인

### ➕ 추가 메모
- `GET /api/v1/posts/me`의 응답 스키마가 `List<PostResponse>`에서 `PagedResponse<PostResponse>`로 변경되었습니다.
  - 클라이언트에서는 이제 `data.contents`에서 목록을 읽고, `data.page`, `data.size`, `data.totalElements`, `data.totalPages`, `data.last`를 사용해 페이지네이션 UI를 구성할 수 있습니다.
- 현재는 “내가 쓴 포스트 목록”에만 페이지네이션을 적용했으며,
  추후 공개글/전체글 목록 조회 API에도 같은 `PagedResponse` 패턴을 재사용할 수 있습니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- [x] PostRepositoryTest 통과
- [x] PostServiceTest 통과
- [x] PostControllerTest 통과
- [x] IntelliJ HTTP Client로 /api/v1/posts/me 페이지네이션 수동 검증 완료