### PR TITLE
[Auth] OAuth/JWT 전달 방식을 HttpOnly 쿠키 기반으로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 
 .omx/
 .agents/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !gradle/wrapper/gradle-wrapper.properties
 
-.omx
+.omx/
+.agents/

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -10,8 +10,9 @@ info:
     - 사용자 관리 (User): 프로필 관리, 관리자 기능
     
     ## 인증
-    Bearer 토큰을 사용한 JWT 인증을 사용합니다.
-    `Authorization: Bearer <token>` 헤더를 포함하여 요청하세요.
+    브라우저 환경에서는 HttpOnly 쿠키 기반 JWT 인증을 사용합니다.
+    로그인/OAuth 성공 후 서버는 access/refresh 토큰을 쿠키로 설정하며, 클라이언트는 이후 요청에서 쿠키 기반 인증을 사용합니다.
+    비브라우저 클라이언트와 수동 테스트에서는 `Authorization: Bearer <token>` 헤더 기반 접근도 사용할 수 있습니다.
 
   contact:
     name: API Support
@@ -81,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthResponse'
+                $ref: '#/components/schemas/SignupResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '409':
@@ -110,7 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthResponse'
+                $ref: '#/components/schemas/LoginResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -118,120 +119,20 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequests'
 
-  /auth/refresh:
-    post:
+  /auth/me:
+    get:
       tags: [Auth]
-      summary: 액세스 토큰 재발급
-      operationId: refreshToken
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RefreshTokenRequest'
+      summary: 현재 로그인 사용자 조회
+      operationId: getMyInfo
       responses:
         '200':
-          description: 토큰 재발급 성공
+          description: 현재 로그인 사용자 조회 성공
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenResponse'
+                $ref: '#/components/schemas/MyInfoResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
-
-  /auth/logout:
-    post:
-      tags: [Auth]
-      summary: 로그아웃
-      operationId: logout
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LogoutRequest'
-      responses:
-        '200':
-          description: 로그아웃 성공
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-      security:
-        - BearerAuth: []
-
-  /auth/verify-email:
-    post:
-      tags: [Auth]
-      summary: 이메일 인증
-      operationId: verifyEmail
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VerifyEmailRequest'
-      responses:
-        '200':
-          description: 이메일 인증 성공
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
-  /auth/forgot-password:
-    post:
-      tags: [Auth]
-      summary: 비밀번호 재설정 요청
-      operationId: forgotPassword
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ForgotPasswordRequest'
-      responses:
-        '200':
-          description: 재설정 이메일 발송 완료
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-
-  /auth/reset-password:
-    post:
-      tags: [Auth]
-      summary: 비밀번호 재설정
-      operationId: resetPassword
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ResetPasswordRequest'
-      responses:
-        '200':
-          description: 비밀번호 재설정 성공
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -757,52 +658,7 @@ components:
           format: password
       required: [email, password]
 
-    RefreshTokenRequest:
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 리프레시 토큰
-      required: [refreshToken]
-
-    LogoutRequest:
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 무효화할 리프레시 토큰
-      required: [refreshToken]
-
-    VerifyEmailRequest:
-      type: object
-      properties:
-        token:
-          type: string
-          description: 이메일 인증 토큰
-      required: [token]
-
-    ForgotPasswordRequest:
-      type: object
-      properties:
-        email:
-          type: string
-          format: email
-      required: [email]
-
-    ResetPasswordRequest:
-      type: object
-      properties:
-        token:
-          type: string
-          description: 비밀번호 재설정 토큰
-        newPassword:
-          type: string
-          format: password
-          minLength: 8
-          pattern: '^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$'
-      required: [token, newPassword]
-
-    AuthResponse:
+    SignupResponse:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - type: object
@@ -810,41 +666,51 @@ components:
             data:
               type: object
               properties:
-                user:
-                  $ref: '#/components/schemas/UserDetail'
-                tokens:
-                  $ref: '#/components/schemas/TokenPair'
-              required: [user, tokens]
+                id:
+                  type: integer
+                  format: int64
+                email:
+                  type: string
+                  format: email
+                name:
+                  type: string
+              required: [id, email, name]
 
-    TokenResponse:
+    LoginResponse:
       allOf:
         - $ref: '#/components/schemas/ApiResponse'
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/TokenPair'
+              type: object
+              properties:
+                userId:
+                  type: integer
+                  format: int64
+                email:
+                  type: string
+                  format: email
+              required: [userId, email]
 
-    TokenPair:
-      type: object
-      properties:
-        accessToken:
-          type: string
-          description: JWT 액세스 토큰
-        refreshToken:
-          type: string
-          description: JWT 리프레시 토큰
-        tokenType:
-          type: string
-          default: Bearer
-        expiresIn:
-          type: integer
-          description: 액세스 토큰 만료 시간 (초)
-          example: 3600
-        refreshExpiresIn:
-          type: integer
-          description: 리프레시 토큰 만료 시간 (초)
-          example: 604800
-      required: [accessToken, refreshToken, tokenType, expiresIn]
+    MyInfoResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                userId:
+                  type: integer
+                  format: int64
+                email:
+                  type: string
+                  format: email
+                name:
+                  type: string
+                role:
+                  $ref: '#/components/schemas/UserRole'
+              required: [userId, email, name, role]
 
     # ========== User Schemas ==========
     UserRole:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -145,6 +145,20 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: 로그아웃
+      operationId: logout
+      security: []
+      responses:
+        '200':
+          description: 로그아웃 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
   # ========== User Endpoints ==========
   /users/me:
     get:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: 블링블링 API
+  title: Keepgoing API
   version: 1.0.0
   description: |
     블로그 + RAG + 이력서 생성 서비스의 백엔드 API 스펙.
@@ -13,6 +13,13 @@ info:
     브라우저 환경에서는 HttpOnly 쿠키 기반 JWT 인증을 사용합니다.
     로그인/OAuth 성공 후 서버는 access/refresh 토큰을 쿠키로 설정하며, 클라이언트는 이후 요청에서 쿠키 기반 인증을 사용합니다.
     비브라우저 클라이언트와 수동 테스트에서는 `Authorization: Bearer <token>` 헤더 기반 접근도 사용할 수 있습니다.
+    
+    ## CSRF 보안
+     이 서비스는 브라우저 환경에서 쿠키 기반 인증을 사용할 때 다음과 같은 전략으로 CSRF 위험을 완화합니다.
+     - 인증 쿠키는 `HttpOnly`, `Secure`, `SameSite=Lax`(또는 더 엄격한) 옵션으로 설정됩니다.
+     - 상태를 변경하는 모든 API는 `GET` 대신 `POST`, `PUT`, `PATCH`, `DELETE` 메서드를 사용합니다.
+     - 서버는 별도의 CSRF 토큰 검증 매커니즘을 사용하지 않으므로, 위 정책과 API 설계를 전제로 보안 위협 모델을 구성합니다.
+     - 브라우저 클라이언트는 다른 출처에서 이 API를 임베드하여 자동으로 쿠키가 전송되는 패턴을 피해야 합니다.
 
   contact:
     name: API Support
@@ -124,6 +131,8 @@ paths:
       tags: [Auth]
       summary: 현재 로그인 사용자 조회
       operationId: getMyInfo
+      security:
+        - BearerAuth: []
       responses:
         '200':
           description: 현재 로그인 사용자 조회 성공

--- a/src/main/java/com/keepgoing/keepgoing/KeepgoingApplication.java
+++ b/src/main/java/com/keepgoing/keepgoing/KeepgoingApplication.java
@@ -1,13 +1,9 @@
 package com.keepgoing.keepgoing;
 
-import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableConfigurationProperties(TokenCookieProperties.class)
 public class KeepgoingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/keepgoing/keepgoing/KeepgoingApplication.java
+++ b/src/main/java/com/keepgoing/keepgoing/KeepgoingApplication.java
@@ -1,10 +1,13 @@
 package com.keepgoing.keepgoing;
 
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableConfigurationProperties(TokenCookieProperties.class)
 public class KeepgoingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/keepgoing/keepgoing/auth/AuthMapper.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/AuthMapper.java
@@ -2,10 +2,12 @@ package com.keepgoing.keepgoing.auth;
 
 import com.keepgoing.keepgoing.auth.controller.dto.LoginRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.LoginResponse;
+import com.keepgoing.keepgoing.auth.controller.dto.MyInfoResponse;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupResponse;
 import com.keepgoing.keepgoing.auth.service.dto.LoginCommand;
 import com.keepgoing.keepgoing.auth.service.dto.LoginResult;
+import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -48,9 +50,17 @@ public class AuthMapper {
 
     public LoginResponse toResponse(LoginResult dto) {
         return new LoginResponse(
-                dto.accessToken(),
-                dto.refreshToken(),
-                dto.userId()
+                dto.userId(),
+                dto.email()
+        );
+    }
+
+    public MyInfoResponse toResponse(MyInfoResult dto) {
+        return new MyInfoResponse(
+                dto.userId(),
+                dto.email(),
+                dto.name(),
+                dto.role()
         );
     }
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -106,6 +107,39 @@ public interface AuthApiDocs {
     ResponseEntity<ApiResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse servletResponse
+    );
+
+    @Operation(summary = "Access Token 재발급")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "재발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "리프레시 토큰이 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "RefreshTokenInvalid",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "AUTH_REFRESH_TOKEN_INVALID",
+                                                "message": "유효하지 않은 리프레시 토큰입니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PostMapping("/refresh")
+    ResponseEntity<ApiResponse<Void>> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
     );
 
     @Operation(summary = "내 정보 조회")

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepgoing.auth.controller;
 
 import com.keepgoing.keepgoing.auth.controller.dto.LoginRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.LoginResponse;
+import com.keepgoing.keepgoing.auth.controller.dto.MyInfoResponse;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupResponse;
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
@@ -12,8 +13,11 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -100,6 +104,35 @@ public interface AuthApiDocs {
     })
     @PostMapping("/login")
     ResponseEntity<ApiResponse<LoginResponse>> login(
-            @Valid @RequestBody LoginRequest request
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse servletResponse
+    );
+
+    @Operation(summary = "내 정보 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/me")
+    ResponseEntity<ApiResponse<MyInfoResponse>> getMyInfo(
+            @AuthenticationPrincipal Long userId
     );
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -142,6 +142,18 @@ public interface AuthApiDocs {
             HttpServletResponse response
     );
 
+    @Operation(summary = "로그아웃")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공"
+            )
+    })
+    @PostMapping("/logout")
+    ResponseEntity<ApiResponse<Void>> logout(
+            HttpServletResponse response
+    );
+
     @Operation(summary = "내 정보 조회")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -93,4 +93,11 @@ public class AuthController implements AuthApiDocs {
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+			HttpServletResponse response
+	) {
+		authCookieManager.clearAllTokens(response);
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -3,18 +3,24 @@ package com.keepgoing.keepgoing.auth.controller;
 import com.keepgoing.keepgoing.auth.AuthMapper;
 import com.keepgoing.keepgoing.auth.controller.dto.LoginRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.LoginResponse;
+import com.keepgoing.keepgoing.auth.controller.dto.MyInfoResponse;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupRequest;
 import com.keepgoing.keepgoing.auth.controller.dto.SignupResponse;
 import com.keepgoing.keepgoing.auth.service.AuthService;
 import com.keepgoing.keepgoing.auth.service.dto.LoginCommand;
 import com.keepgoing.keepgoing.auth.service.dto.LoginResult;
+import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
+import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,30 +31,48 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController implements AuthApiDocs {
 
-    private final AuthService authService;
-    private final AuthMapper authMapper;
+	private final AuthService authService;
+	private final AuthMapper authMapper;
+	private final AuthCookieManager authCookieManager;
 
-    @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponse>> signup(
-            @Valid @RequestBody SignupRequest request
-    ) {
-        SignupCommand command = authMapper.toCommand(request);
-        SignupResult result = authService.signup(command);
-        SignupResponse response = authMapper.toResponse(result);
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<SignupResponse>> signup(
+			@Valid @RequestBody SignupRequest request
+	) {
+		SignupCommand command = authMapper.toCommand(request);
+		SignupResult result = authService.signup(command);
+		SignupResponse response = authMapper.toResponse(result);
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(response));
-    }
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(ApiResponse.success(response));
+	}
 
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(
-            @Valid @RequestBody LoginRequest request
-    ) {
-        LoginCommand command = authMapper.toCommand(request);
-        LoginResult result = authService.login(command);
-        LoginResponse response = authMapper.toResponse(result);
+	@PostMapping("/login")
+	public ResponseEntity<ApiResponse<LoginResponse>> login(
+			@Valid @RequestBody LoginRequest request,
+			HttpServletResponse servletResponse
+	) {
+		LoginCommand command = authMapper.toCommand(request);
+		LoginResult result = authService.login(command);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.success(response));
-    }
+		authCookieManager.addAccessToken(servletResponse, result.accessToken());
+		authCookieManager.addRefreshToken(servletResponse, result.refreshToken());
+
+		LoginResponse body = authMapper.toResponse(result);
+
+		return ResponseEntity.status(HttpStatus.OK)
+				.body(ApiResponse.success(body));
+	}
+
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<MyInfoResponse>> getMyInfo(
+			@AuthenticationPrincipal Long userId
+	) {
+		MyInfoResult result = authService.getMyInfo(userId);
+
+		MyInfoResponse body = authMapper.toResponse(result);
+
+		return ResponseEntity.status(HttpStatus.OK)
+				.body(ApiResponse.success(body));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -13,7 +13,10 @@ import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
+import com.keepgoing.keepgoing.global.common.error.BusinessException;
+import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -75,4 +78,19 @@ public class AuthController implements AuthApiDocs {
 		return ResponseEntity.status(HttpStatus.OK)
 				.body(ApiResponse.success(body));
 	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponse<Void>> refresh(
+			HttpServletRequest request,
+			HttpServletResponse response
+	) {
+		// TODO : 에러 처리 아키텍처 수정 검토 필요
+		String refreshToken = authCookieManager.extractRefreshToken(request)
+				.orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+		String accessToken = authService.refresh(refreshToken);
+		authCookieManager.addAccessToken(response, accessToken);
+
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/dto/LoginResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/dto/LoginResponse.java
@@ -4,8 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "로그인 응답")
 public record LoginResponse(
-        String accessToken,
-        String refreshToken,
-        Long userId
+        Long userId,
+        String email
 ) {
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/dto/MyInfoResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/dto/MyInfoResponse.java
@@ -1,0 +1,11 @@
+package com.keepgoing.keepgoing.auth.controller.dto;
+
+import com.keepgoing.keepgoing.user.domain.UserRole;
+
+public record MyInfoResponse(
+		Long userId,
+		String email,
+		String name,
+		UserRole role
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/AppOAuthPrincipal.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/AppOAuthPrincipal.java
@@ -1,0 +1,6 @@
+package com.keepgoing.keepgoing.auth.security;
+
+public interface AppOAuthPrincipal {
+	Long getUserId();
+	String getRole();
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOAuth2UserService.java
@@ -25,7 +25,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return new CustomOAuth2User(oAuth2User, principal.userId(), principal.role());
 	}
 
-	protected OAuth2User loadProviderUser(OAuth2UserRequest  userRequest) {
+	protected OAuth2User loadProviderUser(OAuth2UserRequest userRequest) {
 		return super.loadUser(userRequest);
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOidcUser.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOidcUser.java
@@ -5,18 +5,35 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 @RequiredArgsConstructor
-public class CustomOAuth2User implements OAuth2User, AppOAuthPrincipal {
+public class CustomOidcUser implements OidcUser, AppOAuthPrincipal {
 
-	private final OAuth2User delegate;
+	private final OidcUser delegate;
 
 	@Getter
 	private final Long userId;
 
 	@Getter
 	private final String role;
+
+	@Override
+	public Map<String, Object> getClaims() {
+		return delegate.getClaims();
+	}
+
+	@Override
+	public OidcUserInfo getUserInfo() {
+		return delegate.getUserInfo();
+	}
+
+	@Override
+	public OidcIdToken getIdToken() {
+		return delegate.getIdToken();
+	}
 
 	@Override
 	public Map<String, Object> getAttributes() {

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOidcUserService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/CustomOidcUserService.java
@@ -1,0 +1,36 @@
+package com.keepgoing.keepgoing.auth.security;
+
+import com.keepgoing.keepgoing.auth.service.OAuthLoginService;
+import com.keepgoing.keepgoing.auth.service.dto.OAuthUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+
+	private final OAuthLoginService oAuthLoginService;
+
+	@Override
+	public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+		OidcUser oidcUser = loadProviderUser(userRequest);
+
+		GoogleOAuthAttributes attr = GoogleOAuthAttributes.from(oidcUser);
+
+		OAuthUserPrincipal principal = oAuthLoginService.processOAuthLogin(
+				attr.email(),
+				attr.providerUserId(),
+				attr.avatarUrl(),
+				attr.name()
+		);
+		return new CustomOidcUser(oidcUser, principal.userId(), principal.role());
+	}
+
+	protected OidcUser loadProviderUser(OidcUserRequest userRequest) {
+		return super.loadUser(userRequest);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributes.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/GoogleOAuthAttributes.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepgoing.auth.security;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 public record GoogleOAuthAttributes(
@@ -25,6 +26,25 @@ public record GoogleOAuthAttributes(
 			name = email.split("@")[0];
 		}
 		String avatarUrl = oAuth2User.getAttribute("picture");
+
+		return new GoogleOAuthAttributes(email, providerUserId, avatarUrl, name);
+	}
+
+	public static GoogleOAuthAttributes from(OidcUser oidcUser) {
+
+		String providerUserId = oidcUser.getSubject();
+		String email = oidcUser.getEmail();
+		if (providerUserId == null || email == null) {
+			throw new OAuth2AuthenticationException(
+					new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST),
+					"Google 필수 정보 누락"
+			);
+		}
+		String name = oidcUser.getFullName();
+		if (name == null) {
+			name = email.split("@")[0];
+		}
+		String avatarUrl = oidcUser.getPicture();
 
 		return new GoogleOAuthAttributes(email, providerUserId, avatarUrl, name);
 	}

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandler.java
@@ -6,11 +6,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -28,25 +25,6 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 			HttpServletResponse response,
 			AuthenticationException exception
 	) throws IOException, ServletException {
-		String errorCode = resolveErrorCode(exception);
-
-		String uriString = UriComponentsBuilder
-				.fromUriString(redirectUri)
-				.queryParam("error", errorCode)
-				.build()
-				.toUriString();
-		response.sendRedirect(uriString);
-	}
-
-	private String resolveErrorCode(AuthenticationException exception) {
-		if (!(exception instanceof OAuth2AuthenticationException oauthException)) {
-			return "oauth_login_failed";
-		}
-
-		return switch (oauthException.getError().getErrorCode()) {
-			case OAuth2ErrorCodes.ACCESS_DENIED -> "oauth_access_denied";
-			case OAuth2ErrorCodes.INVALID_REQUEST -> "oauth_invalid_user_info";
-			default -> "oauth_login_failed";
-		};
+		response.sendRedirect(redirectUri);
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.keepgoing.keepgoing.auth.security;
 
+import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,25 +11,30 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-	private final JwtProvider jwtProvider;
 	private final String redirectUri;
+	private final JwtProvider jwtProvider;
+	private final AuthCookieManager authCookieManager;
 
 	public OAuth2AuthenticationSuccessHandler(
+			@Value("${oauth.redirect-uri}") String redirectUri,
 			JwtProvider jwtProvider,
-			@Value("${oauth.redirect-uri}") String redirectUri
+			AuthCookieManager authCookieManager
 	) {
-		this.jwtProvider = jwtProvider;
 		this.redirectUri = redirectUri;
+		this.jwtProvider = jwtProvider;
+		this.authCookieManager = authCookieManager;
 	}
 
 	@Override
-	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-	                                    Authentication authentication) throws IOException, ServletException {
+	public void onAuthenticationSuccess(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			Authentication authentication
+	) throws IOException, ServletException {
 		CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
 		Long userId = principal.getUserId();
 		String role = principal.getRole();
@@ -36,11 +42,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		String accessToken = jwtProvider.generateAccessToken(userId, List.of(role));
 		String refreshToken = jwtProvider.generateRefreshToken(userId);
 
-		String uriString = UriComponentsBuilder
-				.fromUriString(redirectUri)
-				.queryParam("token", accessToken)
-				.queryParam("refresh", refreshToken)
-				.build().toUriString();
-		response.sendRedirect(uriString);
+		authCookieManager.addAccessToken(response, accessToken);
+		authCookieManager.addRefreshToken(response, refreshToken);
+		response.sendRedirect(redirectUri);
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 			HttpServletResponse response,
 			Authentication authentication
 	) throws IOException, ServletException {
-		CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
+		AppOAuthPrincipal principal = (AppOAuthPrincipal) authentication.getPrincipal();
 		Long userId = principal.getUserId();
 		String role = principal.getRole();
 

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.keepgoing.keepgoing.auth.AuthMapper;
 import com.keepgoing.keepgoing.auth.security.CustomUserDetails;
 import com.keepgoing.keepgoing.auth.service.dto.LoginCommand;
 import com.keepgoing.keepgoing.auth.service.dto.LoginResult;
+import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
@@ -26,50 +27,59 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final AuthenticationManager authenticationManager;
-    private final JwtProvider jwtProvider;
+	private final AuthenticationManager authenticationManager;
+	private final JwtProvider jwtProvider;
 
-    private final UserRepository userRepository;
-    private final UserPasswordCredentialRepository credentialRepository;
+	private final UserRepository userRepository;
+	private final UserPasswordCredentialRepository credentialRepository;
 
-    private final PasswordEncoder passwordEncoder;
-    private final AuthMapper authMapper;
+	private final PasswordEncoder passwordEncoder;
+	private final AuthMapper authMapper;
 
-    @Transactional
-    public SignupResult signup(SignupCommand command) {
-        // 중복 이메일 체크
-        if (userRepository.existsByEmail(command.email())) {
-            throw new BusinessException(ErrorCode.USER_ALREADY_EXISTS);
-        }
+	@Transactional
+	public SignupResult signup(SignupCommand command) {
+		// 중복 이메일 체크
+		if (userRepository.existsByEmail(command.email())) {
+			throw new BusinessException(ErrorCode.USER_ALREADY_EXISTS);
+		}
 
-        // User 생성 후 저장
-        User user = User.create(command.email(), command.name());
-        userRepository.save(user);
+		// User 생성 후 저장
+		User user = User.create(command.email(), command.name());
+		userRepository.save(user);
 
-        // encodedPassword 생성 후 저장
-        UserPasswordCredential credential = UserPasswordCredential.create(
-                user,
-                command.email(),
-                passwordEncoder.encode(command.rawPassword())
-        );
-        credentialRepository.save(credential);
+		// encodedPassword 생성 후 저장
+		UserPasswordCredential credential = UserPasswordCredential.create(
+				user,
+				command.email(),
+				passwordEncoder.encode(command.rawPassword())
+		);
+		credentialRepository.save(credential);
 
-        return authMapper.toSignupResult(user);
-    }
+		return authMapper.toSignupResult(user);
+	}
 
-    @Transactional
-    public LoginResult login(LoginCommand command) {
-        UsernamePasswordAuthenticationToken unauthenticated =
-                UsernamePasswordAuthenticationToken.unauthenticated(command.email(), command.rawPassword());
-        Authentication authenticate = authenticationManager.authenticate(unauthenticated);
+	@Transactional
+	public LoginResult login(LoginCommand command) {
+		UsernamePasswordAuthenticationToken unauthenticated =
+				UsernamePasswordAuthenticationToken.unauthenticated(command.email(), command.rawPassword());
+		Authentication authenticate = authenticationManager.authenticate(unauthenticated);
 
-        CustomUserDetails principal = (CustomUserDetails) authenticate.getPrincipal();
-        List<String> roles = principal.getRoles();
+		CustomUserDetails principal = (CustomUserDetails) authenticate.getPrincipal();
+		List<String> roles = principal.getRoles();
 
-        Long userId = principal.getUserId();
-        String accessToken = jwtProvider.generateAccessToken(userId, roles);
-        String refreshToken = jwtProvider.generateRefreshToken(userId);
+		Long userId = principal.getUserId();
+		String accessToken = jwtProvider.generateAccessToken(userId, roles);
+		String refreshToken = jwtProvider.generateRefreshToken(userId);
 
-        return new LoginResult(accessToken, refreshToken, userId);
-    }
+		String email = principal.getUsername();
+		return new LoginResult(accessToken, refreshToken, userId, email);
+	}
+
+	@Transactional(readOnly = true)
+	public MyInfoResult getMyInfo(Long userId) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		return new MyInfoResult(userId, user.getEmail(), user.getName(), user.getRole());
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
@@ -82,4 +82,13 @@ public class AuthService {
 
 		return new MyInfoResult(userId, user.getEmail(), user.getName(), user.getRole());
 	}
+
+	@Transactional(readOnly = true)
+	public String refresh(String refreshToken) {
+		Long userId = jwtProvider.validateRefreshTokenAndGetUserId(refreshToken);
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		return jwtProvider.generateAccessToken(userId, List.of(user.getRole().toAuthority()));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/dto/LoginResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/dto/LoginResult.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepgoing.auth.service.dto;
 public record LoginResult(
         String accessToken,
         String refreshToken,
-        Long userId
+        Long userId,
+        String email
 ) {
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/dto/MyInfoResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/dto/MyInfoResult.java
@@ -1,0 +1,11 @@
+package com.keepgoing.keepgoing.auth.service.dto;
+
+import com.keepgoing.keepgoing.user.domain.UserRole;
+
+public record MyInfoResult(
+		Long userId,
+		String email,
+		String name,
+		UserRole role
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepgoing.global.config;
 
 import com.keepgoing.keepgoing.auth.security.CustomOAuth2UserService;
+import com.keepgoing.keepgoing.auth.security.CustomOidcUserService;
 import com.keepgoing.keepgoing.auth.security.OAuth2AuthenticationFailureHandler;
 import com.keepgoing.keepgoing.auth.security.OAuth2AuthenticationSuccessHandler;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
@@ -27,7 +28,6 @@ public class SecurityConfig {
 	private static final String AUTH_API_PREFIX = "/api/auth";
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
-	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 	private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
@@ -44,7 +44,9 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(
 			HttpSecurity http,
-			CorsConfigurationSource corsConfigurationSource
+			CorsConfigurationSource corsConfigurationSource,
+			CustomOAuth2UserService customOAuth2UserService,
+			CustomOidcUserService customOidcUserService
 	) throws Exception {
 
 		http
@@ -82,7 +84,8 @@ public class SecurityConfig {
 				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 				.oauth2Login(oauth2 -> oauth2
 						.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
-								.userService(customOAuth2UserService))
+								.userService(customOAuth2UserService)
+								.oidcUserService(customOidcUserService))
 						.successHandler(oAuth2AuthenticationSuccessHandler)
 						.failureHandler(oAuth2AuthenticationFailureHandler)
 				);

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 						.requestMatchers(
 								AUTH_API_PREFIX + "/signup",
 								AUTH_API_PREFIX + "/login",
-								AUTH_API_PREFIX + "/refresh"
+								AUTH_API_PREFIX + "/refresh",
+								AUTH_API_PREFIX + "/logout"
 						).permitAll()
 						// TODO: 포스트 API는 일단 모두 허용 (개발용)
 						.requestMatchers(

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
@@ -1,38 +1,58 @@
 package com.keepgoing.keepgoing.global.security.cookie;
 
 import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
 public class AuthCookieManager {
 
-	private final TokenCookieProperties tokenCookieProperties;
+	private final TokenCookieProperties properties;
 
 	public void addAccessToken(HttpServletResponse response, String token) {
-		addCookie(response, tokenCookieProperties.accessToken(), token);
+		addCookie(response, properties.accessToken(), token);
 	}
 
 	public void addRefreshToken(HttpServletResponse response, String token) {
-		addCookie(response, tokenCookieProperties.refreshToken(), token);
+		addCookie(response, properties.refreshToken(), token);
 	}
 
 	public void clearAccessToken(HttpServletResponse response) {
-		expireCookie(response, tokenCookieProperties.accessToken());
+		expireCookie(response, properties.accessToken());
 	}
 
 	public void clearRefreshToken(HttpServletResponse response) {
-		expireCookie(response, tokenCookieProperties.refreshToken());
+		expireCookie(response, properties.refreshToken());
 	}
 
 	public void clearAllTokens(HttpServletResponse response) {
 		clearAccessToken(response);
 		clearRefreshToken(response);
 	}
+
+	public Optional<String> extractRefreshToken(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return Optional.empty();
+		}
+
+		for (Cookie cookie : cookies) {
+			if (cookie.getName().equals(properties.refreshToken().name())
+					&& StringUtils.hasText(cookie.getValue())) {
+				return Optional.of(cookie.getValue());
+			}
+		}
+		return Optional.empty();
+	}
+
 
 	private void addCookie(
 			HttpServletResponse response,
@@ -41,8 +61,8 @@ public class AuthCookieManager {
 	) {
 		ResponseCookie cookie = ResponseCookie.from(spec.name(), value)
 				.httpOnly(true)
-				.secure(tokenCookieProperties.secure())
-				.sameSite(tokenCookieProperties.sameSite())
+				.secure(properties.secure())
+				.sameSite(properties.sameSite())
 				.path(spec.path())
 				.maxAge(spec.maxAge())
 				.build();
@@ -56,8 +76,8 @@ public class AuthCookieManager {
 	) {
 		ResponseCookie cookie = ResponseCookie.from(spec.name(), "")
 				.httpOnly(true)
-				.secure(tokenCookieProperties.secure())
-				.sameSite(tokenCookieProperties.sameSite())
+				.secure(properties.secure())
+				.sameSite(properties.sameSite())
 				.path(spec.path())
 				.maxAge(0)
 				.build();

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
@@ -1,0 +1,69 @@
+package com.keepgoing.keepgoing.global.security.cookie;
+
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableConfigurationProperties(TokenCookieProperties.class)
+@RequiredArgsConstructor
+public class AuthCookieManager {
+
+	private final TokenCookieProperties tokenCookieProperties;
+
+	public void addAccessToken(HttpServletResponse response, String token) {
+		addCookie(response, tokenCookieProperties.accessToken(), token);
+	}
+
+	public void addRefreshToken(HttpServletResponse response, String token) {
+		addCookie(response, tokenCookieProperties.refreshToken(), token);
+	}
+
+	public void clearAccessToken(HttpServletResponse response) {
+		expireCookie(response, tokenCookieProperties.accessToken());
+	}
+
+	public void clearRefreshToken(HttpServletResponse response) {
+		expireCookie(response, tokenCookieProperties.refreshToken());
+	}
+
+	public void clearAllTokens(HttpServletResponse response) {
+		clearAccessToken(response);
+		clearRefreshToken(response);
+	}
+
+	private void addCookie(
+			HttpServletResponse response,
+			CookieSpec spec,
+			String value
+	) {
+		ResponseCookie cookie = ResponseCookie.from(spec.name(), value)
+				.httpOnly(true)
+				.secure(tokenCookieProperties.secure())
+				.sameSite(tokenCookieProperties.sameSite())
+				.path(spec.path())
+				.maxAge(spec.maxAge())
+				.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
+
+	private void expireCookie(
+			HttpServletResponse response,
+			CookieSpec spec
+	) {
+		ResponseCookie cookie = ResponseCookie.from(spec.name(), "")
+				.httpOnly(true)
+				.secure(tokenCookieProperties.secure())
+				.sameSite(tokenCookieProperties.sameSite())
+				.path(spec.path())
+				.maxAge(0)
+				.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
@@ -3,13 +3,11 @@ package com.keepgoing.keepgoing.global.security.cookie;
 import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-@EnableConfigurationProperties(TokenCookieProperties.class)
 @RequiredArgsConstructor
 public class AuthCookieManager {
 

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/CookieConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/CookieConfig.java
@@ -1,0 +1,4 @@
+package com.keepgoing.keepgoing.global.security.cookie;
+
+public class CookieConfig {
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/CookieConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/CookieConfig.java
@@ -1,4 +1,9 @@
 package com.keepgoing.keepgoing.global.security.cookie;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TokenCookieProperties.class)
 public class CookieConfig {
 }

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/TokenCookieProperties.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/TokenCookieProperties.java
@@ -1,0 +1,29 @@
+package com.keepgoing.keepgoing.global.security.cookie;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth.cookie")
+public record TokenCookieProperties(
+		boolean secure,
+		String sameSite,
+		CookieSpec accessToken,
+		CookieSpec refreshToken
+) {
+	public record CookieSpec(
+			String name,
+			String path,
+			Long maxAge
+	) {
+		public CookieSpec {
+			if (name == null || name.isBlank()) {
+				throw new IllegalArgumentException("cookie name must not be blank");
+			}
+			if (path == null || path.isBlank()) {
+				path = "/";
+			}
+			if (maxAge == null || maxAge <= 0) {
+				throw new IllegalArgumentException("cookie maxAge must be positive");
+			}
+		}
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,13 +1,16 @@
 package com.keepgoing.keepgoing.global.security.jwt;
 
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,43 +23,57 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
+	private static final String BEARER_PREFIX = "Bearer ";
 
-    private final JwtProvider jwtProvider;
+	private final JwtProvider jwtProvider;
+	private final TokenCookieProperties tokenCookieProperties;
 
-    @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
-        String token = extractToken(request);
+	@Override
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
+		String token = extractToken(request);
 
-        if (token != null) {
-            try {
-                Long userId = jwtProvider.getUserIdFromToken(token);
-                List<String> roles = jwtProvider.getRolesFromToken(token);
+		if (token != null) {
+			try {
+				Long userId = jwtProvider.getUserIdFromToken(token);
+				List<String> roles = jwtProvider.getRolesFromToken(token);
 
-                List<SimpleGrantedAuthority> authorities = roles.stream()
-                        .map(SimpleGrantedAuthority::new)
-                        .toList();
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userId, null, authorities);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (Exception e) {
-                log.debug("JWT 인증 실패: {}", e.getMessage());
-            }
-        }
-        filterChain.doFilter(request, response);
-    }
+				List<SimpleGrantedAuthority> authorities = roles.stream()
+						.map(SimpleGrantedAuthority::new)
+						.toList();
+				UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+						userId, null, authorities);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} catch (Exception e) {
+				log.debug("JWT 인증 실패: {}", e.getMessage());
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
 
-    private String extractToken(HttpServletRequest request) {
-        String header = request.getHeader(AUTHORIZATION_HEADER);
+	private String extractToken(HttpServletRequest request) {
+		String header = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
-            return header.substring(BEARER_PREFIX.length());
-        }
-        return null;
-    }
+		if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+			return header.substring(BEARER_PREFIX.length());
+		}
+
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return null;
+		}
+
+		String accessTokenCookieName = tokenCookieProperties.accessToken().name();
+		for (Cookie cookie : cookies) {
+			if (accessTokenCookieName.equals(cookie.getName())
+					&& StringUtils.hasText(cookie.getValue())) {
+				return cookie.getValue();
+			}
+		}
+
+		return null;
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,16 @@ cors:
 
 oauth:
   redirect-uri: http://localhost:5173/oauth/callback
+
+auth:
+  cookie:
+    secure: false
+    same-site: Lax
+    access-token:
+      name: access_token
+      path: /api
+      max-age: 3600
+    refresh-token:
+      name: refresh_token
+      path: /api/auth
+      max-age: 604800

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -362,4 +362,21 @@ class AuthControllerTest {
 			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
 		}
 	}
+
+	@Nested
+	@DisplayName("POST /api/auth/logout")
+	class Logout {
+
+		@Test
+		@DisplayName("성공 시 200을 반환하고 토큰 쿠키를 만료시킨다.")
+		void logout_success() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/auth/logout"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			then(authService).shouldHaveNoInteractions();
+			then(authCookieManager).should().clearAllTokens(any(HttpServletResponse.class));
+		}
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static com.keepgoing.keepgoing.auth.AuthTestFixtures.signupRequestWithEma
 import static com.keepgoing.keepgoing.auth.AuthTestFixtures.toJson;
 import static com.keepgoing.keepgoing.auth.AuthTestFixtures.validLoginRequest;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.AUTH_INVALID_CREDENTIALS;
+import static com.keepgoing.keepgoing.global.common.error.ErrorCode.AUTH_REFRESH_TOKEN_INVALID;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_ALREADY_EXISTS;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_NOT_FOUND;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.VALIDATION_FAILED;
@@ -37,6 +38,7 @@ import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,6 +70,9 @@ class AuthControllerTest {
 
 	private static final String EMAIL = "test@test.com";
 	public static final String NAME = "홍길동";
+	public static final String ACCESS_TOKEN = "access-token";
+	public static final String REFRESH_TOKEN = "refresh-token";
+	public static final String NEW_ACCESS_TOKEN = "new-access-token";
 
 	@Autowired
 	MockMvc mockMvc;
@@ -179,8 +184,8 @@ class AuthControllerTest {
 			// given
 			LoginRequest request = validLoginRequest();
 			LoginResult result = new LoginResult(
-					"access-token",
-					"refresh-token",
+					ACCESS_TOKEN,
+					REFRESH_TOKEN,
 					1L,
 					EMAIL
 			);
@@ -199,8 +204,8 @@ class AuthControllerTest {
 					.andExpect(jsonPath("$.data.userId").value(1L))
 					.andExpect(jsonPath("$.data.email").value(EMAIL));
 
-			then(authCookieManager).should().addAccessToken(any(HttpServletResponse.class), eq("access-token"));
-			then(authCookieManager).should().addRefreshToken(any(HttpServletResponse.class), eq("refresh-token"));
+			then(authCookieManager).should().addAccessToken(any(HttpServletResponse.class), eq(ACCESS_TOKEN));
+			then(authCookieManager).should().addRefreshToken(any(HttpServletResponse.class), eq(REFRESH_TOKEN));
 		}
 
 		@Test
@@ -296,6 +301,65 @@ class AuthControllerTest {
 					.andExpect(jsonPath("$.error.code").value(USER_NOT_FOUND.name()));
 
 			then(authService).should().getMyInfo(userId);
+		}
+	}
+
+	@Nested
+	@DisplayName("POST /api/auth/refresh")
+	class Refresh {
+
+		@Test
+		@DisplayName("성공 시 200 + access token 재발급")
+		void refresh_success() throws Exception {
+			// given
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.of(REFRESH_TOKEN));
+			given(authService.refresh(REFRESH_TOKEN))
+					.willReturn(NEW_ACCESS_TOKEN);
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			then(authService).should().refresh(REFRESH_TOKEN);
+			then(authCookieManager).should()
+					.addAccessToken(any(HttpServletResponse.class), eq(NEW_ACCESS_TOKEN));
+		}
+
+		@Test
+		@DisplayName("refresh 쿠기가 없으면 401을 반환한다.")
+		void refresh_token_missing() throws Exception {
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.empty());
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(AUTH_REFRESH_TOKEN_INVALID.name()));
+
+			then(authService).shouldHaveNoInteractions();
+			then(authCookieManager).should(never())
+					.addAccessToken(any(HttpServletResponse.class), anyString());
+		}
+
+		@Test
+		@DisplayName("유효하지 않은 refresh token이면 401을 반환한다.")
+		void invalid_refresh_token() throws Exception {
+			// given
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.of("bad-refresh-token"));
+			willThrow(new BusinessException(AUTH_REFRESH_TOKEN_INVALID))
+					.given(authService).refresh("bad-refresh-token");
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(AUTH_REFRESH_TOKEN_INVALID.name()));
+
+			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -5,10 +5,16 @@ import static com.keepgoing.keepgoing.auth.AuthTestFixtures.toJson;
 import static com.keepgoing.keepgoing.auth.AuthTestFixtures.validLoginRequest;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.AUTH_INVALID_CREDENTIALS;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_ALREADY_EXISTS;
+import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_NOT_FOUND;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.VALIDATION_FAILED;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,10 +28,16 @@ import com.keepgoing.keepgoing.auth.controller.dto.SignupResponse;
 import com.keepgoing.keepgoing.auth.service.AuthService;
 import com.keepgoing.keepgoing.auth.service.dto.LoginCommand;
 import com.keepgoing.keepgoing.auth.service.dto.LoginResult;
+import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
+import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
+import com.keepgoing.keepgoing.user.domain.UserRole;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +47,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -50,161 +66,236 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import({ObjectMapper.class, AuthMapper.class})
 class AuthControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+	private static final String EMAIL = "test@test.com";
+	public static final String NAME = "홍길동";
 
-    @Autowired
-    ObjectMapper objectMapper;
+	@Autowired
+	MockMvc mockMvc;
 
-    @MockitoBean
-    AuthService authService;
+	@Autowired
+	ObjectMapper objectMapper;
 
-    @MockitoBean
-    JwtAuthenticationFilter jwtAuthenticationFilter;
+	@MockitoBean
+	AuthService authService;
 
-    // 계층 구조로 테스트 코드 가독성 증가
-    @Nested
-    @DisplayName("POST /api/auth/signup - 회원가입")
-    class Signup {
+	@MockitoBean
+	JwtAuthenticationFilter jwtAuthenticationFilter;
 
-        @Test
-        @DisplayName("성공 시 201과 SignupResponse를 반환한다.")
-        void success() throws Exception {
-            // given
-            SignupRequest request = AuthTestFixtures.validSignupRequest();
-            SignupResult result = new SignupResult(
-                    1L,
-                    request.email(),
-                    request.name()
-            );
-            SignupResponse response = new SignupResponse(
-                    result.id(),
-                    request.email(),
-                    request.name()
-            );
+	@MockitoBean
+	AuthCookieManager authCookieManager;
 
-            given(authService.signup(any(SignupCommand.class)))
-                    .willReturn(result);
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
 
-            String json = toJson(objectMapper, request);
 
-            // when & then
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json))
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.id").value(1L))
-                    .andExpect(jsonPath("$.data.email").value(request.email()))
-                    .andExpect(jsonPath("$.data.name").value(request.name()));
-        }
+	// 계층 구조로 테스트 코드 가독성 증가
+	@Nested
+	@DisplayName("POST /api/auth/signup - 회원가입")
+	class Signup {
 
-        @Test
-        @DisplayName("이메일이 이미 존재하면 409와 USER_ALREADY_EXISTS 에러를 반환한다.")
-        void email_duplicate() throws Exception {
-            // given
-            SignupRequest request = signupRequestWithEmail("dup@example.com");
-            String json = toJson(objectMapper, request);
+		@Test
+		@DisplayName("성공 시 201과 SignupResponse를 반환한다.")
+		void success() throws Exception {
+			// given
+			SignupRequest request = AuthTestFixtures.validSignupRequest();
+			SignupResult result = new SignupResult(
+					1L,
+					request.email(),
+					request.name()
+			);
+			SignupResponse response = new SignupResponse(
+					result.id(),
+					request.email(),
+					request.name()
+			);
 
-            willThrow(new BusinessException(USER_ALREADY_EXISTS))
-                    .given(authService)
-                    .signup(any(SignupCommand.class));
+			given(authService.signup(any(SignupCommand.class)))
+					.willReturn(result);
 
-            // when & then
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json))
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value(USER_ALREADY_EXISTS.name()));
-        }
+			String json = toJson(objectMapper, request);
 
-        @Test
-        @DisplayName("검증 실패 시 400과 VALIDATION_FAILED, FieldErrors 배열을 반환한다.")
-        void validation_failed() throws Exception {
-            // given
-            var invalid = SignupRequest.builder()
-                    .email("not-an-email")
-                    .password("")
-                    .name("")
-                    .build();
-            var json = toJson(objectMapper, invalid);
+			// when & then
+			mockMvc.perform(post("/api/auth/signup")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json))
+					.andExpect(status().isCreated())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.id").value(1L))
+					.andExpect(jsonPath("$.data.email").value(request.email()))
+					.andExpect(jsonPath("$.data.name").value(request.name()));
+		}
 
-            // when & then
-            mockMvc.perform(post("/api/auth/signup")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value(VALIDATION_FAILED.name()))
-                    .andExpect(jsonPath("$.error.fieldErrors").isArray());
-        }
-    }
+		@Test
+		@DisplayName("이메일이 이미 존재하면 409와 USER_ALREADY_EXISTS 에러를 반환한다.")
+		void email_duplicate() throws Exception {
+			// given
+			SignupRequest request = signupRequestWithEmail("dup@example.com");
+			String json = toJson(objectMapper, request);
 
-    @Nested
-    @DisplayName("POST /api/auth/login - 로그인")
-    class Login {
+			willThrow(new BusinessException(USER_ALREADY_EXISTS))
+					.given(authService)
+					.signup(any(SignupCommand.class));
 
-        @Test
-        @DisplayName("성공 시 200과 토큰을 반환한다.")
-        void success() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/auth/signup")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json))
+					.andExpect(status().isConflict())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(USER_ALREADY_EXISTS.name()));
+		}
 
-            // given
-            LoginRequest request = validLoginRequest();
-            LoginResult result = new LoginResult(
-                    "access-token",
-                    "refresh-token",
-                    1L
-            );
+		@Test
+		@DisplayName("검증 실패 시 400과 VALIDATION_FAILED, FieldErrors 배열을 반환한다.")
+		void validation_failed() throws Exception {
+			// given
+			var invalid = SignupRequest.builder()
+					.email("not-an-email")
+					.password("")
+					.name("")
+					.build();
+			var json = toJson(objectMapper, invalid);
 
-            given(authService.login(any(LoginCommand.class)))
-                    .willReturn(result);
+			// when & then
+			mockMvc.perform(post("/api/auth/signup")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(VALIDATION_FAILED.name()))
+					.andExpect(jsonPath("$.error.fieldErrors").isArray());
+		}
+	}
 
-            String json = toJson(objectMapper, request);
+	@Nested
+	@DisplayName("POST /api/auth/login - 로그인")
+	class Login {
 
-            // when & then
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json)
-                    ).andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.accessToken").value("access-token"))
-                    .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"))
-                    .andExpect(jsonPath("$.data.userId").value(1L));
-        }
+		@Test
+		@DisplayName("성공 시 200 응답과 함께 access/refresh 토큰 쿠키를 발급한다.")
+		void success() throws Exception {
+			// given
+			LoginRequest request = validLoginRequest();
+			LoginResult result = new LoginResult(
+					"access-token",
+					"refresh-token",
+					1L,
+					EMAIL
+			);
 
-        @Test
-        @DisplayName("잘못된 자격 증명 시 401과 AUTH_INVALID_CREDENTIALS 에러를 반환한다.")
-        void invalid_credentials() throws Exception {
-            // given
-            LoginRequest request = validLoginRequest();
-            String json = toJson(objectMapper, request);
+			given(authService.login(any(LoginCommand.class)))
+					.willReturn(result);
 
-            willThrow(new BadCredentialsException("Bad credentials"))
-                    .given(authService)
-                    .login(any(LoginCommand.class));
+			String json = toJson(objectMapper, request);
 
-            // when & then
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json))
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value(AUTH_INVALID_CREDENTIALS.name()));
-        }
+			// when & then
+			mockMvc.perform(post("/api/auth/login")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json)
+					).andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.userId").value(1L))
+					.andExpect(jsonPath("$.data.email").value(EMAIL));
 
-        @Test
-        @DisplayName("검증 실패 시 400과 VALIDATION_FAILED를 반환한다.")
-        void validation_failed() throws Exception {
-            // given
-            LoginRequest invalidRequest = new LoginRequest("", "");
-            String json = toJson(objectMapper, invalidRequest);
+			then(authCookieManager).should().addAccessToken(any(HttpServletResponse.class), eq("access-token"));
+			then(authCookieManager).should().addRefreshToken(any(HttpServletResponse.class), eq("refresh-token"));
+		}
 
-            // when & then
-            mockMvc.perform(post("/api/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(json))
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.code").value(VALIDATION_FAILED.name()));
-        }
-    }
+		@Test
+		@DisplayName("잘못된 자격 증명 시 401과 AUTH_INVALID_CREDENTIALS 에러를 반환한다.")
+		void invalid_credentials() throws Exception {
+			// given
+			LoginRequest request = validLoginRequest();
+			String json = toJson(objectMapper, request);
+
+			willThrow(new BadCredentialsException("Bad credentials"))
+					.given(authService)
+					.login(any(LoginCommand.class));
+
+			// when & then
+			mockMvc.perform(post("/api/auth/login")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json))
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(AUTH_INVALID_CREDENTIALS.name()));
+
+			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
+			then(authCookieManager).should(never()).addRefreshToken(any(), anyString());
+		}
+
+		@Test
+		@DisplayName("검증 실패 시 400과 VALIDATION_FAILED를 반환한다.")
+		void validation_failed() throws Exception {
+			// given
+			LoginRequest invalidRequest = new LoginRequest("", "");
+			String json = toJson(objectMapper, invalidRequest);
+
+			// when & then
+			mockMvc.perform(post("/api/auth/login")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(json))
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(VALIDATION_FAILED.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /api/auth/me - 정보")
+	class MyInfo {
+
+		@Test
+		@DisplayName("성공 시 200과 사용자 정보를 반환한다.")
+		void success() throws Exception {
+			// given
+			Long userId = 1L;
+			MyInfoResult result = new MyInfoResult(userId, EMAIL, NAME, UserRole.USER);
+
+			given(authService.getMyInfo(any()))
+					.willReturn(result);
+
+			Authentication authenticated = UsernamePasswordAuthenticationToken.authenticated(
+					userId,
+					null,
+					List.of(new SimpleGrantedAuthority(UserRole.USER.toAuthority()))
+			);
+			SecurityContextHolder.getContext().setAuthentication(authenticated);
+
+			// when
+			mockMvc.perform(get("/api/auth/me"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.userId").value(1L))
+					.andExpect(jsonPath("$.data.name").value(NAME))
+					.andExpect(jsonPath("$.data.role").value(UserRole.USER.toString()));
+
+			then(authService).should().getMyInfo(userId);
+		}
+
+		@Test
+		@DisplayName("가입된 사용자가 없는 경우 404와 USER_NOT_FOUND 반환한다.")
+		void me_userNotFound() throws Exception {
+			// given
+			Long userId = 1L;
+			Authentication authenticated = UsernamePasswordAuthenticationToken.authenticated(
+					userId,
+					null,
+					List.of(new SimpleGrantedAuthority(UserRole.USER.toAuthority()))
+			);
+			SecurityContextHolder.getContext().setAuthentication(authenticated);
+
+			willThrow(new BusinessException(USER_NOT_FOUND))
+					.given(authService)
+					.getMyInfo(userId);
+
+			// when & then
+			mockMvc.perform(get("/api/auth/me"))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(USER_NOT_FOUND.name()));
+
+			then(authService).should().getMyInfo(userId);
+		}
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationFailureHandlerTest.java
@@ -2,17 +2,11 @@ package com.keepgoing.keepgoing.auth.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
 class OAuth2AuthenticationFailureHandlerTest {
 
@@ -26,68 +20,18 @@ class OAuth2AuthenticationFailureHandlerTest {
 	}
 
 	@Test
-	@DisplayName("OAuth 접근 거부 시 프론트 엔드로 oauth_access_denied를 전달한다.")
-	void failure_accessDenied_redirectsWithError() throws Exception {
+	@DisplayName("OAuth 인증 실패 시 프론트 콜백 URI로 redirect한다.")
+	void failure_redirectsCallback() throws Exception {
 		// given
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
-		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
-				new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED),
-				"access denied"
-		);
+		AuthenticationExceptionStub exception = new AuthenticationExceptionStub("fail");
 
 		// when
 		handler.onAuthenticationFailure(request, response, exception);
 
 		// then
-		String redirectedUrl = response.getRedirectedUrl();
-		assertThat(redirectedUrl).isNotNull();
-
-		UriComponents uri = UriComponentsBuilder.fromUriString(redirectedUrl).build();
-		assertThat(uri.getScheme()).isEqualTo("http");
-		assertThat(uri.getHost()).isEqualTo("localhost");
-		assertThat(uri.getPort()).isEqualTo(5173);
-		assertThat(uri.getPath()).isEqualTo("/oauth/callback");
-		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_access_denied");
-	}
-
-	@Test
-	@DisplayName("필수 사용자 정보 누락시 프론트엔드로 oauth_invalid_user_info를 전달한다")
-	void failure_invalidRequest_redirectsWithError() throws Exception {
-		// given
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
-				new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST),
-				"invalid request"
-		);
-
-		// when
-		handler.onAuthenticationFailure(request, response, exception);
-
-		// then
-		UriComponents uri = UriComponentsBuilder
-				.fromUriString(Objects.requireNonNull(response.getRedirectedUrl()))
-				.build();
-		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_invalid_user_info");
-	}
-
-	@Test
-	@DisplayName("알 수 없는 인증 실패 시 프론트앤드로 oauth_login_failed를 전달한다")
-	void failure_unknown_redirectsWithDefaultError() throws Exception {
-		// given
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		AuthenticationExceptionStub exception = new AuthenticationExceptionStub("unknown");
-
-		// when
-		handler.onAuthenticationFailure(request, response, exception);
-
-		// then
-
-		UriComponents uri = UriComponentsBuilder.fromUriString(Objects.requireNonNull(response.getRedirectedUrl()))
-				.build();
-		assertThat(uri.getQueryParams().getFirst("error")).isEqualTo("oauth_login_failed");
+		assertThat(response.getRedirectedUrl()).isEqualTo(OAUTH_CALLBACK);
 	}
 
 	private static class AuthenticationExceptionStub

--- a/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.keepgoing.keepgoing.auth.OAuthTestFixtures.GoogleUserFixture;
+import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +18,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class OAuth2AuthenticationSuccessHandlerTest {
@@ -32,23 +30,26 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
 	OAuth2AuthenticationSuccessHandler handler;
 
+	@Mock
+	AuthCookieManager authCookieManager;
+
 	@BeforeEach
 	void setup() {
 		handler = new OAuth2AuthenticationSuccessHandler(
+				OAUTH_CALLBACK,
 				jwtProvider,
-				OAUTH_CALLBACK
+				authCookieManager
 		);
 	}
 
 	@Test
-	@DisplayName("인증 성공 시 access token, refresh token을 포함한 redirect를 수행한다.")
+	@DisplayName("인증 성공 시 인증 쿠키를 설정하고 콜백 URI로 redirect한다.")
 	void success_redirectsWithTokens() throws Exception {
 		// given
-		DefaultOAuth2User delegate = new DefaultOAuth2User(
-				List.of(new SimpleGrantedAuthority("ROLE_USER")),
-				Map.of("sub", "google-123", "email", "user@gmail.com"),
-				"sub"
-		);
+		DefaultOAuth2User delegate = GoogleUserFixture.builder()
+				.name(null)
+				.build()
+				.oauth2User();
 		CustomOAuth2User principal = new CustomOAuth2User(delegate, 1L, "ROLE_USER");
 		Authentication authentication = new UsernamePasswordAuthenticationToken(
 				principal,
@@ -67,19 +68,11 @@ class OAuth2AuthenticationSuccessHandlerTest {
 		handler.onAuthenticationSuccess(request, response, authentication);
 
 		// then
-		String redirectedUrl = response.getRedirectedUrl();
-		assertThat(redirectedUrl).isNotNull();
-
-		UriComponents uri = UriComponentsBuilder.fromUriString(redirectedUrl).build();
-		assertThat(uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + uri.getPath())
-				.isEqualTo(OAUTH_CALLBACK);
-
-		assertThat(uri.getQueryParams().getFirst("token"))
-				.isEqualTo("access-token");
-		assertThat(uri.getQueryParams().getFirst("refresh"))
-				.isEqualTo("refresh-token");
+		assertThat(response.getRedirectedUrl()).isEqualTo(OAUTH_CALLBACK);
 
 		then(jwtProvider).should().generateAccessToken(1L, List.of("ROLE_USER"));
 		then(jwtProvider).should().generateRefreshToken(1L);
+		then(authCookieManager).should().addAccessToken(response, "access-token");
+		then(authCookieManager).should().addRefreshToken(response, "refresh-token");
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/service/AuthServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.domain.UserPasswordCredential;
 import com.keepgoing.keepgoing.user.repository.UserPasswordCredentialRepository;
@@ -32,162 +33,196 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 class AuthServiceIntegrationTest {
 
-    @Autowired
-    UserRepository userRepository;
+	@Autowired
+	UserRepository userRepository;
 
-    @Autowired
-    UserPasswordCredentialRepository credentialRepository;
+	@Autowired
+	UserPasswordCredentialRepository credentialRepository;
 
-    @Autowired
-    PasswordEncoder passwordEncoder;
+	@Autowired
+	PasswordEncoder passwordEncoder;
 
-    @Autowired
-    AuthService authService;
+	@Autowired
+	AuthService authService;
+	@Autowired
+	private JwtProvider jwtProvider;
 
-    @Nested
-    @DisplayName("회원가입")
-    class Signup {
-        @Test
-        @DisplayName("회원가입 성공 시 User/PasswordCredential을 저장하고 SignupResult를 반환한다.")
-        void signup_success() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
+	@Nested
+	@DisplayName("회원가입")
+	class Signup {
+		@Test
+		@DisplayName("회원가입 성공 시 User/PasswordCredential을 저장하고 SignupResult를 반환한다.")
+		void signup_success() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            assertThat(userRepository.existsByEmail(command.email())).isTrue();
-            assertThat(result.id()).isNotNull();
-            assertThat(result.email()).isEqualTo(command.email());
-            assertThat(result.name()).isEqualTo(command.name());
-        }
+			// then
+			assertThat(userRepository.existsByEmail(command.email())).isTrue();
+			assertThat(result.id()).isNotNull();
+			assertThat(result.email()).isEqualTo(command.email());
+			assertThat(result.name()).isEqualTo(command.name());
+		}
 
-        @Test
-        @DisplayName("회원가입 성공 시 Credential이 User와 연관되어 저장된다.")
-        void signup_saves_credential_with_user_association() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
+		@Test
+		@DisplayName("회원가입 성공 시 Credential이 User와 연관되어 저장된다.")
+		void signup_saves_credential_with_user_association() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            UserPasswordCredential credential = credentialRepository.findById(result.id()).orElseThrow();
+			// then
+			UserPasswordCredential credential = credentialRepository.findById(result.id()).orElseThrow();
 
-            assertThat(credential.getUserId()).isEqualTo(result.id());
-            assertThat(credential.getUser().getId()).isEqualTo(result.id());
-            assertThat(credential.getLoginId()).isEqualTo(command.email());
-        }
+			assertThat(credential.getUserId()).isEqualTo(result.id());
+			assertThat(credential.getUser().getId()).isEqualTo(result.id());
+			assertThat(credential.getLoginId()).isEqualTo(command.email());
+		}
 
-        @Test
-        @DisplayName("비밀번호는 암호화되어 저장된다.")
-        void password_is_encrypted() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
-            String rawPassword = command.rawPassword();
+		@Test
+		@DisplayName("비밀번호는 암호화되어 저장된다.")
+		void password_is_encrypted() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
+			String rawPassword = command.rawPassword();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            UserPasswordCredential credential = credentialRepository.findById(result.id())
-                    .orElseThrow();
+			// then
+			UserPasswordCredential credential = credentialRepository.findById(result.id())
+					.orElseThrow();
 
-            assertThat(credential.getPasswordHash()).isNotEqualTo(rawPassword);
-            assertThat(passwordEncoder.matches(rawPassword, credential.getPasswordHash())).isTrue();
-        }
+			assertThat(credential.getPasswordHash()).isNotEqualTo(rawPassword);
+			assertThat(passwordEncoder.matches(rawPassword, credential.getPasswordHash())).isTrue();
+		}
 
-        @Test
-        @DisplayName("중복 이메일 가입 시 예외발생하고 아무것도 저장하지 않는다.")
-        void duplicate_email_throws_and_rolls_back() {
-            // given
-            SignupCommand firstCommand = AuthTestFixtures.validSignupCommand();
-            authService.signup(firstCommand);
+		@Test
+		@DisplayName("중복 이메일 가입 시 예외발생하고 아무것도 저장하지 않는다.")
+		void duplicate_email_throws_and_rolls_back() {
+			// given
+			SignupCommand firstCommand = AuthTestFixtures.validSignupCommand();
+			authService.signup(firstCommand);
 
-            long userCountBefore = userRepository.count();
+			long userCountBefore = userRepository.count();
 
-            // when & then
-            SignupCommand duplicate = SignupCommand.builder()
-                    .email(firstCommand.email())
-                    .name("다른이름")
-                    .rawPassword("testtEst8!")
-                    .build();
+			// when & then
+			SignupCommand duplicate = SignupCommand.builder()
+					.email(firstCommand.email())
+					.name("다른이름")
+					.rawPassword("testtEst8!")
+					.build();
 
-            assertThatThrownBy(() -> authService.signup(duplicate))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(ex -> {
-                        BusinessException bex = (BusinessException) ex;
-                        assertThat(bex.getErrorCode()).isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
-                    });
+			assertThatThrownBy(() -> authService.signup(duplicate))
+					.isInstanceOf(BusinessException.class)
+					.satisfies(ex -> {
+						BusinessException bex = (BusinessException) ex;
+						assertThat(bex.getErrorCode()).isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
+					});
 
-            assertThat(userRepository.count()).isEqualTo(userCountBefore);
-        }
-    }
+			assertThat(userRepository.count()).isEqualTo(userCountBefore);
+		}
+	}
 
-    @Nested
-    @DisplayName("로그인")
-    class Login {
+	@Nested
+	@DisplayName("로그인")
+	class Login {
 
-        private void signupTestUser() {
-            authService.signup(AuthTestFixtures.validSignupCommand());
-        }
+		@Test
+		@DisplayName("성공 시 accessToken, refreshToken, userId를 반환한다.")
+		void login_success() {
+			// given
+			signupTestUser();
+			LoginCommand command = AuthTestFixtures.validLoginCommand();
 
-        @Test
-        @DisplayName("성공 시 accessToken, refreshToken, userId를 반환한다.")
-        void login_success() {
-            // given
-            signupTestUser();
-            LoginCommand command = AuthTestFixtures.validLoginCommand();
+			// when
+			LoginResult result = authService.login(command);
 
-            // when
-            LoginResult result = authService.login(command);
+			// then
+			assertThat(result.accessToken()).isNotBlank();
+			assertThat(result.refreshToken()).isNotBlank();
+			assertThat(result.userId()).isNotNull();
+		}
 
-            // then
-            assertThat(result.accessToken()).isNotBlank();
-            assertThat(result.refreshToken()).isNotBlank();
-            assertThat(result.userId()).isNotNull();
-        }
+		@Test
+		@DisplayName("존재하지 않는 이메일로 로그인 시 BadCredentialsException이 발생한다.")
+		void login_with_nonexistent_email_throws() {
+			// given
+			LoginCommand command = AuthTestFixtures.loginCommandWithEmail("nonExistent@examle.com");
 
-        @Test
-        @DisplayName("존재하지 않는 이메일로 로그인 시 BadCredentialsException이 발생한다.")
-        void login_with_nonexistent_email_throws() {
-            // given
-            LoginCommand command = AuthTestFixtures.loginCommandWithEmail("nonExistent@examle.com");
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(BadCredentialsException.class);
+		}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(BadCredentialsException.class);
-        }
+		@Test
+		@DisplayName("잘못된 비밀번호로 로그인 시 BadCredentialsException이 발생한다.")
+		void login_with_wrong_password_throws() {
+			// given
+			signupTestUser();
+			LoginCommand command = AuthTestFixtures.loginCommandWithPassword("WrongP@ss1!");
 
-        @Test
-        @DisplayName("잘못된 비밀번호로 로그인 시 BadCredentialsException이 발생한다.")
-        void login_with_wrong_password_throws() {
-            // given
-            signupTestUser();
-            LoginCommand command = AuthTestFixtures.loginCommandWithPassword("WrongP@ss1!");
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(BadCredentialsException.class);
+		}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(BadCredentialsException.class);
-        }
+		@Test
+		@DisplayName("정지된 계정으로 로그인 시 LockedException이 발생한다.")
+		void login_with_suspended_account_throws() {
+			// given
+			signupTestUser();
 
-        @Test
-        @DisplayName("정지된 계정으로 로그인 시 LockedException이 발생한다.")
-        void login_with_suspended_account_throws() {
-            // given
-            signupTestUser();
+			// 계정 정지 처리
+			User user = userRepository.findByEmail("user@example.com").orElseThrow();
+			user.suspend();
+			userRepository.saveAndFlush(user);  // 즉시 DB 반영
 
-            // 계정 정지 처리
-            User user = userRepository.findByEmail("user@example.com").orElseThrow();
-            user.suspend();
-            userRepository.saveAndFlush(user);  // 즉시 DB 반영
+			LoginCommand command = AuthTestFixtures.validLoginCommand();
 
-            LoginCommand command = AuthTestFixtures.validLoginCommand();
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(LockedException.class);
+		}
+	}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(LockedException.class);
-        }
-    }
+	@Nested
+	@DisplayName("Refresh")
+	class refresh {
+
+		@Test
+		@DisplayName("유효한 refresh token이면 새 access token을 반환한다.")
+		void refresh_success() {
+			// given
+			Long userId = signupTestUser();
+			String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+			// when
+			String accessToken = authService.refresh(refreshToken);
+
+			// then
+			assertThat(accessToken).isNotBlank();
+		}
+
+		@Test
+		@DisplayName("유요한 refresh token이지만 사용자가 없으면 USER_NOT_FOUND 예외가 발생한다.")
+		void refresh_withNonexistentUserThrows() throws Exception {
+			// given
+			String refreshToken = jwtProvider.generateRefreshToken(Long.MAX_VALUE);
+
+			// when
+			assertThatThrownBy(() -> authService.refresh(refreshToken))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	private Long signupTestUser() {
+		SignupResult result = authService.signup(AuthTestFixtures.validSignupCommand());
+		return result.id();
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManagerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManagerTest.java
@@ -1,0 +1,109 @@
+package com.keepgoing.keepgoing.global.security.cookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AuthCookieManagerTest {
+
+	private AuthCookieManager authCookieManager;
+	private MockHttpServletResponse response;
+
+	@BeforeEach
+	void setUp() {
+		TokenCookieProperties prop = new TokenCookieProperties(
+				false,
+				"Lax",
+				new CookieSpec("access_token", "/api", 3600L),
+				new CookieSpec("refresh_token", "/api/auth", 604800L)
+		);
+		authCookieManager = new AuthCookieManager(prop);
+		response = new MockHttpServletResponse();
+	}
+
+	@Test
+	@DisplayName("access token 쿠키를 추가한다.")
+	void addAccessToken() {
+		// given
+		String token = "access-token";
+
+		// when
+		authCookieManager.addAccessToken(response, token);
+		List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+		// then
+		assertThat(cookies).hasSize(1);
+		assertThat(cookies.getFirst()).contains("access_token=access-token");
+		assertThat(cookies.getFirst()).contains("Path=/api");
+		assertThat(cookies.getFirst()).contains("Max-Age=3600");
+		assertThat(cookies.getFirst()).contains("HttpOnly");
+		assertThat(cookies.getFirst()).contains("SameSite=Lax");
+	}
+
+	@Test
+	@DisplayName("refresh token 쿠키를 추가한다.")
+	void addRefreshToken() {
+		// given
+		String token = "refresh-token";
+
+		// when
+		authCookieManager.addRefreshToken(response, token);
+		List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+		// then
+		assertThat(cookies).hasSize(1);
+		assertThat(cookies.getFirst()).contains("refresh_token=refresh-token");
+		assertThat(cookies.getFirst()).contains("Path=/api/auth");
+		assertThat(cookies.getFirst()).contains("Max-Age=604800");
+		assertThat(cookies.getFirst()).contains("HttpOnly");
+		assertThat(cookies.getFirst()).contains("SameSite=Lax");
+	}
+
+	@Test
+	@DisplayName("access token 쿠키를 만료시킨다")
+	void clearAccessToken() {
+		// when
+		authCookieManager.clearAccessToken(response);
+		List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+		// then
+		assertThat(cookies.getFirst()).contains("access_token=");
+		assertThat(cookies.getFirst()).contains("Path=/api");
+		assertThat(cookies.getFirst()).contains("Max-Age=0");
+		assertThat(cookies.getFirst()).contains("HttpOnly");
+	}
+
+	@Test
+	@DisplayName("refresh token 쿠키를 만료시킨다")
+	void clearRefreshToken() {
+		// when
+		authCookieManager.clearRefreshToken(response);
+		List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+		// then
+		assertThat(cookies.getFirst()).contains("refresh_token=");
+		assertThat(cookies.getFirst()).contains("Path=/api/auth");
+		assertThat(cookies.getFirst()).contains("Max-Age=0");
+		assertThat(cookies.getFirst()).contains("HttpOnly");
+	}
+
+	@Test
+	@DisplayName("모든 토큰 쿠키를 만료시킨다")
+	void clearAllTokens() {
+		// when
+		authCookieManager.clearAllTokens(response);
+		List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+		// then
+		assertThat(cookies.get(0)).contains("access_token=");
+		assertThat(cookies.get(0)).contains("Max-Age=0");
+		assertThat(cookies.get(1)).contains("refresh_token=");
+		assertThat(cookies.get(1)).contains("Max-Age=0");
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,186 @@
+package com.keepgoing.keepgoing.global.security.jwt;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties;
+import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
+import jakarta.servlet.http.Cookie;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+	private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String ACCESS_TOKEN_VALUE = "access-token";
+	private static final String ROLE_USER = "ROLE_USER";
+	private static final String COOKIE_TOKEN_VALUE = "cookie-token";
+	private static final String HEADER_TOKEN = "header-token";
+	private static final String AUTHORITY = "authority";
+
+	@Mock
+	JwtProvider jwtProvider;
+
+	JwtAuthenticationFilter jwtAuthenticationFilter;
+	MockHttpServletRequest request;
+	MockHttpServletResponse response;
+	MockFilterChain filterChain;
+
+	@BeforeEach
+	void setUp() {
+		TokenCookieProperties tokenCookieProperties = new TokenCookieProperties(
+				false,
+				"Lax",
+				new CookieSpec(ACCESS_TOKEN_COOKIE_NAME, "/api", 3600L),
+				new CookieSpec(REFRESH_TOKEN_COOKIE_NAME, "/api/auth", 604800L)
+		);
+		jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider, tokenCookieProperties);
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		filterChain = new MockFilterChain();
+	}
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("Authorization Bearer 헤더가 있으면 인증한다.")
+	void authenticate_withBearerHeader() throws Exception {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN_VALUE);
+
+		given(jwtProvider.getUserIdFromToken(ACCESS_TOKEN_VALUE)).willReturn(1L);
+		given(jwtProvider.getRolesFromToken(ACCESS_TOKEN_VALUE)).willReturn(List.of(ROLE_USER));
+
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isEqualTo(1L);
+		assertThat(authentication.getAuthorities())
+				.extracting(AUTHORITY)
+				.containsExactly(ROLE_USER);
+
+		then(jwtProvider).should().getUserIdFromToken(ACCESS_TOKEN_VALUE);
+		then(jwtProvider).should().getRolesFromToken(ACCESS_TOKEN_VALUE);
+	}
+
+	@Test
+	@DisplayName("Bearer 헤더가 없으면 access_token 쿠키로 인증한다")
+	void authentication_withAccessTokenCookie() throws Exception {
+		// given
+		request.setCookies(new Cookie(ACCESS_TOKEN_COOKIE_NAME, COOKIE_TOKEN_VALUE));
+
+		given(jwtProvider.getUserIdFromToken(COOKIE_TOKEN_VALUE)).willReturn(2L);
+		given(jwtProvider.getRolesFromToken(COOKIE_TOKEN_VALUE)).willReturn(List.of(ROLE_USER));
+
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isEqualTo(2L);
+		assertThat(authentication.getAuthorities())
+				.extracting(AUTHORITY)
+				.containsExactly(ROLE_USER);
+	}
+
+	@Test
+	@DisplayName("헤더와 쿠기가 함께 있으면 헤더를 우선한다")
+	void authenticate_headerTakesPrecedenceOverCookie() throws Exception {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + HEADER_TOKEN);
+		request.setCookies(new Cookie(ACCESS_TOKEN_COOKIE_NAME, COOKIE_TOKEN_VALUE));
+
+		given(jwtProvider.getUserIdFromToken(HEADER_TOKEN)).willReturn(3L);
+		given(jwtProvider.getRolesFromToken(HEADER_TOKEN)).willReturn(List.of(ROLE_USER));
+
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isEqualTo(3L);
+		assertThat(authentication.getAuthorities())
+				.extracting(AUTHORITY)
+				.contains(ROLE_USER);
+
+		then(jwtProvider).should().getUserIdFromToken(HEADER_TOKEN);
+		then(jwtProvider).should().getRolesFromToken(HEADER_TOKEN);
+		then(jwtProvider).should(never()).getUserIdFromToken(COOKIE_TOKEN_VALUE);
+		then(jwtProvider).should(never()).getRolesFromToken(COOKIE_TOKEN_VALUE);
+	}
+
+	@Test
+	@DisplayName("토큰이 없으면 인증하지 않는다")
+	void doNotAuthenticate_whenNoTokenExists() throws Exception {
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+
+	@Test
+	@DisplayName("토큰 검증 중 예외가 발생하면 인증하지 않고 다음 필터로 진행한다")
+	void doNotAuthenticate_whenTokenValidationFails() throws Exception {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + "invalid-token");
+
+		given(jwtProvider.getUserIdFromToken("invalid-token"))
+				.willThrow(new RuntimeException("invalid token"));
+
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		assertThat(filterChain.getResponse()).isSameAs(response);
+		assertThat(filterChain.getRequest()).isSameAs(request);
+	}
+
+	@Test
+	@DisplayName("Authorization 헤더가 Bearer 타입이 아니면 헤더를 무시하고 쿠키로 인증한다")
+	void authenticate_withCookie_whenHeaderIsNotBearerType() throws Exception {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + ACCESS_TOKEN_VALUE);
+		request.setCookies(new Cookie(ACCESS_TOKEN_COOKIE_NAME, COOKIE_TOKEN_VALUE));
+
+		given(jwtProvider.getUserIdFromToken(COOKIE_TOKEN_VALUE)).willReturn(4L);
+		given(jwtProvider.getRolesFromToken(COOKIE_TOKEN_VALUE)).willReturn(List.of(ROLE_USER));
+
+		// when
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		// then
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isEqualTo(4L);
+
+		then(jwtProvider).should(never()).getUserIdFromToken("Basic " + ACCESS_TOKEN_VALUE);
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/post/controller/PostControllerTest.java
@@ -1,15 +1,36 @@
 package com.keepgoing.keepgoing.post.controller;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keepgoing.keepgoing.global.api.exception.GlobalExceptionHandler;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.global.security.cookie.CookieConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.post.controller.dto.PostCreateRequest;
 import com.keepgoing.keepgoing.post.controller.dto.PostUpdateRequest;
 import com.keepgoing.keepgoing.post.domain.PostVisibility;
 import com.keepgoing.keepgoing.post.service.PostService;
-import com.keepgoing.keepgoing.post.service.dto.*;
+import com.keepgoing.keepgoing.post.service.dto.PostCreateCommand;
+import com.keepgoing.keepgoing.post.service.dto.PostDetailResult;
+import com.keepgoing.keepgoing.post.service.dto.PostSearchQuery;
+import com.keepgoing.keepgoing.post.service.dto.PostSummaryResult;
+import com.keepgoing.keepgoing.post.service.dto.PostUpdateCommand;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +39,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,19 +51,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(PostController.class)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, CookieConfig.class})
 public class PostControllerTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,3 +36,16 @@ cors:
 
 oauth:
   redirect-uri: http://localhost:5173/oauth/callback
+
+auth:
+  cookie:
+    secure: false
+    same-site: Lax
+    access-token:
+      name: access_token
+      path: /api
+      max-age: 3600
+    refresh-token:
+      name: refresh_token
+      path: /api/auth
+      max-age: 604800


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
- #44

### ✨ 반영 브랜치
feat/44 -> develop

### 📝 변경 사항
- [x] 로그인 응답의 Access/Refresh Token 전달 방식을 HttpOnly 쿠키 기반으로 전환했습니다.
- [x] Google OAuth 성공 시 query parameter 전달을 제거하고 인증 쿠키를 발급하도록 변경했습니다.
- [x] OAuth 실패 시 프론트 콜백 URI로 고정 redirect 하도록 단순화했습니다.
- [x] JWT 인증 필터가 access_token 쿠키를 읽어 인증할 수 있도록 확장했습니다.
- [x] 현재 로그인 사용자를 확인할 수 있도록 `/api/auth/me` API를 추가했습니다.
- [x] 쿠키 설정용 properties 및 cookie manager를 추가하고 관련 테스트를 보강했습니다.
- [x] OpenAPI 문서를 현재 구현 기준으로 정리했습니다.

### ➕ 추가 메모
- `post-api.http`의 Bearer 기반 수동 테스트 흐름은 요청에 따라 유지했습니다.
- 비브라우저 클라이언트/수동 테스트를 위해 Bearer 헤더 기반 접근은 필터에서 fallback으로 유지했습니다.

###  추가 변경 사항
- 프론트 연동 과정에서 Google 로그인 사용자가 `OAuth2User`가 아닌 `OidcUser` 경로로 처리되는점을 확인했습니다.
- 이에 따라 `CustomOidcUser`, `CustomOidcUserService`를 추가하여 Google 로그인 principal 처리를 OIDC 기반으로 보완했습니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- `./gradlew test`
- 결과: BUILD SUCCESSFUL