### PR TITLE
feat(post): #26 게시글 검색 API 추가 및 테스트 보강

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -148,6 +148,11 @@ public enum ErrorCode {
             "POST_02",
             "해당 게시글에 대한 권한이 없습니다."
     ),
+    POST_SEARCH_KEYWORD_REQUIRED(
+            HttpStatus.BAD_REQUEST,
+            "POST_03",
+            "검색어(keyword)는 필수입니다."
+    )
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html"
+                                "/swagger-ui.html",
+                                "/api/posts/search"
                         ).permitAll()
 
                         // 회원가입/로그인 API 허용

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -123,8 +123,30 @@ public class PostController {
         );
 
         List<PostSummaryResponse> contents = page.getContent().stream()
-               .map(PostSummaryResponse::from)
-               .toList();
+                .map(PostSummaryResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
+    }
+
+    /**
+     * 포스트 검색
+     */
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PagedResponse<PostSummaryResponse>>> search(
+            @RequestParam String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Pageable safePageable = safePageable(pageable);
+
+        Page<PostSummaryResult> page = postService.searchPost(
+                new PostSearchQuery(keyword, safePageable)
+        );
+
+        List<PostSummaryResponse> contents = page.getContent().stream()
+                .map(PostSummaryResponse::from)
+                .toList();
 
         return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
     }

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -7,10 +7,7 @@ import com.keepgoing.keepgoing.post.controller.dto.PostDetailResponse;
 import com.keepgoing.keepgoing.post.controller.dto.PostSummaryResponse;
 import com.keepgoing.keepgoing.post.controller.dto.PostUpdateRequest;
 import com.keepgoing.keepgoing.post.service.PostService;
-import com.keepgoing.keepgoing.post.service.dto.PostCreateCommand;
-import com.keepgoing.keepgoing.post.service.dto.PostDetailResult;
-import com.keepgoing.keepgoing.post.service.dto.PostSummaryResult;
-import com.keepgoing.keepgoing.post.service.dto.PostUpdateCommand;
+import com.keepgoing.keepgoing.post.service.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -69,12 +66,7 @@ public class PostController {
             Pageable pageable,
             @AuthenticationPrincipal Long userId
     ) {
-        int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
-        Pageable safePageable = PageRequest.of(
-                pageable.getPageNumber(),
-                safeSize,
-                pageable.getSort()
-        );
+        Pageable safePageable = safePageable(pageable);
 
         Page<PostSummaryResult> page = postService.getPosts(userId, safePageable);
 
@@ -111,5 +103,36 @@ public class PostController {
     ) {
         postService.deletePost(userId, postId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 포스트 조회
+     */
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PagedResponse<PostSummaryResponse>>> search(
+            @RequestParam String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Pageable safePageable = safePageable(pageable);
+
+        Page<PostSummaryResult> page = postService.searchPost(
+                new PostSearchQuery(keyword, safePageable)
+        );
+
+       List<PostSummaryResponse> contents = page.getContent().stream()
+               .map(PostSummaryResponse::from)
+               .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
+    }
+
+    private Pageable safePageable(Pageable pageable) {
+        int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                safeSize,
+                pageable.getSort()
+        );
     }
 }

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/PostController.java
@@ -106,21 +106,23 @@ public class PostController {
     }
 
     /**
-     * 포스트 조회
+     * 내 포스트 검색
      */
-    @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PagedResponse<PostSummaryResponse>>> search(
+    @GetMapping("/me/search")
+    public ResponseEntity<ApiResponse<PagedResponse<PostSummaryResponse>>> searchMyPosts(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable
+            Pageable pageable,
+            @AuthenticationPrincipal Long userId
     ) {
         Pageable safePageable = safePageable(pageable);
 
-        Page<PostSummaryResult> page = postService.searchPost(
+        Page<PostSummaryResult> page = postService.searchMyPosts(
+                userId,
                 new PostSearchQuery(keyword, safePageable)
         );
 
-       List<PostSummaryResponse> contents = page.getContent().stream()
+        List<PostSummaryResponse> contents = page.getContent().stream()
                .map(PostSummaryResponse::from)
                .toList();
 

--- a/src/main/java/com/keepgoing/keepgoing/post/controller/dto/PostCreateRequest.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/controller/dto/PostCreateRequest.java
@@ -23,9 +23,9 @@ public record PostCreateRequest(
         if (visibility == null) {
             visibility = PostVisibility.PRIVATE;
         }
-        // aiCollectable이 요청에 없거나 null이면 기본값 true
+        // aiCollectable이 요청에 없거나 null이면 기본값 false
         if (aiCollectable == null) {
-            aiCollectable = true;
+            aiCollectable = false;
         }
     }
 

--- a/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
@@ -44,7 +44,7 @@ public class Post {
 
     @Column(name = "ai_collectable", nullable = false)
     @Builder.Default
-    private boolean aiCollectable = true;
+    private boolean aiCollectable = false;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -68,15 +68,28 @@ public class Post {
                               PostVisibility visibility,
                               Boolean aiCollectable) {
 
+        if (author == null || author.getId() == null) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        if (title == null || title.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (content == null || content.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
         PostVisibility finalVisibility =
                 (visibility != null) ? visibility : PostVisibility.PRIVATE;
+
+        boolean finalAiCollectable =
+                (aiCollectable != null) && aiCollectable;
 
         return Post.builder()
                 .author(author)
                 .title(title)
                 .content(content)
                 .visibility(finalVisibility)
-                .aiCollectable(aiCollectable)
+                .aiCollectable(finalAiCollectable)
                 .build();
     }
 

--- a/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/domain/Post.java
@@ -103,7 +103,7 @@ public class Post {
     }
 
     /**
-     * 삭제 여부 (테스트/관리용)
+     * 삭제 처리된 게시글인지 여부
      */
     public boolean isDeleted() {
         return deletedAt != null;

--- a/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,9 +34,20 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * keyword가 title 혹은 content에 포함된 게시글을 페이징 조회한다.
      * */
     @EntityGraph(attributePaths = {"author"})
-    Page<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+    Page<Post> findByTitleContainingOrContentContaining(
             String titleKeyword,
             String contentKeyword,
             Pageable pageable
     );
+
+    @Query("""
+    select p
+    from Post p
+    where p.author.id = :authorId
+      and (p.title like concat('%', :keyword, '%')
+           or p.content like concat('%', :keyword, '%'))
+    """)
+    Page<Post> searchMyPosts(@Param("authorId") Long authorId,
+                             @Param("keyword") String keyword,
+                             Pageable pageable);
 }

--- a/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
@@ -18,13 +18,23 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     /**
      * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
-     * */
+     */
     @EntityGraph(attributePaths = {"author"})
     Page<Post> findByAuthor_Id(Long authorId, Pageable pageable);
 
     /**
      * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
-     * */
+     */
     @EntityGraph(attributePaths = {"author"})
     List<Post> findByVisibilityOrderByCreatedAtDesc(PostVisibility visibility);
+
+    /**
+     * keyword가 title 혹은 content에 포함된 게시글을 페이징 조회한다.
+     * */
+    @EntityGraph(attributePaths = {"author"})
+    Page<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+            String titleKeyword,
+            String contentKeyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/repository/PostRepository.java
@@ -30,9 +30,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = {"author"})
     List<Post> findByVisibilityOrderByCreatedAtDesc(PostVisibility visibility);
 
-    /**
-     * keyword가 title 혹은 content에 포함된 게시글을 페이징 조회한다.
-     * */
+    // 전체 검색(derived query)
     @EntityGraph(attributePaths = {"author"})
     Page<Post> findByTitleContainingOrContentContaining(
             String titleKeyword,
@@ -40,13 +38,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Pageable pageable
     );
 
+    // (B) 내 글 검색(작성자 조건 포함)
     @Query("""
-    select p
-    from Post p
-    where p.author.id = :authorId
-      and (p.title like concat('%', :keyword, '%')
-           or p.content like concat('%', :keyword, '%'))
-    """)
+            select p
+            from Post p
+            where p.author.id = :authorId
+              and (p.title like concat('%', :keyword, '%')
+                   or p.content like concat('%', :keyword, '%'))
+            """)
     Page<Post> searchMyPosts(@Param("authorId") Long authorId,
                              @Param("keyword") String keyword,
                              Pageable pageable);

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -91,13 +91,14 @@ public class PostService {
     /**
      * 포스트 검색
      */
-    public Page<PostSummaryResult> searchPost(PostSearchQuery query) {
+    @Transactional(readOnly = true)
+    public Page<PostSummaryResult> searchMyPosts(Long userId, PostSearchQuery query) {
         if (query == null || !query.hasKeyword()) {
             throw new BusinessException(ErrorCode.POST_SEARCH_KEYWORD_REQUIRED);
         }
 
-        Page<Post> page = postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-                query.keyword(),
+        Page<Post> page = postRepository.searchMyPosts(
+                userId,
                 query.keyword(),
                 query.pageable()
         );

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -4,10 +4,7 @@ import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.post.domain.Post;
 import com.keepgoing.keepgoing.post.repository.PostRepository;
-import com.keepgoing.keepgoing.post.service.dto.PostCreateCommand;
-import com.keepgoing.keepgoing.post.service.dto.PostDetailResult;
-import com.keepgoing.keepgoing.post.service.dto.PostSummaryResult;
-import com.keepgoing.keepgoing.post.service.dto.PostUpdateCommand;
+import com.keepgoing.keepgoing.post.service.dto.*;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +86,23 @@ public class PostService {
 
         post.validateAuthor(userId);
         post.softDelete(); // deleted_at만 채움 → @Where 때문에 이후 조회에서 빠짐
+    }
+
+    /**
+     * 포스트 검색
+     */
+    public Page<PostSummaryResult> searchPost(PostSearchQuery query) {
+        if (query == null || !query.hasKeyword()) {
+            throw new BusinessException(ErrorCode.POST_SEARCH_KEYWORD_REQUIRED);
+        }
+
+        Page<Post> page = postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+                query.keyword(),
+                query.keyword(),
+                query.pageable()
+        );
+
+        return page.map(this::toSummaryResult);
     }
 
     private PostDetailResult toDetailResult(Post post) {

--- a/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/PostService.java
@@ -89,7 +89,7 @@ public class PostService {
     }
 
     /**
-     * 포스트 검색
+     * 내 글 검색
      */
     @Transactional(readOnly = true)
     public Page<PostSummaryResult> searchMyPosts(Long userId, PostSearchQuery query) {
@@ -99,6 +99,28 @@ public class PostService {
 
         Page<Post> page = postRepository.searchMyPosts(
                 userId,
+                query.keyword(),
+                query.pageable()
+        );
+
+        return page.map(this::toSummaryResult);
+    }
+
+    /**
+     * 전체(공개/공통) 검색
+     *
+     * NOTE: MySQL에서 TEXT/MEDIUMTEXT 컬럼(content)이 CLOB로 매핑될 때,
+     *       IgnoreCase 파생 쿼리는 upper()/lower()를 사용하며 오류가 날 수 있어
+     *       Containing(대소문자 구분은 collation에 위임) 형태로 유지합니다.
+     */
+    @Transactional(readOnly = true)
+    public Page<PostSummaryResult> searchPost(PostSearchQuery query) {
+        if (query == null || !query.hasKeyword()) {
+            throw new BusinessException(ErrorCode.POST_SEARCH_KEYWORD_REQUIRED);
+        }
+
+        Page<Post> page = postRepository.findByTitleContainingOrContentContaining(
+                query.keyword(),
                 query.keyword(),
                 query.pageable()
         );

--- a/src/main/java/com/keepgoing/keepgoing/post/service/dto/PostSearchQuery.java
+++ b/src/main/java/com/keepgoing/keepgoing/post/service/dto/PostSearchQuery.java
@@ -1,0 +1,18 @@
+package com.keepgoing.keepgoing.post.service.dto;
+
+import org.springframework.data.domain.Pageable;
+
+public record PostSearchQuery(
+        String keyword,
+        Pageable pageable
+) {
+    public PostSearchQuery {
+        if (keyword != null) {
+            keyword = keyword.trim();
+        }
+    }
+
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.isBlank();
+    }
+}

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -347,9 +347,14 @@ public class PostControllerTest {
     // ========== SEARCH ==========
 
     @Test
-    @DisplayName("GET /api/posts/search - 검색 성공 시 200 OK 및 contents 반환")
+    @DisplayName("GET /api/posts/me/search - 검색 성공 시 200 OK 및 contents 반환")
     void search_success() throws Exception {
-        //given
+        // given
+        Long userId = 1L;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+        );
+
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         List<PostSummaryResult> results = List.of(
@@ -359,11 +364,11 @@ public class PostControllerTest {
 
         Page<PostSummaryResult> page = new PageImpl<>(results, pageable, results.size());
 
-        given(postService.searchPost(any(PostSearchQuery.class)))
+        given(postService.searchMyPosts(eq(userId), any(PostSearchQuery.class)))
                 .willReturn(page);
 
         // when & then
-        mockMvc.perform(get("/api/posts/search")
+        mockMvc.perform(get("/api/posts/me/search")
                         .param("keyword", "spring")
                         .param("page", "0")
                         .param("size", "10"))
@@ -372,17 +377,24 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.data.contents").isArray())
                 .andExpect(jsonPath("$.data.contents.length()").value(2))
                 .andExpect(jsonPath("$.data.contents[0].title").value("spring 제목"));
+
+        verify(postService).searchMyPosts(eq(userId), any(PostSearchQuery.class));
     }
 
     @Test
-    @DisplayName("GET /api/posts/search - size가 MAX_PAGE_SIZE보다 크면 상한(100)으로 제한된다")
+    @DisplayName("GET /api/posts/me/search - size가 MAX_PAGE_SIZE보다 크면 상한(100)으로 제한된다")
     void search_clampsPageSize() throws Exception {
         // given
-        given(postService.searchPost(any(PostSearchQuery.class)))
+        Long userId = 1L;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+        );
+
+        given(postService.searchMyPosts(eq(userId), any(PostSearchQuery.class)))
                 .willReturn(Page.empty());
 
         // when
-        mockMvc.perform(get("/api/posts/search")
+        mockMvc.perform(get("/api/posts/me/search")
                         .param("keyword", "spring")
                         .param("page", "0")
                         .param("size", "1000"))
@@ -391,22 +403,27 @@ public class PostControllerTest {
 
         // then
         ArgumentCaptor<PostSearchQuery> captor = ArgumentCaptor.forClass(PostSearchQuery.class);
-        verify(postService).searchPost(captor.capture());
+        verify(postService).searchMyPosts(eq(userId), captor.capture());
 
         PostSearchQuery passed = captor.getValue();
         assertThat(passed.keyword()).isEqualTo("spring");
-        assertThat(passed.pageable().getPageSize()).isEqualTo(100); // MAX_PAGE_SIZE
+        assertThat(passed.pageable().getPageSize()).isEqualTo(100);
     }
 
     @Test
-    @DisplayName("GET /api/posts/search - keyword가 공백이면 400 + POST_SEARCH_KEYWORD_REQUIRED 반환")
+    @DisplayName("GET /api/posts/me/search - keyword가 공백이면 400 + POST_SEARCH_KEYWORD_REQUIRED 반환")
     void search_blankKeyword_returns400() throws Exception {
         // given
-        given(postService.searchPost(any(PostSearchQuery.class)))
+        Long userId = 1L;
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+        );
+
+        given(postService.searchMyPosts(eq(userId), any(PostSearchQuery.class)))
                 .willThrow(new BusinessException(ErrorCode.POST_SEARCH_KEYWORD_REQUIRED));
 
         // when & then
-        mockMvc.perform(get("/api/posts/search")
+        mockMvc.perform(get("/api/posts/me/search")
                         .param("keyword", "   ")
                         .param("page", "0")
                         .param("size", "10"))

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -9,12 +9,11 @@ import com.keepgoing.keepgoing.post.controller.dto.PostCreateRequest;
 import com.keepgoing.keepgoing.post.controller.dto.PostUpdateRequest;
 import com.keepgoing.keepgoing.post.domain.PostVisibility;
 import com.keepgoing.keepgoing.post.service.PostService;
-import com.keepgoing.keepgoing.post.service.dto.PostCreateCommand;
-import com.keepgoing.keepgoing.post.service.dto.PostDetailResult;
-import com.keepgoing.keepgoing.post.service.dto.PostSummaryResult;
-import com.keepgoing.keepgoing.post.service.dto.PostUpdateCommand;
+import com.keepgoing.keepgoing.post.service.dto.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
@@ -56,6 +56,10 @@ public class PostControllerTest {
     @MockitoBean
     JwtProvider jwtProvider;
 
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
     // ========== Post ==========
 
     @Test
@@ -178,16 +182,24 @@ public class PostControllerTest {
                 .willReturn(postPage);
 
         SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(1L, null, List.of())
+                new UsernamePasswordAuthenticationToken(userId, null, List.of())
         );
 
         // when & then
         mockMvc.perform(get("/api/posts/me")
                         .param("page", "0")
-                        .param("size", "1000"))
-                .andExpect(status().isOk());
-
-        SecurityContextHolder.clearContext();
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.contents").isArray())
+                .andExpect(jsonPath("$.data.contents.length()").value(2))
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.contents[0].title").value("제목1"))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.last").value(true));
+        verify(postService).getPosts(eq(userId), any(Pageable.class));
     }
 
     @Test
@@ -196,36 +208,26 @@ public class PostControllerTest {
         // given
         Long userId = 1L;
 
-        PostSummaryResult post = new PostSummaryResult(
-                1L,
-                "제목",
-                PostVisibility.PUBLIC,
-                true,
-                null
-        );
-
-        int requestedSize = 1000;
-        int expectedSize = 100; // MAX_PAGE_SIZE
-
-        Pageable clampedPageable = PageRequest.of(0, expectedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<PostSummaryResult> postPage = new PageImpl<>(List.of(post), clampedPageable, 1);
-
         given(postService.getPosts(eq(userId), any(Pageable.class)))
-                .willReturn(postPage);
+                .willReturn(Page.empty());
 
         SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(1L, null, List.of())
+                new UsernamePasswordAuthenticationToken(userId, null, List.of())
         );
 
-        // when & then
+        // when
         mockMvc.perform(get("/api/posts/me")
                         .param("page", "0")
-                        .param("size", String.valueOf(requestedSize)))
+                        .param("size", "1000"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.size").value(expectedSize)); // 100
+                .andExpect(jsonPath("$.success").value(true));
 
-        SecurityContextHolder.clearContext();
+        // then
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(postService).getPosts(eq(userId), captor.capture());
+
+        assertThat(captor.getValue().getPageSize()).isEqualTo(100);
+
     }
 
     // ========== PUT ==========
@@ -319,7 +321,6 @@ public class PostControllerTest {
 
         verify(postService).deletePost(userId, postId);
 
-        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -341,7 +342,76 @@ public class PostControllerTest {
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("POST_ACCESS_DENIED"));
+    }
 
-        SecurityContextHolder.clearContext();
+    // ========== SEARCH ==========
+
+    @Test
+    @DisplayName("GET /api/posts/search - 검색 성공 시 200 OK 및 contents 반환")
+    void search_success() throws Exception {
+        //given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        List<PostSummaryResult> results = List.of(
+                new PostSummaryResult(1L, "spring 제목", PostVisibility.PUBLIC, true, null),
+                new PostSummaryResult(2L, "기타 제목", PostVisibility.PRIVATE, false, null)
+        );
+
+        Page<PostSummaryResult> page = new PageImpl<>(results, pageable, results.size());
+
+        given(postService.searchPost(any(PostSearchQuery.class)))
+                .willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/api/posts/search")
+                        .param("keyword", "spring")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.contents").isArray())
+                .andExpect(jsonPath("$.data.contents.length()").value(2))
+                .andExpect(jsonPath("$.data.contents[0].title").value("spring 제목"));
+    }
+
+    @Test
+    @DisplayName("GET /api/posts/search - size가 MAX_PAGE_SIZE보다 크면 상한(100)으로 제한된다")
+    void search_clampsPageSize() throws Exception {
+        // given
+        given(postService.searchPost(any(PostSearchQuery.class)))
+                .willReturn(Page.empty());
+
+        // when
+        mockMvc.perform(get("/api/posts/search")
+                        .param("keyword", "spring")
+                        .param("page", "0")
+                        .param("size", "1000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        // then
+        ArgumentCaptor<PostSearchQuery> captor = ArgumentCaptor.forClass(PostSearchQuery.class);
+        verify(postService).searchPost(captor.capture());
+
+        PostSearchQuery passed = captor.getValue();
+        assertThat(passed.keyword()).isEqualTo("spring");
+        assertThat(passed.pageable().getPageSize()).isEqualTo(100); // MAX_PAGE_SIZE
+    }
+
+    @Test
+    @DisplayName("GET /api/posts/search - keyword가 공백이면 400 + POST_SEARCH_KEYWORD_REQUIRED 반환")
+    void search_blankKeyword_returns400() throws Exception {
+        // given
+        given(postService.searchPost(any(PostSearchQuery.class)))
+                .willThrow(new BusinessException(ErrorCode.POST_SEARCH_KEYWORD_REQUIRED));
+
+        // when & then
+        mockMvc.perform(get("/api/posts/search")
+                        .param("keyword", "   ")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("POST_SEARCH_KEYWORD_REQUIRED"));
     }
 }

--- a/src/test/java/com/keepgoing/keepgoing/post/domain/PostTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/domain/PostTest.java
@@ -53,7 +53,7 @@ class PostTest {
         String title = "제목";
         String content = "내용";
         PostVisibility visibility = null;
-        boolean aiCollectable = true;
+        boolean aiCollectable = false;
 
         //when
         Post post = Post.create(
@@ -69,7 +69,7 @@ class PostTest {
         assertThat(post.getTitle()).isEqualTo(title);
         assertThat(post.getContent()).isEqualTo(content);
         assertThat(post.getVisibility()).isEqualTo(PostVisibility.PRIVATE);
-        assertThat(post.isAiCollectable()).isTrue();
+        assertThat(post.isAiCollectable()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
@@ -58,7 +58,7 @@ public class PostServiceTest {
         String title = "제목";
         String content = "내용";
         PostVisibility visibility = PostVisibility.PRIVATE;
-        boolean aiCollectable = true;
+        boolean aiCollectable = false;
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -100,7 +100,7 @@ public class PostServiceTest {
         String title = "제목";
         String content = "내용";
         PostVisibility visibility = PostVisibility.PRIVATE;
-        boolean aiCollectable = true;
+        boolean aiCollectable = false;
 
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
@@ -375,10 +375,10 @@ public class PostServiceTest {
         verifyNoInteractions(userRepository);
     }
 
-    // ========== searchPost ==========
+    // ========== searchMyPosts ==========
 
     @Test
-    @DisplayName("searchPost: keyword가 있으면 검색 결과를 페이지로 반환한다")
+    @DisplayName("searchMyPosts: keyword가 있으면 검색 결과를 페이지로 반환한다")
     void searchPost_returnsPageWhenKeywordProvided() {
         //given
         Long userId = 1L;
@@ -392,46 +392,45 @@ public class PostServiceTest {
 
         PostSearchQuery query = new PostSearchQuery("spring", pageable);
 
-        given(postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-                "spring",  "spring", pageable
-        )).willReturn(postPage);
+        given(postRepository.searchMyPosts(userId, "spring", pageable))
+                .willReturn(postPage);
 
         // when
-        Page<PostSummaryResult> result = postService.searchPost(query); // 메서드명 맞추기
+        Page<PostSummaryResult> result = postService.searchMyPosts(userId, query);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(2);
-        verify(postRepository).findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-                "spring", "spring", pageable
-        );
+        verify(postRepository).searchMyPosts(userId, "spring", pageable);
         verifyNoMoreInteractions(postRepository);
         verifyNoInteractions(userRepository);
     }
 
     @Test
-    @DisplayName("searchPost: keyword가 비어있으면 POST_SEARCH_KEYWORD_REQUIRED 예외")
+    @DisplayName("searchMyPosts: keyword가 비어있으면 POST_SEARCH_KEYWORD_REQUIRED 예외")
     void searchPost_throwsWhenKeywordBlank() {
         // given
+        Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
         PostSearchQuery query = new PostSearchQuery("   ", pageable);
 
         // when & then
-        assertThatThrownBy(() -> postService.searchPost(query)) // 메서드명 맞추기
+        assertThatThrownBy(() -> postService.searchMyPosts(userId, query))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_SEARCH_KEYWORD_REQUIRED);
 
         // repository 호출되면 안 됨
         verify(postRepository, never())
-                .findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(any(), any(), any());
+                .searchMyPosts(any(), any(), any());
         verifyNoInteractions(userRepository);
     }
 
 
     @Test
-    @DisplayName("searchPost: keyword 앞뒤 공백은 trim되어 검색된다")
+    @DisplayName("searchMyPosts: keyword 앞뒤 공백은 trim되어 검색된다")
     void searchPost_trimsKeywordBeforeSearching() {
         // given
-        User user = createUser(1L);
+        Long userId = 1L;
+        User user = createUser(userId);
         Post post = Post.create(user, "spring 제목", "내용", PostVisibility.PUBLIC, true);
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
@@ -439,18 +438,15 @@ public class PostServiceTest {
 
         PostSearchQuery query = new PostSearchQuery("  spring  ", pageable);
 
-        given(postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-                "spring", "spring", pageable
-        )).willReturn(postPage);
+        given(postRepository.searchMyPosts(userId, "spring", pageable))
+                .willReturn(postPage);
 
         // when
-        Page<PostSummaryResult> result = postService.searchPost(query);
+        Page<PostSummaryResult> result = postService.searchMyPosts(userId, query);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
-        verify(postRepository).findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-                "spring", "spring", pageable
-        );
+        verify(postRepository).searchMyPosts(userId, "spring", pageable);
         verifyNoMoreInteractions(postRepository);
         verifyNoInteractions(userRepository);
     }

--- a/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/service/PostServiceTest.java
@@ -5,10 +5,7 @@ import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.post.domain.Post;
 import com.keepgoing.keepgoing.post.domain.PostVisibility;
 import com.keepgoing.keepgoing.post.repository.PostRepository;
-import com.keepgoing.keepgoing.post.service.dto.PostCreateCommand;
-import com.keepgoing.keepgoing.post.service.dto.PostDetailResult;
-import com.keepgoing.keepgoing.post.service.dto.PostSummaryResult;
-import com.keepgoing.keepgoing.post.service.dto.PostUpdateCommand;
+import com.keepgoing.keepgoing.post.service.dto.*;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class PostServiceTest {
@@ -92,6 +89,7 @@ public class PostServiceTest {
         assertThat(result.aiCollectable()).isEqualTo(aiCollectable);
         verify(userRepository).findById(userId);
         verify(postRepository).save(any(Post.class));
+        verifyNoMoreInteractions(userRepository, postRepository);
     }
 
     @Test
@@ -117,6 +115,8 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.createPost(command))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        verify(userRepository).findById(userId);
+        verifyNoInteractions(postRepository);
     }
 
     // ========== getPost ==========
@@ -136,7 +136,12 @@ public class PostServiceTest {
 
         // then
         assertThat(result.title()).isEqualTo("제목");
+        assertThat(result.content()).isEqualTo("내용");
+        assertThat(result.visibility()).isEqualTo(PostVisibility.PRIVATE);
+
         verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -150,6 +155,10 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.getPost(postId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
+
     }
 
     // ========== getPosts ==========
@@ -189,6 +198,8 @@ public class PostServiceTest {
         assertThat(result.getContent().get(0).title()).isEqualTo("제목1");
         assertThat(result.getContent().get(1).title()).isEqualTo("제목2");
         verify(postRepository).findByAuthor_Id(userId, pageable);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     // ========== updatePost ==========
@@ -228,6 +239,8 @@ public class PostServiceTest {
         assertThat(result.visibility()).isEqualTo(newVisibility);
         assertThat(result.aiCollectable()).isEqualTo(newAiCollectable);
         verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -257,6 +270,9 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.updatePost(command))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -290,6 +306,9 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.updatePost(command))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_ACCESS_DENIED);
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     // ========== deletePost ==========
@@ -312,6 +331,8 @@ public class PostServiceTest {
         // then
         assertThat(post.isDeleted()).isTrue(); // isDeleted 없으면 deletedAt != null 로 체크
         verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -327,6 +348,9 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.deletePost(userId, postId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -346,5 +370,88 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.deletePost(userId, postId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_ACCESS_DENIED);
+        verify(postRepository).findById(postId);
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
+    }
+
+    // ========== searchPost ==========
+
+    @Test
+    @DisplayName("searchPost: keyword가 있으면 검색 결과를 페이지로 반환한다")
+    void searchPost_returnsPageWhenKeywordProvided() {
+        //given
+        Long userId = 1L;
+        User user = createUser(userId);
+
+        Post post1 = Post.create(user, "spring 제목", "내용", PostVisibility.PUBLIC, true);
+        Post post2 = Post.create(user, "제목", "spring 내용", PostVisibility.PUBLIC, true);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = new PageImpl<>(java.util.List.of(post1, post2), pageable, 2);
+
+        PostSearchQuery query = new PostSearchQuery("spring", pageable);
+
+        given(postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+                "spring",  "spring", pageable
+        )).willReturn(postPage);
+
+        // when
+        Page<PostSummaryResult> result = postService.searchPost(query); // 메서드명 맞추기
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(postRepository).findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+                "spring", "spring", pageable
+        );
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    @DisplayName("searchPost: keyword가 비어있으면 POST_SEARCH_KEYWORD_REQUIRED 예외")
+    void searchPost_throwsWhenKeywordBlank() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        PostSearchQuery query = new PostSearchQuery("   ", pageable);
+
+        // when & then
+        assertThatThrownBy(() -> postService.searchPost(query)) // 메서드명 맞추기
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_SEARCH_KEYWORD_REQUIRED);
+
+        // repository 호출되면 안 됨
+        verify(postRepository, never())
+                .findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(any(), any(), any());
+        verifyNoInteractions(userRepository);
+    }
+
+
+    @Test
+    @DisplayName("searchPost: keyword 앞뒤 공백은 trim되어 검색된다")
+    void searchPost_trimsKeywordBeforeSearching() {
+        // given
+        User user = createUser(1L);
+        Post post = Post.create(user, "spring 제목", "내용", PostVisibility.PUBLIC, true);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = new PageImpl<>(java.util.List.of(post), pageable, 1);
+
+        PostSearchQuery query = new PostSearchQuery("  spring  ", pageable);
+
+        given(postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+                "spring", "spring", pageable
+        )).willReturn(postPage);
+
+        // when
+        Page<PostSummaryResult> result = postService.searchPost(query);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(postRepository).findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+                "spring", "spring", pageable
+        );
+        verifyNoMoreInteractions(postRepository);
+        verifyNoInteractions(userRepository);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,10 +2,19 @@ spring:
   application:
     name: keepgoing
 
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+
   jpa:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+
+  flyway:
+    enabled: false
 
 jwt:
   secret-key: "test-secret-key-for-testing-purpose-only-32bytes!!"


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #26 

### ✨ 반영 브랜치
feat/26 -> develop

### 📝 변경 사항
- [x] 게시글 검색 API(`/api/posts/search`) 추가 (keyword 기반 검색 + 페이지네이션)
- [x] 페이지 size 상한(safePageable) 적용
- [x] 서비스/리포지토리 검색 로직 및 Query DTO(`PostSearchQuery`) 추가
- [x] 검색 기능 테스트 추가/보강
- [x]  게시글 검색 기능(내 글 기준) Repository/Service/Controller 반영
- [x]  관련 테스트 수정/보완

### ➕ 추가 메모
- keyword 누락: `@RequestParam` required로 400 처리
- keyword 공백: 서비스 정책(B)으로 400 처리(`POST_SEARCH_KEYWORD_REQUIRED`)
- 성능 측정(MySQL 기반 벤치마크/k6)은 별도 이슈/PR로 진행 예정

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- [x] `./gradlew test` 통과