### PR TITLE
[Infra] MySQL → PostgreSQL DB 전환 (#55)

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,10 +1,10 @@
 # local profile
 export SPRING_PROFILES_ACTIVE=local
 
-# mysql (docker-compose 기준)
-export MYSQL_DATABASE=keepgoing
-export MYSQL_USER=keepgoing
-export MYSQL_PASSWORD=keepgoing
+# postgresql (docker-compose 기준)
+export POSTGRES_DB=keepgoing
+export POSTGRES_USER=keepgoing
+export POSTGRES_PASSWORD=keepgoing
 
 # jwt (최소 32바이트 이상)
 export JWT_SECRET_KEY="CHANGE_ME_TO_AT_LEAST_32_BYTES_SECRET_KEY"

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ application-oauth.yml
 docs/perf/results/
 
 .omx/
+.omc/
 .agents/
 .claude/
+
+.classpath
+.factorypath

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,8 @@ dependencies {
     // Persistence (JPA) + DB Migration (Flyway) + Drivers
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'org.flywaydb:flyway-mysql'
 
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'com.h2database:h2'
 
     // Swagger UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,17 @@
 services:
-  mysql:
-    image: mysql:8.0
-    container_name: keepgoing-mysql
+  postgres:
+    image: postgres:17-alpine
+    container_name: keepgoing-postgres
     restart: unless-stopped
     ports:
-      - "3306:3306"
+      - "5432:5432"
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       TZ: Asia/Seoul
-    command: >
-      --character-set-server=utf8mb4
-      --collation-server=utf8mb4_0900_ai_ci
     volumes:
-      - keepgoing-mysql-data:/var/lib/mysql
+      - keepgoing-postgres-data:/var/lib/postgresql/data
 
 volumes:
-  keepgoing-mysql-data:
+  keepgoing-postgres-data:

--- a/docs/perf/search_fulltext_newest.md
+++ b/docs/perf/search_fulltext_newest.md
@@ -1,3 +1,5 @@
+> **[Archive]** MySQL 8.0 FULLTEXT 기반 벤치마크. PostgreSQL 전환(#55) 이후 현재 API와 일치하지 않음.
+
 # Improved: 내 글 검색 성능 (MySQL, FULLTEXT by NEWEST)
 
 ## 목적

--- a/docs/perf/search_fulltext_score.md
+++ b/docs/perf/search_fulltext_score.md
@@ -1,3 +1,5 @@
+> **[Archive]** MySQL 8.0 FULLTEXT 기반 벤치마크. PostgreSQL 전환(#55) 이후 현재 API와 일치하지 않음.
+
 # Improved: 내 글 검색 성능 (MySQL, FULLTEXT by SCORE)
 
 ## 목적

--- a/docs/perf/search_like.md
+++ b/docs/perf/search_like.md
@@ -1,3 +1,5 @@
+> **[Archive]** MySQL 8.0 LIKE 기반 벤치마크. PostgreSQL 전환(#55) 이후 검색 방식이 변경됨.
+
 # Baseline: 내 글 검색 성능 (MySQL, LIKE baseline)
 
 ## 목적

--- a/docs/perf/search_summary.md
+++ b/docs/perf/search_summary.md
@@ -1,3 +1,5 @@
+> **[Archive]** 이 문서는 MySQL 8.0 FULLTEXT 기반 벤치마크입니다. PostgreSQL 전환(#55) 이후 FULLTEXT 검색이 제거되어 현재 API와 일치하지 않습니다. 벤치마크 방법론은 추후 PostgreSQL 성능 측정 시 참고할 수 있습니다.
+
 # 결론: 내 글 검색 성능 개선 요약 (LIKE vs FULLTEXT/SCORE vs FULLTEXT/NEWEST)
 
 ## 한 줄 결론

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
@@ -9,7 +9,6 @@ import com.keepgoing.keepgoing.note.controller.dto.NoteUpdateRequest;
 import com.keepgoing.keepgoing.note.service.NoteService;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
-import com.keepgoing.keepgoing.note.service.dto.NoteSearchMode;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
@@ -121,14 +120,9 @@ public class NoteController {
 
     /**
      * 내 노트 검색
-     * 내 포스트 검색 (LIKE baseline)
-     * - FULLTEXT와 비교 측정을 위해 별도 endpoint로 유지
-     * - 정렬/페이지는 Controller에서 safePageableUnsorted로 고정한다.
-     * - 따라서 Repository 쿼리 자체에 ORDER BY(createdAt DESC)를 명시해 결과 정렬을 보장한다.
-     * - keyword는 앞/뒤 공백을 제거(trim)하여 FULLTEXT와 입력 정규화 정책을 일치시킨다.
      */
-    @GetMapping("/me/search-like")
-    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> searchMyNotesLike(
+    @GetMapping("/me/search")
+    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> searchMyNotes(
             @RequestParam String keyword,
             @PageableDefault(size = 10)
             Pageable pageable,
@@ -136,7 +130,7 @@ public class NoteController {
     ) {
         Pageable safePageable = safePageableUnsorted(pageable);
 
-        Page<NoteSummaryResult> page = noteService.searchMyNotesLike(
+        Page<NoteSummaryResult> page = noteService.searchMyNotes(
                 userId,
                 new NoteSearchQuery(keyword, safePageable)
         );
@@ -149,43 +143,18 @@ public class NoteController {
     }
 
     /**
-     * 내 포스트 검색(FULLTEXT)
-     */
-    @GetMapping("/me/search")
-    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> searchMyNotes(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "SCORE") NoteSearchMode mode,
-            @PageableDefault(size = 10)
-            Pageable pageable,
-            @AuthenticationPrincipal Long userId
-    ) {
-        Pageable safePageable = safePageableUnsorted(pageable);
-
-        Page<NoteSummaryResult> page = noteService.searchMyNotes(
-                userId,
-                new NoteSearchQuery(keyword, safePageable, mode)
-        );
-
-        List<NoteSummaryResponse> contents = page.getContent().stream()
-                .map(NoteSummaryResponse::from)
-                .toList();
-        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
-    }
-
-    /**
      * 전체 노트 검색
      */
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> search(
             @RequestParam String keyword,
-            @RequestParam(defaultValue = "SCORE") NoteSearchMode mode,
             @PageableDefault(size = 10)
             Pageable pageable
     ) {
         Pageable safePageable = safePageableUnsorted(pageable);
 
         Page<NoteSummaryResult> page = noteService.searchNote(
-                new NoteSearchQuery(keyword, safePageable, mode)
+                new NoteSearchQuery(keyword, safePageable)
         );
 
         List<NoteSummaryResponse> contents = page.getContent().stream()

--- a/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
@@ -33,8 +33,7 @@ public class Note {
     @Column(name = "title", nullable = false, length = 200)
     private String title;
 
-    @Lob
-    @Column(name = "content", nullable = false, columnDefinition = "MEDIUMTEXT")
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -30,72 +30,25 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     @EntityGraph(attributePaths = {"author"})
     List<Note> findByVisibilityOrderByCreatedAtDesc(NoteVisibility visibility);
 
+	// TODO: 기존 성능 최적화(Mysql 기반)을 단순 검색으로 전환했으므로 이를 Postgres에 맞게 전환하는 작업 필요
     // 전체 검색(derived query)
     @EntityGraph(attributePaths = {"author"})
-    Page<Note> findByTitleContainingOrContentContaining(
+    Page<Note> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
             String titleKeyword,
             String contentKeyword,
             Pageable pageable
     );
 
-    // 내 글 검색(작성자 조건 포함) Before: LIKE 검색
+    // 내 글 검색(작성자 조건 포함)
     @Query("""
-            SELECT p
-            FROM Note p
-            WHERE p.author.id = :authorId
-              AND (p.title LIKE CONCAT('%', :keyword, '%')
-                   OR p.content LIKE CONCAT('%', :keyword, '%'))
-              ORDER BY p.createdAt DESC, p.id DESC
+            SELECT n
+            FROM Note n
+            WHERE n.author.id = :authorId
+              AND (LOWER(n.title) LIKE CONCAT('%', LOWER(:keyword), '%')
+                   OR LOWER(n.content) LIKE CONCAT('%', LOWER(:keyword), '%'))
+              ORDER BY n.createdAt DESC, n.id DESC
             """)
-    Page<Note> searchMyNotesLike(@Param("authorId") Long authorId,
-                                 @Param("keyword") String keyword,
-                                 Pageable pageable);
-
-    // 내 글 검색(작성자 조건 포함) After: Fulltext 검색
-    @Query(
-            value = """
-                SELECT n.*
-                FROM notes n
-                WHERE n.author_id = :authorId
-                    AND n.deleted_at IS NULL
-                    AND MATCH(n.title, n.content) AGAINST (:keyword IN BOOLEAN MODE)
-                ORDER BY MATCH(n.title, n.content) AGAINST (:keyword IN BOOLEAN MODE) DESC,
-                        n.created_at DESC,
-                        n.id DESC
-                """,
-            countQuery = """
-                SELECT COUNT(*)
-                FROM notes n
-                WHERE n.author_id = :authorId
-                    AND n.deleted_at IS NULL
-                    AND MATCH(n.title, n.content) AGAINST (:keyword IN BOOLEAN MODE)
-                """,
-            nativeQuery = true
-    )
-    Page<Note> searchMyNotesFullTextByScore(@Param("authorId") Long authorId,
-                                     @Param("keyword") String keyword,
-                                     Pageable pageable);
-
-    @Query(
-            value = """
-                SELECT n.*
-                FROM notes n
-                WHERE n.author_id = :authorId
-                    AND n.deleted_at IS NULL
-                    AND MATCH(n.title, n.content) AGAINST (:keyword IN BOOLEAN MODE)
-                ORDER BY n.created_at DESC,
-                        n.id DESC
-                """,
-            countQuery = """
-                SELECT COUNT(*)
-                FROM notes n
-                WHERE n.author_id = :authorId
-                    AND n.deleted_at IS NULL
-                    AND MATCH(n.title, n.content) AGAINST (:keyword IN BOOLEAN MODE)
-                """,
-            nativeQuery = true
-    )
-    Page<Note> searchMyNotesFullTextByNewest(@Param("authorId") Long authorId,
-                                             @Param("keyword") String keyword,
-                                             Pageable pageable);
+    Page<Note> searchMyNotes(@Param("authorId") Long authorId,
+                             @Param("keyword") String keyword,
+                             Pageable pageable);
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -89,28 +89,11 @@ public class NoteService {
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
 
 		note.validateAuthor(userId);
-		note.softDelete(); // deleted_at만 채움 → @Where 때문에 이후 조회에서 빠짐
+		note.softDelete();
 	}
 
 	/**
-	 * 내 글 검색 (LIKE baseline)
-	 * - FULLTEXT와 성능 비교를 위한 baseline
-	 * - 정렬/페이지는 Controller에서 safePageableUnsorted로 고정한다.
-	 * - 따라서 Repository 쿼리 자체에 ORDER BY(createdAt DESC)를 명시해 결과 정렬을 보장한다.
-	 * - keyword는 앞/뒤 공백을 제거(trim)하여 FULLTEXT와 입력 정규화 정책을 일치시킨다.
-	 */
-	@Transactional(readOnly = true)
-	public Page<NoteSummaryResult> searchMyNotesLike(Long userId, NoteSearchQuery query) {
-		if (query == null || !query.hasKeyword()) {
-			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-		}
-
-		return noteRepository.searchMyNotesLike(userId, query.keyword(), query.pageable())
-				.map(this::toSummaryResult);
-	}
-
-	/**
-	 * 내 글 검색(FULLTEXT SCORE/NEWEST)
+	 * 내 글 검색
 	 */
 	@Transactional(readOnly = true)
 	public Page<NoteSummaryResult> searchMyNotes(Long userId, NoteSearchQuery query) {
@@ -118,28 +101,12 @@ public class NoteService {
 			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
 		}
 
-		Page<Note> page = switch (query.mode()) {
-			case SCORE -> noteRepository.searchMyNotesFullTextByScore(
-					userId,
-					query.keyword(),
-					query.pageable()
-			);
-			case NEWEST -> noteRepository.searchMyNotesFullTextByNewest(
-					userId,
-					query.keyword(),
-					query.pageable()
-			);
-		};
-
-		return page.map(this::toSummaryResult);
+		return noteRepository.searchMyNotes(userId, query.keyword(), query.pageable())
+				.map(this::toSummaryResult);
 	}
 
 	/**
-	 * 전체(공개/공통) 검색
-	 *
-	 * NOTE: MySQL에서 TEXT/MEDIUMTEXT 컬럼(content)이 CLOB로 매핑될 때,
-	 *       IgnoreCase 파생 쿼리는 upper()/lower()를 사용하며 오류가 날 수 있어
-	 *       Containing(대소문자 구분은 collation에 위임) 형태로 유지합니다.
+	 * 전체(공개) 검색
 	 */
 	@Transactional(readOnly = true)
 	public Page<NoteSummaryResult> searchNote(NoteSearchQuery query) {
@@ -147,7 +114,7 @@ public class NoteService {
 			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
 		}
 
-		Page<Note> page = noteRepository.findByTitleContainingOrContentContaining(
+		Page<Note> page = noteRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
 				query.keyword(),
 				query.keyword(),
 				query.pageable()

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSearchMode.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSearchMode.java
@@ -1,6 +1,0 @@
-package com.keepgoing.keepgoing.note.service.dto;
-
-public enum NoteSearchMode {
-    SCORE,
-    NEWEST
-}

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSearchQuery.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSearchQuery.java
@@ -4,22 +4,12 @@ import org.springframework.data.domain.Pageable;
 
 public record NoteSearchQuery(
         String keyword,
-        Pageable pageable,
-        NoteSearchMode mode
+        Pageable pageable
 ) {
     public NoteSearchQuery {
         if (keyword != null) {
             keyword = keyword.trim();
         }
-
-        if (mode == null) {
-            mode = NoteSearchMode.SCORE;
-        }
-    }
-
-    // search LIKE 편의 생성자
-    public NoteSearchQuery(String keyword, Pageable pageable) {
-        this(keyword, pageable, null);
     }
 
     public boolean hasKeyword() {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,22 +1,20 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
-    username: ${MYSQL_USER}
-    password: ${MYSQL_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://localhost:5432/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
     open-in-view: false
 
   flyway:
-    enabled: true
-    locations:
-      - classpath:db/migration
+    enabled: false
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: keepgoing
+  flyway:
+    enabled: false
   security:
     oauth2:
       client:

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -20,6 +20,7 @@ import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
+import java.util.List;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.Optional;
@@ -391,39 +392,7 @@ public class NoteServiceTest {
 
     @Test
     @DisplayName("searchMyNotes: keyword가 있으면 검색 결과를 페이지로 반환한다")
-    void searchNote_returnsPageWhenKeywordProvided() {
-        //given
-        Long userId = 1L;
-        User user = createUser(userId);
-
-        Note note1 = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-        Note note2 = Note.create(user, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
-
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Note> notePage = new PageImpl<>(java.util.List.of(note1, note2), pageable, 2);
-
-        NoteSearchQuery query = new NoteSearchQuery("spring", pageable, com.keepgoing.keepgoing.note.service.dto.NoteSearchMode.SCORE);
-
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-
-        given(noteRepository.searchMyNotesFullTextByScore(eq(userId), eq("spring"), any(Pageable.class)))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-        //then
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent()).hasSize(2);
-        verify(noteRepository).searchMyNotesFullTextByScore(eq(userId), eq("spring"), pageableCaptor.capture());
-        assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("searchMyNotes: mode=NEWEST이면 최신순 FULLTEXT 쿼리를 호출한다")
-    void searchNote_routesToNewestWhenModeNewest() {
+    void searchMyNotes_returnsPageWhenKeywordProvided() {
         // given
         Long userId = 1L;
         User user = createUser(userId);
@@ -432,13 +401,11 @@ public class NoteServiceTest {
         Note note2 = Note.create(user, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
 
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Note> notePage = new PageImpl<>(java.util.List.of(note1, note2), pageable, 2);
+        Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
 
-        NoteSearchQuery query = new NoteSearchQuery("spring", pageable, com.keepgoing.keepgoing.note.service.dto.NoteSearchMode.NEWEST);
+        NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
 
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-
-        given(noteRepository.searchMyNotesFullTextByNewest(eq(userId), eq("spring"), any(Pageable.class)))
+        given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
                 .willReturn(notePage);
 
         // when
@@ -447,113 +414,21 @@ public class NoteServiceTest {
         // then
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
-        verify(noteRepository).searchMyNotesFullTextByNewest(eq(userId), eq("spring"), pageableCaptor.capture());
-        assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
-        verify(noteRepository, never()).searchMyNotesFullTextByScore(any(), any(), any());
+        verify(noteRepository).searchMyNotes(eq(userId), eq("spring"), any(Pageable.class));
         verifyNoMoreInteractions(noteRepository);
         verifyNoInteractions(userRepository);
     }
 
     @Test
     @DisplayName("searchMyNotes: keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외")
-    void searchNote_throwsWhenKeywordBlank() {
-        // given
-        Long userId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        NoteSearchQuery query = new NoteSearchQuery("   ", pageable, com.keepgoing.keepgoing.note.service.dto.NoteSearchMode.SCORE);
-
-        // when & then
-        assertThatThrownBy(() -> noteService.searchMyNotes(
-                userId, query))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-
-        // repository 호출되면 안 됨
-        verify(noteRepository, never())
-                .searchMyNotesFullTextByScore(any(), any(), any());
-        verify(noteRepository, never())
-                .searchMyNotesFullTextByNewest(any(), any(), any());
-        verifyNoInteractions(userRepository);
-    }
-
-
-    @Test
-    @DisplayName("searchMyNotes: keyword 앞뒤 공백은 trim되어 검색된다")
-    void searchNote_trimsKeywordBeforeSearching() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-        Note note = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Note> notePage = new PageImpl<>(java.util.List.of(note), pageable, 1);
-
-        NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable, com.keepgoing.keepgoing.note.service.dto.NoteSearchMode.SCORE);
-
-        given(noteRepository.searchMyNotesFullTextByScore(eq(userId), eq("spring"), any(Pageable.class)))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(1);
-
-        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-
-        verify(noteRepository).searchMyNotesFullTextByScore(eq(userId), keywordCaptor.capture(), pageableCaptor.capture());
-        assertThat(keywordCaptor.getValue()).isEqualTo("spring");
-
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    // ========== searchMyNotesLike (LIKE baseline) ==========
-
-    @Test
-    @DisplayName("searchMyNotesLike: keyword 앞뒤 공백은 trim되어 검색된다")
-    void searchMyNotesLike_trimsKeywordBeforeSearching() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-        Note note = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Note> notePage = new PageImpl<>(java.util.List.of(note), pageable, 1);
-
-        NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
-
-        given(noteRepository.searchMyNotesLike(eq(userId), eq("spring"), any(Pageable.class)))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.searchMyNotesLike(userId, query);
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(1);
-
-        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-
-        verify(noteRepository).searchMyNotesLike(eq(userId), keywordCaptor.capture(), pageableCaptor.capture());
-        assertThat(keywordCaptor.getValue()).isEqualTo("spring");
-        assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
-
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("searchMyNotesLike: keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외")
-    void searchMyNotesLike_throwsWhenKeywordBlank() {
+    void searchMyNotes_throwsWhenKeywordBlank() {
         // given
         Long userId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
         NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
 
         // when & then
-        assertThatThrownBy(() -> noteService.searchMyNotesLike(userId, query))
+        assertThatThrownBy(() -> noteService.searchMyNotes(userId, query))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
 
@@ -561,5 +436,34 @@ public class NoteServiceTest {
         verifyNoInteractions(userRepository);
     }
 
+    @Test
+    @DisplayName("searchMyNotes: keyword 앞뒤 공백은 trim되어 검색된다")
+    void searchMyNotes_trimsKeywordBeforeSearching() {
+        // given
+        Long userId = 1L;
+        User user = createUser(userId);
+        Note note = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
+
+        NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
+
+        given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
+                .willReturn(notePage);
+
+        // when
+        Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+
+        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+        verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
+        assertThat(keywordCaptor.getValue()).isEqualTo("spring");
+
+        verifyNoMoreInteractions(noteRepository);
+        verifyNoInteractions(userRepository);
+    }
 
 }

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password: ""

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,7 +10,7 @@ spring:
             client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
 
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password: ""


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 의존성, 환경 변수, 빌드 관련 코드 업데이트
- 기능 삭제

### 📌 관련 이슈
closes #55

### ✨ 반영 브랜치
feat/55 -> develop

### 📝 변경 사항

#### 인프라/설정 전환
- [x] `build.gradle`에서 `flyway-mysql`, `mysql-connector-j` 제거 및 `postgresql` 드라이버 추가
- [x] `docker-compose.yml` MySQL 8.0 → PostgreSQL 17-alpine 전환
- [x] `.envrc.example` 환경변수 `MYSQL_*` → `POSTGRES_*` 변경
- [x] `application-local.yml` PostgreSQL 연결 설정, `ddl-auto: update`, `flyway.enabled: false`

#### 엔티티 수정
- [x] `Note.java`에서 `@Lob` 제거, `columnDefinition = "TEXT"` 명시 (PostgreSQL TEXT 타입 보장)

#### 검색 API 전환 (Breaking Change)
- [x] MySQL FULLTEXT 검색(`MATCH...AGAINST`) 2개 메서드 삭제 → LOWER/LIKE 기반 단일 검색으로 통합
- [x] `NoteSearchMode` enum 삭제, `NoteSearchQuery`에서 `mode` 필드 제거
- [x] `NoteController`에서 `/me/search-like` 엔드포인트 삭제, `/me/search`에서 `mode` 파라미터 제거
- [x] 전체 검색에 `IgnoreCase` 적용 (`findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase`)

> **왜 Breaking Change가 포함되는가:** MySQL FULLTEXT 문법(`MATCH...AGAINST`)은 PostgreSQL에서 동작하지 않으므로, DB 전환 시 검색 쿼리 교체가 필수입니다. FTS 기반 검색 최적화(관련도 정렬 등)는 추후 별도 이슈로 진행합니다.

#### 테스트
- [x] H2 `MODE=MySQL` 제거
- [x] `NoteServiceTest` FULLTEXT 관련 테스트 제거 및 통합 검색 테스트로 대체

#### 문서
- [x] `docs/perf/*` MySQL 벤치마크 문서에 `[Archive]` 헤더 추가

### ➕ 추가 메모
- Flyway는 비활성화만 하고 마이그레이션 SQL 파일(V1~V3)은 보존합니다. 운영 배포 시점에 PostgreSQL 기준으로 재도입 예정입니다.
- `flyway-core` 의존성은 유지하며, 재활성화 시 `flyway-database-postgresql` 추가가 필요합니다.
- 기존 Flyway 테이블명(`posts`)과 엔티티(`notes`)의 불일치는 `ddl-auto: update`로 엔티티 기준 통일됩니다.
- `folders` 테이블은 기존 Flyway에 누락되어 있었으나, `ddl-auto: update`로 자동 생성됩니다.
- 검색 성능 최적화(`pg_trgm` GIN 인덱스)는 이번 PR에 포함하지 않으며 추후 별도 이슈로 진행합니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
`./gradlew test` 전체 통과 (BUILD SUCCESSFUL)