### PR TITLE
feat: #31 Google OAuth 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build/
 
 .env
 .envrc
+application-oauth.yml
 
 # Gradle Wrapper (CI 필수)
 !gradle/wrapper/gradle-wrapper.jar

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.7'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.7'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.keepgoing'
@@ -9,58 +9,65 @@ version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Spring Boot Starters
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Spring Boot Starters
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	// OAuth2 (JWT 포함)
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // OAuth2 (JWT 포함)
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	// Persistence (JPA) + DB Migration (Flyway) + Drivers
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
+    // Persistence (JPA) + DB Migration (Flyway) + Drivers
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
-	// Swagger UI
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14"
+    // Swagger UI
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14"
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
-	// Devtools
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    // Devtools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// Tests
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Tests
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    testLogging {
+        events "FAILED"
+        exceptionFormat "FULL"       // 전체 스택트레이스
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+    useJUnitPlatform()
 }

--- a/docs/db/keepgoing.erd.json
+++ b/docs/db/keepgoing.erd.json
@@ -4,9 +4,9 @@
   "settings": {
     "width": 20000,
     "height": 20000,
-    "scrollTop": -9160.6652,
-    "scrollLeft": -9806.9515,
-    "zoomLevel": 0.72,
+    "scrollTop": -8954.9515,
+    "scrollLeft": -10457.0979,
+    "zoomLevel": 1,
     "show": 495,
     "database": 4,
     "databaseName": "blog_system",

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
@@ -1,0 +1,36 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import com.keepgoing.keepgoing.auth.service.OAuthLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+// TODO: 외부 요청에 의한 응답값 null 체크 로직 추가
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final OAuthLoginService oAuthLoginService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String providerUserId = oAuth2User.getAttribute("sub");
+        String email = oAuth2User.getAttribute("email");
+        if (providerUserId == null || email == null) {
+            throw new OAuth2AuthenticationException("Google 필수 정보 누락");
+        }
+        String name = oAuth2User.getAttribute("name");
+        if (name == null) {
+            name = email.split("@")[0];
+        }
+        String avatarUrl = oAuth2User.getAttribute("picture");
+
+        oAuthLoginService.processOAuthLogin(email, providerUserId, avatarUrl, name);
+        return oAuth2User;
+    }
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
@@ -8,7 +8,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-// TODO: 외부 요청에 의한 응답값 null 체크 로직 추가
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/OAuthLoginService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/OAuthLoginService.java
@@ -1,0 +1,49 @@
+package com.keepgoing.keepgoing.auth.service;
+
+import com.keepgoing.keepgoing.user.domain.OAuthProvider;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.domain.UserOAuthAccount;
+import com.keepgoing.keepgoing.user.repository.UserOAuthAccountRepository;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginService {
+
+    private final UserOAuthAccountRepository userOAuthAccountRepository;
+    private final UserRepository userRepository;
+
+    // 동시성 문제 발생 가능
+    // 그러나 나중에 문제 발생 시 해결하는 방향성으로 나둠
+    @Transactional
+    public void processOAuthLogin(
+            String email,
+            String providerUserId,
+            String avatarUrl,
+            String name
+    ) {
+        Optional<UserOAuthAccount> userOAuthAccountOpt
+                = userOAuthAccountRepository.findByProviderAndProviderUserId(OAuthProvider.GOOGLE, providerUserId);
+
+        if (userOAuthAccountOpt.isEmpty()) {
+            Optional<User> userOpt = userRepository.findByEmail(email);
+            User user = userOpt.orElseGet(() ->
+                    userRepository.save(User.create(email, name))
+            );
+            UserOAuthAccount newUserOAuthAccount = UserOAuthAccount.create(
+                    user,
+                    OAuthProvider.GOOGLE,
+                    providerUserId,
+                    email,
+                    avatarUrl
+            );
+            userOAuthAccountRepository.save(newUserOAuthAccount);
+        } else {
+            userOAuthAccountOpt.get().updateProfile(email, avatarUrl);
+        }
+    }
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -56,6 +56,23 @@ public enum ErrorCode {
             "이메일 인증이 완료되지 않았습니다."
     ),
 
+    // ===== OAuth =====
+    OAUTH_PROVIDER_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "OAUTH_001",
+            "Provider 통신 실패했습니다."
+    ),
+    OAUTH_ACCOUNT_ALREADY_LINK(
+            HttpStatus.CONFLICT,
+            "OAUTH_002",
+            "이미 다른 User에 연동된 계정입니다."
+    ),
+    OAUTH_PROVIDER_NOT_SUPPORTED(
+            HttpStatus.BAD_REQUEST,
+            "OAUTH_003",
+            "지원하지 않은 Provider입니다."
+    ),
+
     // ===== User =====
     USER_NOT_FOUND(
             HttpStatus.NOT_FOUND,

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -1,11 +1,11 @@
 package com.keepgoing.keepgoing.global.config;
 
+import com.keepgoing.keepgoing.auth.security.CustomOAuth2UserService;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -23,6 +23,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     PasswordEncoder passwordEncoder() {
@@ -55,21 +56,25 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/api/posts/me/search"
                         ).permitAll()
-
                         // 회원가입/로그인 API 허용
                         .requestMatchers(
                                 "/api/auth/**"
                         ).permitAll()
-
                         // TODO: 포스트 API는 일단 모두 허용 (개발용)
                         .requestMatchers(
                                 "/api/v1/posts/**"
                         ).permitAll()
-
+                        .requestMatchers(
+                                "/oauth2/**",
+                                "/login/oauth2/**"
+                        ).permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
 
         return http.build();
     }

--- a/src/main/java/com/keepgoing/keepgoing/user/repository/UserOAuthAccountRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/user/repository/UserOAuthAccountRepository.java
@@ -1,0 +1,15 @@
+package com.keepgoing.keepgoing.user.repository;
+
+import com.keepgoing.keepgoing.user.domain.OAuthProvider;
+import com.keepgoing.keepgoing.user.domain.UserOAuthAccount;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserOAuthAccountRepository extends JpaRepository<UserOAuthAccount, Long> {
+
+    Optional<UserOAuthAccount> findByProviderAndProviderUserId(OAuthProvider provider, String providerUserId);
+
+    List<UserOAuthAccount> findByUserId(Long userId);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,13 @@
 spring:
   application:
     name: keepgoing
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/src/test/java/com/keepgoing/keepgoing/auth/service/OAuthLoginServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/service/OAuthLoginServiceTest.java
@@ -1,0 +1,130 @@
+package com.keepgoing.keepgoing.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keepgoing.keepgoing.user.domain.OAuthProvider;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.domain.UserOAuthAccount;
+import com.keepgoing.keepgoing.user.repository.UserOAuthAccountRepository;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@Transactional
+class OAuthLoginServiceTest {
+
+    private static final OAuthProvider PROVIDER = OAuthProvider.GOOGLE;
+    private static final String EMAIL = "hong@gmail.com";
+    private static final String PROVIDER_USER_ID = "google-123";
+    private static final String NAME = "홍길동";
+    private static final String AVATAR_URL = "https://pic.google.com/old";
+
+    @Autowired
+    OAuthLoginService oAuthLoginService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserOAuthAccountRepository userOAuthAccountRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Nested
+    @DisplayName("신규 사용자")
+    class NewUser {
+
+        @Test
+        @DisplayName("User와 UserOAuthAccount가 생성된다.")
+        void newUser_createUserAndUserOAuthAccount() {
+            // given
+            // when
+            oAuthLoginService.processOAuthLogin(EMAIL, PROVIDER_USER_ID, AVATAR_URL, NAME);
+
+            // then
+            assertThat(userRepository.findByEmail(EMAIL))
+                    .isPresent()
+                    .get()
+                    .satisfies(user ->
+                            assertThat(user.getName()).isEqualTo(NAME));
+
+            assertThat(userOAuthAccountRepository.findByProviderAndProviderUserId(PROVIDER, PROVIDER_USER_ID))
+                    .isPresent()
+                    .get()
+                    .satisfies(userOAuthAccount -> {
+                        assertThat(userOAuthAccount.getEmail()).isEqualTo(EMAIL);
+                        assertThat(userOAuthAccount.getAvatarUrl()).isEqualTo(AVATAR_URL);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 이메일 사용자")
+    class ExistingUser {
+
+        @Test
+        @DisplayName("기존 User에 OAuthAccount가 연동된다.")
+        void existingUser_linksOAuthAccountToExistingUser() {
+            // given
+            User existingUser = User.create(EMAIL, NAME);
+            userRepository.save(existingUser);
+
+            // when
+            oAuthLoginService.processOAuthLogin(EMAIL, PROVIDER_USER_ID, AVATAR_URL, NAME);
+
+            // then
+            assertThat(userOAuthAccountRepository.findByUserId(existingUser.getId()))
+                    .hasSize(1)
+                    .first()
+                    .satisfies(userOAuthAccount -> {
+                        assertThat(userOAuthAccount.getProviderUserId()).isEqualTo(PROVIDER_USER_ID);
+                        assertThat(userOAuthAccount.getUser().getId()).isEqualTo(existingUser.getId());
+                    });
+            assertThat(userRepository.count()).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("재로그인")
+    class Relogin {
+
+        @Test
+        @DisplayName("프로필 정보가 갱신된다.")
+        void relogin_updatesProfile() {
+            // given
+            User existingUser = User.create(EMAIL, NAME);
+            userRepository.save(existingUser);
+            UserOAuthAccount existingUserAccount = UserOAuthAccount.create(
+                    existingUser,
+                    PROVIDER,
+                    PROVIDER_USER_ID,
+                    EMAIL,
+                    "https://old-picture"
+            );
+            userOAuthAccountRepository.save(existingUserAccount);
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            oAuthLoginService.processOAuthLogin(EMAIL, PROVIDER_USER_ID, AVATAR_URL, NAME);
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            assertThat(userRepository.count()).isEqualTo(1L);
+            assertThat(userOAuthAccountRepository.count()).isEqualTo(1L);
+            assertThat(userOAuthAccountRepository.findByUserId(existingUser.getId()))
+                    .first()
+                    .satisfies(userOAuthAccount ->
+                            assertThat(userOAuthAccount.getAvatarUrl()).isEqualTo(AVATAR_URL));
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,8 +6,8 @@ spring:
       client:
         registration:
           google:
-            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
-            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID:test-google-client-id}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET:test-google-client-secret}
 
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,13 @@
 spring:
   application:
     name: keepgoing
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
 
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- closes #31

### ✨ 반영 브랜치
feat/31 -> develop

### 📝 변경 사항
- [x] Google OAuth2 로그인 비즈니스 로직 구현 (`OAuthLoginService`)
  - 신규 사용자: User + OAuthAccount 자동 생성
  - 기존 이메일 사용자: 기존 User에 Google 계정 연동
  - 재로그인: 프로필 정보(이메일, 아바타) 갱신
- [x] `CustomOAuth2UserService` 구현 (Spring Security OAuth2 연동 레이어)
  - Google 응답 필수값(`sub`, `email`) null 체크
  - `name` null 시 이메일 앞부분으로 fallback
- [x] `UserOAuthAccountRepository` 구현 (provider+providerUserId 조회, userId 조회)
- [x] `SecurityConfig`에 `.oauth2Login()` 설정 추가
- [x] `application.yml`에 Google OAuth2 client 설정 추가 (환경변수 방식)

### ➕ 추가 메모
- SuccessHandler/FailureHandler는 JWT 토큰 발행 서브 이슈에서 구현 예정
- `SessionCreationPolicy.STATELESS` + OAuth2 세션 충돌 문제는 JWT 서브 이슈에서 CookieAuthorizationRequestRepository로 해결 예정
- `CustomOAuth2User` (userId 전달용)도 JWT 서브 이슈에서 추가 예정

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
`OAuthLoginServiceTest` 통합 테스트 3개 시나리오 전부 통과:
- 신규 사용자: User와 UserOAuthAccount 생성 검증
- 기존 이메일 사용자: 기존 User에 OAuthAccount 연동 검증
- 재로그인: 프로필 정보 갱신 검증