### PR TITLE
[Auth] #46 Refresh 토큰 재발급 엔드포인트 추가

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -145,6 +145,20 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: 로그아웃
+      operationId: logout
+      security: []
+      responses:
+        '200':
+          description: 로그아웃 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
   # ========== User Endpoints ==========
   /users/me:
     get:

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -106,6 +107,39 @@ public interface AuthApiDocs {
     ResponseEntity<ApiResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse servletResponse
+    );
+
+    @Operation(summary = "Access Token 재발급")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "재발급 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "리프레시 토큰이 없거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "RefreshTokenInvalid",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "AUTH_REFRESH_TOKEN_INVALID",
+                                                "message": "유효하지 않은 리프레시 토큰입니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @PostMapping("/refresh")
+    ResponseEntity<ApiResponse<Void>> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
     );
 
     @Operation(summary = "내 정보 조회")

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -142,6 +142,18 @@ public interface AuthApiDocs {
             HttpServletResponse response
     );
 
+    @Operation(summary = "로그아웃")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공"
+            )
+    })
+    @PostMapping("/logout")
+    ResponseEntity<ApiResponse<Void>> logout(
+            HttpServletResponse response
+    );
+
     @Operation(summary = "내 정보 조회")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -93,4 +93,11 @@ public class AuthController implements AuthApiDocs {
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+			HttpServletResponse response
+	) {
+		authCookieManager.clearAllTokens(response);
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -13,7 +13,10 @@ import com.keepgoing.keepgoing.auth.service.dto.MyInfoResult;
 import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
+import com.keepgoing.keepgoing.global.common.error.BusinessException;
+import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.global.security.cookie.AuthCookieManager;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -75,4 +78,19 @@ public class AuthController implements AuthApiDocs {
 		return ResponseEntity.status(HttpStatus.OK)
 				.body(ApiResponse.success(body));
 	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponse<Void>> refresh(
+			HttpServletRequest request,
+			HttpServletResponse response
+	) {
+		// TODO : 에러 처리 아키텍처 수정 검토 필요
+		String refreshToken = authCookieManager.extractRefreshToken(request)
+				.orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+		String accessToken = authService.refresh(refreshToken);
+		authCookieManager.addAccessToken(response, accessToken);
+
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
 }

--- a/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/service/AuthService.java
@@ -82,4 +82,13 @@ public class AuthService {
 
 		return new MyInfoResult(userId, user.getEmail(), user.getName(), user.getRole());
 	}
+
+	@Transactional(readOnly = true)
+	public String refresh(String refreshToken) {
+		Long userId = jwtProvider.validateRefreshTokenAndGetUserId(refreshToken);
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		return jwtProvider.generateAccessToken(userId, List.of(user.getRole().toAuthority()));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 						.requestMatchers(
 								AUTH_API_PREFIX + "/signup",
 								AUTH_API_PREFIX + "/login",
-								AUTH_API_PREFIX + "/refresh"
+								AUTH_API_PREFIX + "/refresh",
+								AUTH_API_PREFIX + "/logout"
 						).permitAll()
 						// TODO: 포스트 API는 일단 모두 허용 (개발용)
 						.requestMatchers(

--- a/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/security/cookie/AuthCookieManager.java
@@ -1,38 +1,58 @@
 package com.keepgoing.keepgoing.global.security.cookie;
 
 import com.keepgoing.keepgoing.global.security.cookie.TokenCookieProperties.CookieSpec;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
 public class AuthCookieManager {
 
-	private final TokenCookieProperties tokenCookieProperties;
+	private final TokenCookieProperties properties;
 
 	public void addAccessToken(HttpServletResponse response, String token) {
-		addCookie(response, tokenCookieProperties.accessToken(), token);
+		addCookie(response, properties.accessToken(), token);
 	}
 
 	public void addRefreshToken(HttpServletResponse response, String token) {
-		addCookie(response, tokenCookieProperties.refreshToken(), token);
+		addCookie(response, properties.refreshToken(), token);
 	}
 
 	public void clearAccessToken(HttpServletResponse response) {
-		expireCookie(response, tokenCookieProperties.accessToken());
+		expireCookie(response, properties.accessToken());
 	}
 
 	public void clearRefreshToken(HttpServletResponse response) {
-		expireCookie(response, tokenCookieProperties.refreshToken());
+		expireCookie(response, properties.refreshToken());
 	}
 
 	public void clearAllTokens(HttpServletResponse response) {
 		clearAccessToken(response);
 		clearRefreshToken(response);
 	}
+
+	public Optional<String> extractRefreshToken(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return Optional.empty();
+		}
+
+		for (Cookie cookie : cookies) {
+			if (cookie.getName().equals(properties.refreshToken().name())
+					&& StringUtils.hasText(cookie.getValue())) {
+				return Optional.of(cookie.getValue());
+			}
+		}
+		return Optional.empty();
+	}
+
 
 	private void addCookie(
 			HttpServletResponse response,
@@ -41,8 +61,8 @@ public class AuthCookieManager {
 	) {
 		ResponseCookie cookie = ResponseCookie.from(spec.name(), value)
 				.httpOnly(true)
-				.secure(tokenCookieProperties.secure())
-				.sameSite(tokenCookieProperties.sameSite())
+				.secure(properties.secure())
+				.sameSite(properties.sameSite())
 				.path(spec.path())
 				.maxAge(spec.maxAge())
 				.build();
@@ -56,8 +76,8 @@ public class AuthCookieManager {
 	) {
 		ResponseCookie cookie = ResponseCookie.from(spec.name(), "")
 				.httpOnly(true)
-				.secure(tokenCookieProperties.secure())
-				.sameSite(tokenCookieProperties.sameSite())
+				.secure(properties.secure())
+				.sameSite(properties.sameSite())
 				.path(spec.path())
 				.maxAge(0)
 				.build();

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -362,4 +362,21 @@ class AuthControllerTest {
 			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
 		}
 	}
+
+	@Nested
+	@DisplayName("POST /api/auth/logout")
+	class Logout {
+
+		@Test
+		@DisplayName("성공 시 200을 반환하고 토큰 쿠키를 만료시킨다.")
+		void logout_success() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/auth/logout"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			then(authService).shouldHaveNoInteractions();
+			then(authCookieManager).should().clearAllTokens(any(HttpServletResponse.class));
+		}
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static com.keepgoing.keepgoing.auth.AuthTestFixtures.signupRequestWithEma
 import static com.keepgoing.keepgoing.auth.AuthTestFixtures.toJson;
 import static com.keepgoing.keepgoing.auth.AuthTestFixtures.validLoginRequest;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.AUTH_INVALID_CREDENTIALS;
+import static com.keepgoing.keepgoing.global.common.error.ErrorCode.AUTH_REFRESH_TOKEN_INVALID;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_ALREADY_EXISTS;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.USER_NOT_FOUND;
 import static com.keepgoing.keepgoing.global.common.error.ErrorCode.VALIDATION_FAILED;
@@ -37,6 +38,7 @@ import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,6 +70,9 @@ class AuthControllerTest {
 
 	private static final String EMAIL = "test@test.com";
 	public static final String NAME = "홍길동";
+	public static final String ACCESS_TOKEN = "access-token";
+	public static final String REFRESH_TOKEN = "refresh-token";
+	public static final String NEW_ACCESS_TOKEN = "new-access-token";
 
 	@Autowired
 	MockMvc mockMvc;
@@ -179,8 +184,8 @@ class AuthControllerTest {
 			// given
 			LoginRequest request = validLoginRequest();
 			LoginResult result = new LoginResult(
-					"access-token",
-					"refresh-token",
+					ACCESS_TOKEN,
+					REFRESH_TOKEN,
 					1L,
 					EMAIL
 			);
@@ -199,8 +204,8 @@ class AuthControllerTest {
 					.andExpect(jsonPath("$.data.userId").value(1L))
 					.andExpect(jsonPath("$.data.email").value(EMAIL));
 
-			then(authCookieManager).should().addAccessToken(any(HttpServletResponse.class), eq("access-token"));
-			then(authCookieManager).should().addRefreshToken(any(HttpServletResponse.class), eq("refresh-token"));
+			then(authCookieManager).should().addAccessToken(any(HttpServletResponse.class), eq(ACCESS_TOKEN));
+			then(authCookieManager).should().addRefreshToken(any(HttpServletResponse.class), eq(REFRESH_TOKEN));
 		}
 
 		@Test
@@ -296,6 +301,65 @@ class AuthControllerTest {
 					.andExpect(jsonPath("$.error.code").value(USER_NOT_FOUND.name()));
 
 			then(authService).should().getMyInfo(userId);
+		}
+	}
+
+	@Nested
+	@DisplayName("POST /api/auth/refresh")
+	class Refresh {
+
+		@Test
+		@DisplayName("성공 시 200 + access token 재발급")
+		void refresh_success() throws Exception {
+			// given
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.of(REFRESH_TOKEN));
+			given(authService.refresh(REFRESH_TOKEN))
+					.willReturn(NEW_ACCESS_TOKEN);
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			then(authService).should().refresh(REFRESH_TOKEN);
+			then(authCookieManager).should()
+					.addAccessToken(any(HttpServletResponse.class), eq(NEW_ACCESS_TOKEN));
+		}
+
+		@Test
+		@DisplayName("refresh 쿠기가 없으면 401을 반환한다.")
+		void refresh_token_missing() throws Exception {
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.empty());
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(AUTH_REFRESH_TOKEN_INVALID.name()));
+
+			then(authService).shouldHaveNoInteractions();
+			then(authCookieManager).should(never())
+					.addAccessToken(any(HttpServletResponse.class), anyString());
+		}
+
+		@Test
+		@DisplayName("유효하지 않은 refresh token이면 401을 반환한다.")
+		void invalid_refresh_token() throws Exception {
+			// given
+			given(authCookieManager.extractRefreshToken(any()))
+					.willReturn(Optional.of("bad-refresh-token"));
+			willThrow(new BusinessException(AUTH_REFRESH_TOKEN_INVALID))
+					.given(authService).refresh("bad-refresh-token");
+
+			// when & then
+			mockMvc.perform(post("/api/auth/refresh"))
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(AUTH_REFRESH_TOKEN_INVALID.name()));
+
+			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/service/AuthServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import com.keepgoing.keepgoing.auth.service.dto.SignupCommand;
 import com.keepgoing.keepgoing.auth.service.dto.SignupResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.domain.UserPasswordCredential;
 import com.keepgoing.keepgoing.user.repository.UserPasswordCredentialRepository;
@@ -32,162 +33,196 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 class AuthServiceIntegrationTest {
 
-    @Autowired
-    UserRepository userRepository;
+	@Autowired
+	UserRepository userRepository;
 
-    @Autowired
-    UserPasswordCredentialRepository credentialRepository;
+	@Autowired
+	UserPasswordCredentialRepository credentialRepository;
 
-    @Autowired
-    PasswordEncoder passwordEncoder;
+	@Autowired
+	PasswordEncoder passwordEncoder;
 
-    @Autowired
-    AuthService authService;
+	@Autowired
+	AuthService authService;
+	@Autowired
+	private JwtProvider jwtProvider;
 
-    @Nested
-    @DisplayName("회원가입")
-    class Signup {
-        @Test
-        @DisplayName("회원가입 성공 시 User/PasswordCredential을 저장하고 SignupResult를 반환한다.")
-        void signup_success() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
+	@Nested
+	@DisplayName("회원가입")
+	class Signup {
+		@Test
+		@DisplayName("회원가입 성공 시 User/PasswordCredential을 저장하고 SignupResult를 반환한다.")
+		void signup_success() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            assertThat(userRepository.existsByEmail(command.email())).isTrue();
-            assertThat(result.id()).isNotNull();
-            assertThat(result.email()).isEqualTo(command.email());
-            assertThat(result.name()).isEqualTo(command.name());
-        }
+			// then
+			assertThat(userRepository.existsByEmail(command.email())).isTrue();
+			assertThat(result.id()).isNotNull();
+			assertThat(result.email()).isEqualTo(command.email());
+			assertThat(result.name()).isEqualTo(command.name());
+		}
 
-        @Test
-        @DisplayName("회원가입 성공 시 Credential이 User와 연관되어 저장된다.")
-        void signup_saves_credential_with_user_association() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
+		@Test
+		@DisplayName("회원가입 성공 시 Credential이 User와 연관되어 저장된다.")
+		void signup_saves_credential_with_user_association() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            UserPasswordCredential credential = credentialRepository.findById(result.id()).orElseThrow();
+			// then
+			UserPasswordCredential credential = credentialRepository.findById(result.id()).orElseThrow();
 
-            assertThat(credential.getUserId()).isEqualTo(result.id());
-            assertThat(credential.getUser().getId()).isEqualTo(result.id());
-            assertThat(credential.getLoginId()).isEqualTo(command.email());
-        }
+			assertThat(credential.getUserId()).isEqualTo(result.id());
+			assertThat(credential.getUser().getId()).isEqualTo(result.id());
+			assertThat(credential.getLoginId()).isEqualTo(command.email());
+		}
 
-        @Test
-        @DisplayName("비밀번호는 암호화되어 저장된다.")
-        void password_is_encrypted() {
-            // given
-            SignupCommand command = AuthTestFixtures.validSignupCommand();
-            String rawPassword = command.rawPassword();
+		@Test
+		@DisplayName("비밀번호는 암호화되어 저장된다.")
+		void password_is_encrypted() {
+			// given
+			SignupCommand command = AuthTestFixtures.validSignupCommand();
+			String rawPassword = command.rawPassword();
 
-            // when
-            SignupResult result = authService.signup(command);
+			// when
+			SignupResult result = authService.signup(command);
 
-            // then
-            UserPasswordCredential credential = credentialRepository.findById(result.id())
-                    .orElseThrow();
+			// then
+			UserPasswordCredential credential = credentialRepository.findById(result.id())
+					.orElseThrow();
 
-            assertThat(credential.getPasswordHash()).isNotEqualTo(rawPassword);
-            assertThat(passwordEncoder.matches(rawPassword, credential.getPasswordHash())).isTrue();
-        }
+			assertThat(credential.getPasswordHash()).isNotEqualTo(rawPassword);
+			assertThat(passwordEncoder.matches(rawPassword, credential.getPasswordHash())).isTrue();
+		}
 
-        @Test
-        @DisplayName("중복 이메일 가입 시 예외발생하고 아무것도 저장하지 않는다.")
-        void duplicate_email_throws_and_rolls_back() {
-            // given
-            SignupCommand firstCommand = AuthTestFixtures.validSignupCommand();
-            authService.signup(firstCommand);
+		@Test
+		@DisplayName("중복 이메일 가입 시 예외발생하고 아무것도 저장하지 않는다.")
+		void duplicate_email_throws_and_rolls_back() {
+			// given
+			SignupCommand firstCommand = AuthTestFixtures.validSignupCommand();
+			authService.signup(firstCommand);
 
-            long userCountBefore = userRepository.count();
+			long userCountBefore = userRepository.count();
 
-            // when & then
-            SignupCommand duplicate = SignupCommand.builder()
-                    .email(firstCommand.email())
-                    .name("다른이름")
-                    .rawPassword("testtEst8!")
-                    .build();
+			// when & then
+			SignupCommand duplicate = SignupCommand.builder()
+					.email(firstCommand.email())
+					.name("다른이름")
+					.rawPassword("testtEst8!")
+					.build();
 
-            assertThatThrownBy(() -> authService.signup(duplicate))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(ex -> {
-                        BusinessException bex = (BusinessException) ex;
-                        assertThat(bex.getErrorCode()).isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
-                    });
+			assertThatThrownBy(() -> authService.signup(duplicate))
+					.isInstanceOf(BusinessException.class)
+					.satisfies(ex -> {
+						BusinessException bex = (BusinessException) ex;
+						assertThat(bex.getErrorCode()).isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
+					});
 
-            assertThat(userRepository.count()).isEqualTo(userCountBefore);
-        }
-    }
+			assertThat(userRepository.count()).isEqualTo(userCountBefore);
+		}
+	}
 
-    @Nested
-    @DisplayName("로그인")
-    class Login {
+	@Nested
+	@DisplayName("로그인")
+	class Login {
 
-        private void signupTestUser() {
-            authService.signup(AuthTestFixtures.validSignupCommand());
-        }
+		@Test
+		@DisplayName("성공 시 accessToken, refreshToken, userId를 반환한다.")
+		void login_success() {
+			// given
+			signupTestUser();
+			LoginCommand command = AuthTestFixtures.validLoginCommand();
 
-        @Test
-        @DisplayName("성공 시 accessToken, refreshToken, userId를 반환한다.")
-        void login_success() {
-            // given
-            signupTestUser();
-            LoginCommand command = AuthTestFixtures.validLoginCommand();
+			// when
+			LoginResult result = authService.login(command);
 
-            // when
-            LoginResult result = authService.login(command);
+			// then
+			assertThat(result.accessToken()).isNotBlank();
+			assertThat(result.refreshToken()).isNotBlank();
+			assertThat(result.userId()).isNotNull();
+		}
 
-            // then
-            assertThat(result.accessToken()).isNotBlank();
-            assertThat(result.refreshToken()).isNotBlank();
-            assertThat(result.userId()).isNotNull();
-        }
+		@Test
+		@DisplayName("존재하지 않는 이메일로 로그인 시 BadCredentialsException이 발생한다.")
+		void login_with_nonexistent_email_throws() {
+			// given
+			LoginCommand command = AuthTestFixtures.loginCommandWithEmail("nonExistent@examle.com");
 
-        @Test
-        @DisplayName("존재하지 않는 이메일로 로그인 시 BadCredentialsException이 발생한다.")
-        void login_with_nonexistent_email_throws() {
-            // given
-            LoginCommand command = AuthTestFixtures.loginCommandWithEmail("nonExistent@examle.com");
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(BadCredentialsException.class);
+		}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(BadCredentialsException.class);
-        }
+		@Test
+		@DisplayName("잘못된 비밀번호로 로그인 시 BadCredentialsException이 발생한다.")
+		void login_with_wrong_password_throws() {
+			// given
+			signupTestUser();
+			LoginCommand command = AuthTestFixtures.loginCommandWithPassword("WrongP@ss1!");
 
-        @Test
-        @DisplayName("잘못된 비밀번호로 로그인 시 BadCredentialsException이 발생한다.")
-        void login_with_wrong_password_throws() {
-            // given
-            signupTestUser();
-            LoginCommand command = AuthTestFixtures.loginCommandWithPassword("WrongP@ss1!");
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(BadCredentialsException.class);
+		}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(BadCredentialsException.class);
-        }
+		@Test
+		@DisplayName("정지된 계정으로 로그인 시 LockedException이 발생한다.")
+		void login_with_suspended_account_throws() {
+			// given
+			signupTestUser();
 
-        @Test
-        @DisplayName("정지된 계정으로 로그인 시 LockedException이 발생한다.")
-        void login_with_suspended_account_throws() {
-            // given
-            signupTestUser();
+			// 계정 정지 처리
+			User user = userRepository.findByEmail("user@example.com").orElseThrow();
+			user.suspend();
+			userRepository.saveAndFlush(user);  // 즉시 DB 반영
 
-            // 계정 정지 처리
-            User user = userRepository.findByEmail("user@example.com").orElseThrow();
-            user.suspend();
-            userRepository.saveAndFlush(user);  // 즉시 DB 반영
+			LoginCommand command = AuthTestFixtures.validLoginCommand();
 
-            LoginCommand command = AuthTestFixtures.validLoginCommand();
+			// when & then
+			assertThatThrownBy(() -> authService.login(command))
+					.isInstanceOf(LockedException.class);
+		}
+	}
 
-            // when & then
-            assertThatThrownBy(() -> authService.login(command))
-                    .isInstanceOf(LockedException.class);
-        }
-    }
+	@Nested
+	@DisplayName("Refresh")
+	class refresh {
+
+		@Test
+		@DisplayName("유효한 refresh token이면 새 access token을 반환한다.")
+		void refresh_success() {
+			// given
+			Long userId = signupTestUser();
+			String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+			// when
+			String accessToken = authService.refresh(refreshToken);
+
+			// then
+			assertThat(accessToken).isNotBlank();
+		}
+
+		@Test
+		@DisplayName("유요한 refresh token이지만 사용자가 없으면 USER_NOT_FOUND 예외가 발생한다.")
+		void refresh_withNonexistentUserThrows() throws Exception {
+			// given
+			String refreshToken = jwtProvider.generateRefreshToken(Long.MAX_VALUE);
+
+			// when
+			assertThatThrownBy(() -> authService.refresh(refreshToken))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	private Long signupTestUser() {
+		SignupResult result = authService.signup(AuthTestFixtures.validSignupCommand());
+		return result.id();
+	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #46

### ✨ 반영 브랜치
feat/46 -> feat/44

### 📝 변경 사항
- [x] refresh 토큰 기반 access token 재발급 엔드포인트를 추가했습니다.
- [x] refresh 토큰 쿠키 추출 책임을 cookie manager로 정리했습니다.
- [x] refresh API 관련 컨트롤러/서비스 테스트를 추가했습니다.
- [x] Auth API 문서에 refresh 엔드포인트를 반영했습니다.

### ➕ 추가 메모
- 이 PR은 #44 브랜치를 base로 하는 stacked PR입니다.
- 현재 refresh 호출 시 access token만 재발급하며 refresh token rotation은 포함하지 않았습니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- `./gradlew test`
- 결과: BUILD SUCCESSFUL