### PR TITLE
feat(db): #28 local 프로필 MySQL 연동 및 초기 마이그레이션 추가

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -7,4 +7,4 @@ export MYSQL_USER=keepgoing
 export MYSQL_PASSWORD=keepgoing
 
 # jwt (최소 32바이트 이상)
-export JWT_SECRET="CHANGE_ME_TO_AT_LEAST_32_BYTES_SECRET_KEY"
+export JWT_SECRET_KEY="CHANGE_ME_TO_AT_LEAST_32_BYTES_SECRET_KEY"

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,10 @@
+# local profile
+export SPRING_PROFILES_ACTIVE=local
+
+# mysql (docker-compose 기준)
+export MYSQL_DATABASE=keepgoing
+export MYSQL_USER=keepgoing
+export MYSQL_PASSWORD=keepgoing
+
+# jwt (최소 32바이트 이상)
+export JWT_SECRET="CHANGE_ME_TO_AT_LEAST_32_BYTES_SECRET_KEY"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ build/
 .settings/
 
 .env
+.envrc
 
 # Gradle Wrapper (CI 필수)
 !gradle/wrapper/gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # Blingbling-BE
+
+## 로컬 실행 (direnv)
+
+> `.envrc`는 개인 로컬 설정 파일이므로 **커밋하지 않습니다.**  
+> 대신 템플릿 파일인 `.envrc.example`를 커밋하고, 각자 복사해서 사용합니다.
+
+### 1) direnv 설치 (macOS)
+
+```bash
+brew install direnv
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### 2) .envrc 생성 및 적용
+
+```
+cp .envrc.example .envrc
+direnv allow
+```
+
+### 3) 로컬 DB 실행 (MySQL)
+
+```
+docker compose up -d
+docker ps
+```
+
+Docker Desktop 대신 Colima를 사용하는 경우:
+
+```
+colima start --cpu 2 --memory 4 --disk 20
+docker context use colima
+docker info
+```
+
+### 4) 애플리케이션 실행 (local 프로필)
+
+```
+./gradlew bootRun
+```
+
+### 5) 종료 / 정리
+- 애플리케이션 종료: 실행 중인 터미널에서 `Ctrl + C`
+- MySQL 컨테이너 종료:
+```
+docker compose down
+```
+
+### 6) 동작 확인 (예시)
+```
+curl -i "http://localhost:8080/api/posts/search?keyword=spring&page=0&size=10"
+```

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ docker compose down
 
 ### 6) 동작 확인 (예시)
 ```
-curl -i "http://localhost:8080/api/posts/search?keyword=spring&page=0&size=10"
+curl -i -H "Authorization: Bearer <ACCESS_TOKEN>" "http://localhost:8080/api/posts/me/search?keyword=spring&page=0&size=10"
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -25,28 +25,39 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    // OAuth2 Resource Server (JWT 포함)
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-    // OAuth2 Client (소셜 로그인용 - 나중에 사용)
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // Swagger UI
-    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14"
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
+	// OAuth2 (JWT 포함)
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Persistence (JPA) + DB Migration (Flyway) + Drivers
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.h2database:h2'
 
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+	// Swagger UI
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14"
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// Devtools
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// Tests
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: keepgoing-mysql
+    restart: unless-stopped
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_0900_ai_ci
+    volumes:
+      - keepgoing-mysql-data:/var/lib/mysql
+
+volumes:
+  keepgoing-mysql-data:

--- a/docs/db/keepgoing.erd.json
+++ b/docs/db/keepgoing.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 20000,
     "height": 20000,
-    "scrollTop": -9138.6667,
-    "scrollLeft": -9951.1732,
-    "zoomLevel": 0.75,
+    "scrollTop": -9160.6652,
+    "scrollLeft": -9806.9515,
+    "zoomLevel": 0.72,
     "show": 495,
     "database": 4,
     "databaseName": "blog_system",
@@ -560,7 +560,7 @@
         "name": "ai_collectable",
         "comment": "AI 학습 허용",
         "dataType": "BOOLEAN",
-        "default": "TRUE",
+        "default": "FALSE",
         "options": 8,
         "ui": {
           "keys": 0,
@@ -570,7 +570,7 @@
           "widthDefault": 60
         },
         "meta": {
-          "updateAt": 1699999999999,
+          "updateAt": 1770291614260,
           "createAt": 1699999999999
         }
       },

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/api/posts/search"
+                                "/api/posts/me/search"
                         ).permitAll()
 
                         // 회원가입/로그인 API 허용

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,22 @@
+CREATE TABLE posts (
+                       id             BIGINT NOT NULL AUTO_INCREMENT,
+                       author_id      BIGINT NOT NULL,
+
+                       title          VARCHAR(200) NOT NULL,
+                       content        MEDIUMTEXT NOT NULL,
+
+                       visibility     VARCHAR(20) NOT NULL DEFAULT 'PRIVATE',
+                       ai_collectable TINYINT(1) NOT NULL DEFAULT 0,
+
+                       created_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                       updated_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+
+                       deleted_at     DATETIME(6) NULL,
+
+                       PRIMARY KEY (id),
+
+                       INDEX idx_posts_author_deleted_created (author_id, deleted_at, created_at),
+                       INDEX idx_posts_visibility_deleted_created (visibility, deleted_at, created_at)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V2__create_user_auth_tables.sql
+++ b/src/main/resources/db/migration/V2__create_user_auth_tables.sql
@@ -1,0 +1,70 @@
+-- src/main/resources/db/migration/V2__create_user_auth_tables.sql
+-- User / UserOAuthAccount / UserPasswordCredential 엔티티 기반 (MySQL 8.x)
+
+-- 1) users
+CREATE TABLE users (
+                       id            BIGINT NOT NULL AUTO_INCREMENT,
+                       email         VARCHAR(320) NOT NULL,
+                       name          VARCHAR(100) NOT NULL,
+
+                       role          VARCHAR(10)  NOT NULL DEFAULT 'USER',
+                       status        VARCHAR(10)  NOT NULL DEFAULT 'ACTIVE',
+
+                       last_login_at DATETIME(6) NULL,
+
+                       created_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                       updated_at    DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+
+                       PRIMARY KEY (id),
+
+                       CONSTRAINT uq_users_email UNIQUE (email)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+-- 2) user_oauth_accounts
+CREATE TABLE user_oauth_accounts (
+                                     id               BIGINT NOT NULL AUTO_INCREMENT,
+                                     user_id          BIGINT NOT NULL,
+
+                                     provider         VARCHAR(20)  NOT NULL,
+                                     provider_user_id VARCHAR(190) NOT NULL,
+
+                                     email            VARCHAR(320) NULL,
+                                     avatar_url       VARCHAR(500) NULL,
+
+                                     created_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                                     updated_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+
+                                     PRIMARY KEY (id),
+
+                                     CONSTRAINT uq_user_oauth_provider_user UNIQUE (provider, provider_user_id),
+
+                                     CONSTRAINT fk_user_oauth_accounts_user
+                                         FOREIGN KEY (user_id) REFERENCES users(id)
+                                             ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_user_oauth_accounts_user_id
+    ON user_oauth_accounts (user_id);
+
+-- 3) user_password_credentials (Shared Primary Key: PK = FK)
+CREATE TABLE user_password_credentials (
+                                           user_id             BIGINT NOT NULL,
+
+                                           login_id            VARCHAR(320) NOT NULL,
+                                           password_hash       VARCHAR(255) NOT NULL,
+                                           password_changed_at DATETIME(6) NOT NULL,
+
+                                           PRIMARY KEY (user_id),
+
+                                           CONSTRAINT uq_user_password_login_id UNIQUE (login_id),
+
+                                           CONSTRAINT fk_user_password_credentials_user
+                                               FOREIGN KEY (user_id) REFERENCES users(id)
+                                                   ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+
+  flyway:
+    enabled: false
+
+jwt:
+  secret-key: "test-secret-key-for-testing-purpose-only-32bytes!!"
+  access-token-expiry: 3600000
+  refresh-token-expiry: 604800000
+  issuer: keepgoing-test
+
+cors:
+  allowed-origins:
+    - http://localhost:5173
+  max-age: 3600


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
#28 

### ✨ 반영 브랜치
feat/28 -> develop

### 📝 변경 사항
- [x] docker-compose 기반 로컬 MySQL 실행 환경 추가
- [x] application-local.yml로 MySQL datasource 설정 분리(기본 application.yml 유지)
- [x] Flyway 도입 및 초기 스키마 마이그레이션(V1) 추가
- [x] 로컬 실행을 위한 .envrc.example 및 README 실행 가이드 추가

### ➕ 추가 메모
- envrc는 개인 로컬 파일로 커밋하지 않고, .envrc.example 템플릿을 제공합니다.
- Docker Desktop 없이 Colima 환경에서도 실행 가능하도록 가이드에 포함했습니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- ./gradlew clean test 통과
- 로컬 MySQL 실행 후 API 동작 확인
 예) GET /api/posts/search?keyword=... (페이징 포함)
