### PR TITLE
[Auth] #34 OAuth 로그인 성공/실패 시 프론트엔드로 JWT 및 에러 전달

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,9 @@ build/
 
 .env
 .envrc
-application-oauth.yml
 
 # Gradle Wrapper (CI 필수)
 !gradle/wrapper/gradle-wrapper.jar
 !gradle/wrapper/gradle-wrapper.properties
 
-docs/perf/results/
+.omx

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2User.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2User.java
@@ -1,0 +1,35 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+	private final OAuth2User delegate;
+
+	@Getter
+	private final Long userId;
+
+	@Getter
+	private final String role;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return delegate.getAttributes();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return delegate.getAuthorities();
+	}
+
+	@Override
+	public String getName() {
+		return delegate.getName();
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepgoing.auth.security;
 
 import com.keepgoing.keepgoing.auth.service.OAuthLoginService;
+import com.keepgoing.keepgoing.auth.service.dto.OAuthUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -8,28 +9,23 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+// TODO: 외부 요청에 의한 응답값 null 체크 로직 추가
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final OAuthLoginService oAuthLoginService;
+	private final OAuthLoginService oAuthLoginService;
 
-    @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oAuth2User = super.loadUser(userRequest);
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = loadProviderUser(userRequest);
+		GoogleOAuthAttributes attr = GoogleOAuthAttributes.from(oAuth2User);
+		OAuthUserPrincipal principal =
+				oAuthLoginService.processOAuthLogin(attr.email(), attr.providerUserId(), attr.avatarUrl(), attr.name());
+		return new CustomOAuth2User(oAuth2User, principal.userId(), principal.role());
+	}
 
-        String providerUserId = oAuth2User.getAttribute("sub");
-        String email = oAuth2User.getAttribute("email");
-        if (providerUserId == null || email == null) {
-            throw new OAuth2AuthenticationException("Google 필수 정보 누락");
-        }
-        String name = oAuth2User.getAttribute("name");
-        if (name == null) {
-            name = email.split("@")[0];
-        }
-        String avatarUrl = oAuth2User.getAttribute("picture");
-
-        oAuthLoginService.processOAuthLogin(email, providerUserId, avatarUrl, name);
-        return oAuth2User;
-    }
+	protected OAuth2User loadProviderUser(OAuth2UserRequest  userRequest) {
+		return super.loadUser(userRequest);
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributes.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributes.java
@@ -1,0 +1,32 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public record GoogleOAuthAttributes(
+		String email,
+		String providerUserId,
+		String avatarUrl,
+		String name
+) {
+	public static GoogleOAuthAttributes from(OAuth2User oAuth2User) {
+		String providerUserId = oAuth2User.getAttribute("sub");
+		String email = oAuth2User.getAttribute("email");
+		if (providerUserId == null || email == null) {
+			throw new OAuth2AuthenticationException(
+					new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST),
+					"Google 필수 정보 누락"
+			);
+		}
+		String name = oAuth2User.getAttribute("name");
+		if (name == null) {
+			name = email.split("@")[0];
+		}
+		String avatarUrl = oAuth2User.getAttribute("picture");
+
+		return new GoogleOAuthAttributes(email, providerUserId, avatarUrl, name);
+	}
+}
+

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,52 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final String redirectUri;
+
+	public OAuth2AuthenticationFailureHandler(
+			@Value("${oauth.redirect-uri}") String redirectUri) {
+		this.redirectUri = redirectUri;
+	}
+
+	@Override
+	public void onAuthenticationFailure(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			AuthenticationException exception
+	) throws IOException, ServletException {
+		String errorCode = resolveErrorCode(exception);
+
+		String uriString = UriComponentsBuilder
+				.fromUriString(redirectUri)
+				.queryParam("error", errorCode)
+				.build()
+				.toUriString();
+		response.sendRedirect(uriString);
+	}
+
+	private String resolveErrorCode(AuthenticationException exception) {
+		if (!(exception instanceof OAuth2AuthenticationException oauthException)) {
+			return "oauth_login_failed";
+		}
+
+		return switch (oauthException.getError().getErrorCode()) {
+			case OAuth2ErrorCodes.ACCESS_DENIED -> "oauth_access_denied";
+			case OAuth2ErrorCodes.INVALID_REQUEST -> "oauth_invalid_user_info";
+			default -> "oauth_login_failed";
+		};
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,46 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtProvider jwtProvider;
+	private final String redirectUri;
+
+	public OAuth2AuthenticationSuccessHandler(
+			JwtProvider jwtProvider,
+			@Value("${oauth.redirect-uri}") String redirectUri
+	) {
+		this.jwtProvider = jwtProvider;
+		this.redirectUri = redirectUri;
+	}
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+	                                    Authentication authentication) throws IOException, ServletException {
+		CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
+		Long userId = principal.getUserId();
+		String role = principal.getRole();
+
+		String accessToken = jwtProvider.generateAccessToken(userId, List.of(role));
+		String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+		String uriString = UriComponentsBuilder
+				.fromUriString(redirectUri)
+				.queryParam("token", accessToken)
+				.queryParam("refresh", refreshToken)
+				.build().toUriString();
+		response.sendRedirect(uriString);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/OAuthLoginService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/OAuthLoginService.java
@@ -1,5 +1,6 @@
 package com.keepgoing.keepgoing.auth.service;
 
+import com.keepgoing.keepgoing.auth.service.dto.OAuthUserPrincipal;
 import com.keepgoing.keepgoing.user.domain.OAuthProvider;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.domain.UserOAuthAccount;
@@ -14,36 +15,45 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OAuthLoginService {
 
-    private final UserOAuthAccountRepository userOAuthAccountRepository;
-    private final UserRepository userRepository;
+	private final UserOAuthAccountRepository userOAuthAccountRepository;
+	private final UserRepository userRepository;
 
-    // 동시성 문제 발생 가능
-    // 그러나 나중에 문제 발생 시 해결하는 방향성으로 나둠
-    @Transactional
-    public void processOAuthLogin(
-            String email,
-            String providerUserId,
-            String avatarUrl,
-            String name
-    ) {
-        Optional<UserOAuthAccount> userOAuthAccountOpt
-                = userOAuthAccountRepository.findByProviderAndProviderUserId(OAuthProvider.GOOGLE, providerUserId);
+	// 동시성 문제 발생 가능
+	// 그러나 나중에 문제 발생 시 해결하는 방향성으로 나둠
+	@Transactional
+	public OAuthUserPrincipal processOAuthLogin(
+			String email,
+			String providerUserId,
+			String avatarUrl,
+			String name
+	) {
+		// TODO: 다중 OAuth Provider 사용 시 하드코딩 수정
+		Optional<UserOAuthAccount> userOAuthAccountOpt
+				= userOAuthAccountRepository.findByProviderAndProviderUserId(OAuthProvider.GOOGLE, providerUserId);
 
-        if (userOAuthAccountOpt.isEmpty()) {
-            Optional<User> userOpt = userRepository.findByEmail(email);
-            User user = userOpt.orElseGet(() ->
-                    userRepository.save(User.create(email, name))
-            );
-            UserOAuthAccount newUserOAuthAccount = UserOAuthAccount.create(
-                    user,
-                    OAuthProvider.GOOGLE,
-                    providerUserId,
-                    email,
-                    avatarUrl
-            );
-            userOAuthAccountRepository.save(newUserOAuthAccount);
-        } else {
-            userOAuthAccountOpt.get().updateProfile(email, avatarUrl);
-        }
-    }
+		User user;
+		// OAuth 가입자 있는 경우
+		if (userOAuthAccountOpt.isPresent()) {
+			UserOAuthAccount userOAuthAccount = userOAuthAccountOpt.get();
+			userOAuthAccount.updateProfile(email, avatarUrl);
+			user = userOAuthAccount.getUser();
+		} else { // 신규
+			user = userRepository.findByEmail(email).orElseGet(() ->
+					userRepository.save(User.create(email, name))
+			);
+			UserOAuthAccount newUserOAuthAccount = UserOAuthAccount.create(
+					user,
+					OAuthProvider.GOOGLE,
+					providerUserId,
+					email,
+					avatarUrl
+			);
+			userOAuthAccountRepository.save(newUserOAuthAccount);
+		}
+
+		return OAuthUserPrincipal.builder()
+				.userId(user.getId())
+				.role(user.getRole().toAuthority())
+				.build();
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/dto/OAuthUserPrincipal.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/dto/OAuthUserPrincipal.java
@@ -1,0 +1,10 @@
+package com.keepgoing.keepgoing.auth.service.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OAuthUserPrincipal(
+		Long userId,
+		String role
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.keepgoing.keepgoing.global.config;
 
 import com.keepgoing.keepgoing.auth.security.CustomOAuth2UserService;
+import com.keepgoing.keepgoing.auth.security.OAuth2AuthenticationFailureHandler;
+import com.keepgoing.keepgoing.auth.security.OAuth2AuthenticationSuccessHandler;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,60 +24,69 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final CustomOAuth2UserService customOAuth2UserService;
+	private static final String AUTH_API_PREFIX = "/api/auth";
 
-    @Bean
-    PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+	private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager();
-    }
+	@Bean
+	PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(
-            HttpSecurity http,
-            CorsConfigurationSource corsConfigurationSource
-    ) throws Exception {
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+		return config.getAuthenticationManager();
+	}
 
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)   // 기본 /login 폼 비활성화
-                .httpBasic(AbstractHttpConfigurer::disable) // 기본 Basic 인증 비활성화
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        // Swagger & OpenAPI 문서 경로 허용
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/posts/me/search"
-                        ).permitAll()
-                        // 회원가입/로그인 API 허용
-                        .requestMatchers(
-                                "/api/auth/**"
-                        ).permitAll()
-                        // TODO: 포스트 API는 일단 모두 허용 (개발용)
-                        .requestMatchers(
-                                "/api/v1/posts/**"
-                        ).permitAll()
-                        .requestMatchers(
-                                "/oauth2/**",
-                                "/login/oauth2/**"
-                        ).permitAll()
-                        // 나머지는 인증 필요
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)));
+	@Bean
+	public SecurityFilterChain securityFilterChain(
+			HttpSecurity http,
+			CorsConfigurationSource corsConfigurationSource
+	) throws Exception {
 
-        return http.build();
-    }
+		http
+				.cors(cors -> cors.configurationSource(corsConfigurationSource))
+				.csrf(AbstractHttpConfigurer::disable)
+				.formLogin(AbstractHttpConfigurer::disable)   // 기본 /login 폼 비활성화
+				.httpBasic(AbstractHttpConfigurer::disable) // 기본 Basic 인증 비활성화
+				.sessionManagement(session ->
+						session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.authorizeHttpRequests(auth -> auth
+						// Swagger & OpenAPI 문서 경로 허용
+						.requestMatchers(
+								"/v3/api-docs/**",
+								"/swagger-ui/**",
+								"/swagger-ui.html",
+								"/api/posts/me/search"
+						).permitAll()
+						// 회원가입/로그인 API 용
+						.requestMatchers(
+								AUTH_API_PREFIX + "/signup",
+								AUTH_API_PREFIX + "/login",
+								AUTH_API_PREFIX + "/refresh"
+						).permitAll()
+						// TODO: 포스트 API는 일단 모두 허용 (개발용)
+						.requestMatchers(
+								"/api/v1/posts/**"
+						).permitAll()
+						.requestMatchers(
+								"/oauth2/**",
+								"/login/oauth2/**"
+						).permitAll()
+						// 나머지는 인증 필요
+						.anyRequest().authenticated()
+				)
+				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+				.oauth2Login(oauth2 -> oauth2
+						.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+								.userService(customOAuth2UserService))
+						.successHandler(oAuth2AuthenticationSuccessHandler)
+						.failureHandler(oAuth2AuthenticationFailureHandler)
+				);
+
+		return http.build();
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/user/domain/UserRole.java
+++ b/src/main/java/com/keepgoing/keepgoing/user/domain/UserRole.java
@@ -2,5 +2,9 @@ package com.keepgoing.keepgoing.user.domain;
 
 public enum UserRole {
     USER,
-    ADMIN
+    ADMIN;
+
+    public String toAuthority() {
+        return "ROLE_" + this.name();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ cors:
   allowed-origins:
     - http://localhost:5173
   max-age: 3600
+
+oauth:
+  redirect-uri: http://localhost:5173/oauth/callback

--- a/src/test/java/com/keepgoing/keepgoing/auth/OAuthTestFixtures.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/OAuthTestFixtures.java
@@ -1,0 +1,72 @@
+package com.keepgoing.keepgoing.auth;
+
+import java.util.HashMap;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthTestFixtures {
+
+	public static final String EMAIL = "user@gmail.com";
+	public static final String USER_ID = "google-123";
+	public static final String PICTURE = "https://image.test/profile.png";
+	public static final String NAME = "홍길동";
+
+	public static DefaultOAuth2User googleUser() {
+		return googleUserBuilder()
+				.build()
+				.oauth2User();
+	}
+
+	public static GoogleUserFixture.GoogleUserFixtureBuilder googleUserBuilder() {
+		return GoogleUserFixture.builder();
+	}
+
+
+	@Getter
+	@Builder(toBuilder = true)
+	public static class GoogleUserFixture {
+
+		@Builder.Default
+		private String sub = "google-123";
+
+		@Builder.Default
+		private String email = "user@gmail.com";
+
+		@Builder.Default
+		private String name = "홍길동";
+
+		@Builder.Default
+		private String picture = "https://image.test/profile.png";
+
+		public DefaultOAuth2User oauth2User() {
+			HashMap<String, Object> attr = new HashMap<>();
+
+			if (sub != null) {
+				attr.put("sub", sub);
+			}
+			if (email != null) {
+				attr.put("email", email);
+			}
+			if (name != null) {
+				attr.put("name", name);
+			}
+			if (picture != null) {
+				attr.put("picture", picture);
+			}
+
+			String nameAttrKey = attr.containsKey("sub") ? "sub" : "email";
+
+			return new DefaultOAuth2User(
+					List.of(new SimpleGrantedAuthority("ROLE_USER")),
+					attr,
+					nameAttrKey
+			);
+		}
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,108 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.spy;
+
+import com.keepgoing.keepgoing.auth.service.OAuthLoginService;
+import com.keepgoing.keepgoing.auth.service.dto.OAuthUserPrincipal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+	private static final String EMAIL = "user@gmail.com";
+	private static final String USER_ID = "google-123";
+	private static final String PICTURE = "https://image.test/profile.png";
+	private static final String NAME = "홍길동";
+
+	@Mock
+	OAuthLoginService oAuthLoginService;
+
+	@Mock
+	OAuth2UserRequest userRequest;
+
+	CustomOAuth2UserService service;
+
+	@BeforeEach
+	void setUp() {
+		service = spy(new CustomOAuth2UserService(oAuthLoginService));
+	}
+
+	@Test
+	@DisplayName("정상 Google 사용자 정보면 OAuthLoginService를 호출하고 CustomOAuth2User를 반환한다.")
+	void success_loadUser() {
+		// given
+		DefaultOAuth2User delegate = new DefaultOAuth2User(
+				List.of(new SimpleGrantedAuthority("ROLE_USER")),
+				Map.of(
+						"sub", USER_ID,
+						"email", EMAIL,
+						"name", NAME,
+						"picture", PICTURE),
+				"sub"
+		);
+		willReturn(delegate).given(service).loadProviderUser(userRequest);
+		given(oAuthLoginService.processOAuthLogin(
+				EMAIL,
+				USER_ID,
+				PICTURE,
+				NAME
+		)).willReturn(OAuthUserPrincipal.builder()
+				.userId(1L)
+				.role("ROLE_USER")
+				.build());
+
+		// when
+		OAuth2User result = service.loadUser(userRequest);
+
+		// then
+		assertThat(result).isInstanceOf(CustomOAuth2User.class);
+
+		CustomOAuth2User principal = (CustomOAuth2User) result;
+		assertThat(principal.getUserId()).isEqualTo(1L);
+		assertThat(principal.getRole()).isEqualTo("ROLE_USER");
+		assertThat(principal.getAttributes().get("email")).isEqualTo(EMAIL);
+
+		then(oAuthLoginService).should().processOAuthLogin(
+				EMAIL,
+				USER_ID,
+				PICTURE,
+				NAME
+		);
+	}
+
+	@Test
+	@DisplayName("필수 정보가 누락되면 OAuth2AuthenticationException이 발생하고 로그인 서비스는 호출되지 않는다.")
+	void loadUser_missingRequiredField_throws() {
+		// given
+		DefaultOAuth2User delegate = new DefaultOAuth2User(
+				List.of(new SimpleGrantedAuthority("ROLE_USER")),
+				Map.of(
+						"sub", USER_ID),
+				"sub"
+		);
+		willReturn(delegate).given(service).loadProviderUser(userRequest);
+
+		// when & then
+		assertThatThrownBy(() -> service.loadUser(userRequest))
+				.isInstanceOf(OAuth2AuthenticationException.class);
+
+		then(oAuthLoginService).shouldHaveNoInteractions();
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributesTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributesTest.java
@@ -1,0 +1,90 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import static com.keepgoing.keepgoing.auth.OAuthTestFixtures.EMAIL;
+import static com.keepgoing.keepgoing.auth.OAuthTestFixtures.NAME;
+import static com.keepgoing.keepgoing.auth.OAuthTestFixtures.PICTURE;
+import static com.keepgoing.keepgoing.auth.OAuthTestFixtures.USER_ID;
+import static com.keepgoing.keepgoing.auth.OAuthTestFixtures.googleUserBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.keepgoing.keepgoing.auth.OAuthTestFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+class GoogleOAuthAttributesTest {
+
+	@Test
+	@DisplayName("Google 사용자 정보가 정상이면 정상 추출한다.")
+	void from_success() {
+		// given
+		OAuth2User user = OAuthTestFixtures.googleUser();
+
+		// when
+		GoogleOAuthAttributes attr = GoogleOAuthAttributes.from(user);
+
+		// then
+		assertThat(attr.email()).isEqualTo(EMAIL);
+		assertThat(attr.providerUserId()).isEqualTo(USER_ID);
+		assertThat(attr.avatarUrl()).isEqualTo(PICTURE);
+		assertThat(attr.name()).isEqualTo(NAME);
+	}
+
+	@Test
+	@DisplayName("name이 없으면 이메일 prefix를 name으로 사용한다")
+	void from_withoutName_usesEmailPrefix() {
+		// given
+		OAuth2User user = OAuthTestFixtures.googleUserBuilder()
+				.name(null)
+				.build()
+				.oauth2User();
+
+		// when
+		GoogleOAuthAttributes attr = GoogleOAuthAttributes.from(user);
+
+		// then
+		assertThat(attr.email()).isEqualTo(EMAIL);
+		assertThat(attr.providerUserId()).isEqualTo(USER_ID);
+		assertThat(attr.avatarUrl()).isEqualTo(PICTURE);
+		assertThat(attr.name()).isEqualTo("user");
+	}
+
+	@Test
+	@DisplayName("email이 없으면 OAuth2AuthenticationException이 발생한다")
+	void from_withoutEmail_throws() {
+		// given
+		OAuth2User user = googleUserBuilder()
+				.email(null)
+				.build()
+				.oauth2User();
+
+		// when & then
+		assertThatThrownBy(() -> GoogleOAuthAttributes.from(user))
+				.isInstanceOf(OAuth2AuthenticationException.class)
+				.satisfies(ex -> {
+					OAuth2AuthenticationException oauthEx = (OAuth2AuthenticationException) ex;
+					assertThat(oauthEx.getError().getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+				});
+	}
+
+	@Test
+	@DisplayName("sub가 없으면 OAuth2AuthenticationException이 발생한다")
+	void from_withoutSub_throws() {
+		// given
+		OAuth2User user = OAuthTestFixtures.googleUserBuilder()
+				.sub(null)
+				.build()
+				.oauth2User();
+
+		// when & sub
+		assertThatThrownBy(() -> GoogleOAuthAttributes.from(user))
+				.isInstanceOf(OAuth2AuthenticationException.class)
+				.satisfies(ex -> {
+					OAuth2AuthenticationException oauthEx = (OAuth2AuthenticationException) ex;
+					assertThat(oauthEx.getError().getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+				});
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,99 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+	private static final String OAUTH_CALLBACK = "http://localhost:5173/oauth/callback";
+
+	OAuth2AuthenticationFailureHandler handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new OAuth2AuthenticationFailureHandler(OAUTH_CALLBACK);
+	}
+
+	@Test
+	@DisplayName("OAuth 접근 거부 시 프론트 엔드로 oauth_access_denied를 전달한다.")
+	void failure_accessDenied_redirectsWithError() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+				new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED),
+				"access denied"
+		);
+
+		// when
+		handler.onAuthenticationFailure(request, response, exception);
+
+		// then
+		String redirectedUrl = response.getRedirectedUrl();
+		assertThat(redirectedUrl).isNotNull();
+
+		UriComponents uri = UriComponentsBuilder.fromUriString(redirectedUrl).build();
+		assertThat(uri.getScheme()).isEqualTo("http");
+		assertThat(uri.getHost()).isEqualTo("localhost");
+		assertThat(uri.getPort()).isEqualTo(5173);
+		assertThat(uri.getPath()).isEqualTo("/oauth/callback");
+		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_access_denied");
+	}
+
+	@Test
+	@DisplayName("필수 사용자 정보 누락시 프론트엔드로 oauth_invalid_user_info를 전달한다")
+	void failure_invalidRequest_redirectsWithError() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+				new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST),
+				"invalid request"
+		);
+
+		// when
+		handler.onAuthenticationFailure(request, response, exception);
+
+		// then
+		UriComponents uri = UriComponentsBuilder
+				.fromUriString(Objects.requireNonNull(response.getRedirectedUrl()))
+				.build();
+		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_invalid_user_info");
+	}
+
+	@Test
+	@DisplayName("알 수 없는 인증 실패 시 프론트앤드로 oauth_login_failed를 전달한다")
+	void failure_unknown_redirectsWithDefaultError() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		AuthenticationExceptionStub exception = new AuthenticationExceptionStub("unknown");
+
+		// when
+		handler.onAuthenticationFailure(request, response, exception);
+
+		// then
+
+		UriComponents uri = UriComponentsBuilder.fromUriString(Objects.requireNonNull(response.getRedirectedUrl()))
+				.build();
+		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_login_failed");
+	}
+
+	private static class AuthenticationExceptionStub
+			extends org.springframework.security.core.AuthenticationException {
+		protected AuthenticationExceptionStub(String msg) {
+			super(msg);
+		}
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,85 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationSuccessHandlerTest {
+
+	private static final String OAUTH_CALLBACK = "http://localhost:5173/oauth/callback";
+
+	@Mock
+	JwtProvider jwtProvider;
+
+	OAuth2AuthenticationSuccessHandler handler;
+
+	@BeforeEach
+	void setup() {
+		handler = new OAuth2AuthenticationSuccessHandler(
+				jwtProvider,
+				OAUTH_CALLBACK
+		);
+	}
+
+	@Test
+	@DisplayName("인증 성공 시 access token, refresh token을 포함한 redirect를 수행한다.")
+	void success_redirectsWithTokens() throws Exception {
+		// given
+		DefaultOAuth2User delegate = new DefaultOAuth2User(
+				List.of(new SimpleGrantedAuthority("ROLE_USER")),
+				Map.of("sub", "google-123", "email", "user@gmail.com"),
+				"sub"
+		);
+		CustomOAuth2User principal = new CustomOAuth2User(delegate, 1L, "ROLE_USER");
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+				principal,
+				null,
+				principal.getAuthorities()
+		);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		given(jwtProvider.generateAccessToken(1L, List.of("ROLE_USER")))
+				.willReturn("access-token");
+		given(jwtProvider.generateRefreshToken(1L))
+				.willReturn("refresh-token");
+
+		// when
+		handler.onAuthenticationSuccess(request, response, authentication);
+
+		// then
+		String redirectedUrl = response.getRedirectedUrl();
+		assertThat(redirectedUrl).isNotNull();
+
+		UriComponents uri = UriComponentsBuilder.fromUriString(redirectedUrl).build();
+		assertThat(uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + uri.getPath())
+				.isEqualTo(OAUTH_CALLBACK);
+
+		assertThat(uri.getQueryParams().getFirst("token"))
+				.isEqualTo("access-token");
+		assertThat(uri.getQueryParams().getFirst("refresh"))
+				.isEqualTo("refresh-token");
+
+		then(jwtProvider).should().generateAccessToken(1L, List.of("ROLE_USER"));
+		then(jwtProvider).should().generateRefreshToken(1L);
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/user/domain/UserPasswordCredentialTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/user/domain/UserPasswordCredentialTest.java
@@ -36,9 +36,9 @@ class UserPasswordCredentialTest {
             - Hibernate 구현에서는 persist() 시점에 insert 쿼리를 실행해서 곧바로 id를 채워 넣는 동작을 볼 수 있다.
          */
         User user = User.create("test@example.com", "test");
-        log.info("User create userId:{}", user.getId()); // user.id = null
+        log.info("User create providerUserId:{}", user.getId()); // user.id = null
         entityManager.persist(user);
-        log.info("JPA persist userId:{}", user.getId()); // user.id = 1
+        log.info("JPA persist providerUserId:{}", user.getId()); // user.id = 1
         entityManager.flush();
 
         /*

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,8 +6,8 @@ spring:
       client:
         registration:
           google:
-            client-id: ${OAUTH_GOOGLE_CLIENT_ID:test-google-client-id}
-            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET:test-google-client-secret}
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
 
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
@@ -33,3 +33,6 @@ cors:
   allowed-origins:
     - http://localhost:5173
   max-age: 3600
+
+oauth:
+  redirect-uri: http://localhost:5173/oauth/callback


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
close #34

### ✨ 반영 브랜치
feat/34 -> develop

### 📝 변경 사항
  - [x] Google OAuth 로그인 성공 시 Access Token / Refresh Token 발급 로직을 추가.
  - [x] OAuth 로그인 성공 시 프론트엔드 callback URI로 토큰을 query parameter로 전달하도록 구현.
  - [x] OAuth 로그인 실패 시 프론트엔드 callback URI로 에러 코드를 query parameter로 전달하도록 구현.
  - [x] Google OAuth 사용자 정보 파싱 로직을 분리하고 테스트 가능하도록 리팩토링.
  - [x] OAuth 성공/실패 핸들러 및 사용자 정보 파싱 관련 테스트를 추가.


### ➕ 추가 메모
  - 토큰 전달 방식은 이번 PR에서 `query parameter` 방식으로 결정
    - 성공: `http://localhost:5173/oauth/callback?token=...&refresh=...`
    - 실패: `http://localhost:5173/oauth/callback?error=...`
  - 실패 시 에러 코드는 아래와 같이 프론트엔드로 전달.
    - `oauth_access_denied`
    - `oauth_invalid_user_info`
    - `oauth_login_failed`
  - 기존 JWT 발급 방식과 동일한 `JwtProvider`를 사용하도록 구현.
  - OAuth 관련 fixture/test helper를 추가해 테스트 중복 제거.

---
이후 쿠키 기반 JWT 반환으로 리팩토링 예정


### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
 ```bash
  ./gradlew test --tests '*OAuth2AuthenticationFailureHandlerTest' \
                 --tests '*OAuth2AuthenticationSuccessHandlerTest' \
                 --tests '*CustomOAuth2UserServiceTest' \
                 --tests '*GoogleOAuthAttributesTest' \
                 --tests '*OAuthLoginServiceTest'
```

  - 확인 내용
      - OAuth 로그인 성공 시 JWT 발급 및 callback redirect
      - OAuth 로그인 실패 시 에러 redirect
      - Google 사용자 정보 파싱 및 예외 처리
      - OAuth 로그인 시 신규 사용자 생성 / 기존 사용자 연동 / 재로그인 프로필 갱신
