### PR TITLE
[Auth] #48 로그아웃 엔드포인트 추가

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -145,6 +145,20 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: 로그아웃
+      operationId: logout
+      security: []
+      responses:
+        '200':
+          description: 로그아웃 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
   # ========== User Endpoints ==========
   /users/me:
     get:

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthApiDocs.java
@@ -142,6 +142,18 @@ public interface AuthApiDocs {
             HttpServletResponse response
     );
 
+    @Operation(summary = "로그아웃")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공"
+            )
+    })
+    @PostMapping("/logout")
+    ResponseEntity<ApiResponse<Void>> logout(
+            HttpServletResponse response
+    );
+
     @Operation(summary = "내 정보 조회")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
+++ b/src/main/java/com/keepgoing/keepgoing/auth/controller/AuthController.java
@@ -93,4 +93,11 @@ public class AuthController implements AuthApiDocs {
 		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+			HttpServletResponse response
+	) {
+		authCookieManager.clearAllTokens(response);
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 						.requestMatchers(
 								AUTH_API_PREFIX + "/signup",
 								AUTH_API_PREFIX + "/login",
-								AUTH_API_PREFIX + "/refresh"
+								AUTH_API_PREFIX + "/refresh",
+								AUTH_API_PREFIX + "/logout"
 						).permitAll()
 						// TODO: 포스트 API는 일단 모두 허용 (개발용)
 						.requestMatchers(

--- a/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/auth/controller/AuthControllerTest.java
@@ -362,4 +362,21 @@ class AuthControllerTest {
 			then(authCookieManager).should(never()).addAccessToken(any(), anyString());
 		}
 	}
+
+	@Nested
+	@DisplayName("POST /api/auth/logout")
+	class Logout {
+
+		@Test
+		@DisplayName("성공 시 200을 반환하고 토큰 쿠키를 만료시킨다.")
+		void logout_success() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/auth/logout"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			then(authService).shouldHaveNoInteractions();
+			then(authCookieManager).should().clearAllTokens(any(HttpServletResponse.class));
+		}
+	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #48

### ✨ 반영 브랜치
feat/48 -> feat/46

### 📝 변경 사항
- [x] `POST /api/auth/logout` 엔드포인트를 추가했습니다.
- [x] logout 호출 시 access/refresh 토큰 쿠키를 만료하도록 반영했습니다.
- [x] `SecurityConfig`에 logout 경로를 허용하도록 반영했습니다.
- [x] `AuthApiDocs` 및 OpenAPI 문서에 logout 내용을 추가했습니다.
- [x] logout 컨트롤러 테스트를 추가했습니다.

### ➕ 추가 메모
- 이 PR은 `feat/46` 브랜치를 base로 하는 stacked PR입니다.
- 이번 작업은 쿠키 만료 기반 로그아웃까지만 포함합니다.
- refresh token rotation이나 서버 저장소 기반 무효화는 후속 작업으로 분리합니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- `./gradlew test`
- 결과: BUILD SUCCESSFUL