### PR TITLE
[Note] #57 노트 생성 시 Folder 지정 지원

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -40,6 +40,8 @@ tags:
     description: 서비스 상태 확인
   - name: Auth
     description: 회원가입, 로그인, 토큰 관리
+  - name: Notes
+    description: 노트 생성 및 조회
   - name: Users
     description: 사용자 프로필 조회 및 관리
 
@@ -158,6 +160,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+
+  /api/notes:
+    post:
+      tags: [Notes]
+      summary: 노트 생성
+      operationId: createNote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NoteCreateRequest'
+            example:
+              folderId: 10
+              title: 첫 번째 글 제목
+              content: 첫 번째 글 내용입니다.
+              visibility: PRIVATE
+              aiCollectable: true
+      responses:
+        '201':
+          description: 노트 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoteCreateResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - BearerAuth: []
 
   # ========== User Endpoints ==========
   /users/me:
@@ -583,6 +620,11 @@ components:
         - USER_ALREADY_EXISTS
         - USER_SUSPENDED
         - USER_DELETED
+        # Note / Folder errors
+        - NOTE_NOT_FOUND
+        - NOTE_ACCESS_DENIED
+        - FOLDER_NOT_FOUND
+        - FOLDER_ACCESS_DENIED
         # Validation errors
         - VALIDATION_FAILED
         - INVALID_INPUT
@@ -734,6 +776,74 @@ components:
                 role:
                   $ref: '#/components/schemas/UserRole'
               required: [userId, email, name, role]
+
+    # ========== Note Schemas ==========
+    NoteVisibility:
+      type: string
+      enum: [PRIVATE, PUBLIC]
+      description: 노트 공개 범위
+
+    NoteCreateRequest:
+      type: object
+      properties:
+        folderId:
+          type: integer
+          format: int64
+          nullable: true
+          description: 생성할 노트가 속할 폴더 ID. null이면 루트에 생성됩니다.
+        title:
+          type: string
+          maxLength: 200
+          description: 노트 제목
+        content:
+          type: string
+          description: 노트 본문
+        visibility:
+          $ref: '#/components/schemas/NoteVisibility'
+        aiCollectable:
+          type: boolean
+          description: AI 수집 가능 여부
+      required: [title, content]
+
+    NoteDetailData:
+      type: object
+      properties:
+        noteId:
+          type: integer
+          format: int64
+        folderId:
+          type: integer
+          format: int64
+          nullable: true
+          description: 노트가 속한 폴더 ID. 루트 노트면 null입니다.
+        userId:
+          type: integer
+          format: int64
+        title:
+          type: string
+        content:
+          type: string
+        visibility:
+          $ref: '#/components/schemas/NoteVisibility'
+        aiCollectable:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+      required: [noteId, userId, title, content, visibility, aiCollectable]
+
+    NoteCreateResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiResponse'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/NoteDetailData'
 
     # ========== User Schemas ==========
     UserRole:

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteCreateRequest.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteCreateRequest.java
@@ -2,10 +2,19 @@ package com.keepgoing.keepgoing.note.controller.dto;
 
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "노트 생성 요청")
 public record NoteCreateRequest(
+
+        @Schema(
+                description = "생성할 노트가 속할 폴더 ID. null이면 루트에 생성됩니다.",
+                example = "10",
+                nullable = true
+        )
+        Long folderId,
 
         @NotBlank
         @Size(max = 200)
@@ -32,6 +41,7 @@ public record NoteCreateRequest(
     public NoteCreateCommand toCommand(Long userId) {
         return new NoteCreateCommand(
                 userId,
+                this.folderId,
                 this.title,
                 this.content,
                 this.visibility,

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteDetailResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteDetailResponse.java
@@ -2,11 +2,19 @@ package com.keepgoing.keepgoing.note.controller.dto;
 
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "노트 상세 응답")
 public record NoteDetailResponse(
         Long noteId,
+        @Schema(
+                description = "노트가 속한 폴더 ID. 루트 노트면 null입니다.",
+                example = "10",
+                nullable = true
+        )
+        Long folderId,
         Long userId,
         String title,
         String content,
@@ -18,6 +26,7 @@ public record NoteDetailResponse(
     public static NoteDetailResponse from(NoteDetailResult result) {
         return new NoteDetailResponse(
                 result.noteId(),
+                result.folderId(),
                 result.userId(),
                 result.title(),
                 result.content(),

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteSummaryResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteSummaryResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 public record NoteSummaryResponse(
         Long noteId,
+        Long folderId,
         String title,
         NoteVisibility visibility,
         boolean aiCollectable,
@@ -15,6 +16,7 @@ public record NoteSummaryResponse(
     public static NoteSummaryResponse from(NoteSummaryResult result) {
         return new NoteSummaryResponse(
                 result.noteId(),
+                result.folderId(),
                 result.title(),
                 result.visibility(),
                 result.aiCollectable(),

--- a/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
@@ -1,5 +1,6 @@
 package com.keepgoing.keepgoing.note.domain;
 
+import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.global.common.entity.BaseEntity;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
@@ -13,7 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -33,123 +33,134 @@ import org.hibernate.annotations.SQLRestriction;
 @Builder
 public class Note extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false, updatable = false)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    private User author;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id", nullable = false)
+	private User author;
 
-    @Column(name = "title", nullable = false, length = 200)
-    private String title;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "folder_id")
+	private Folder folder;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
-    private String content;
+	@Column(name = "title", nullable = false, length = 200)
+	private String title;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "visibility", nullable = false, length = 20)
-    @Builder.Default
-    private NoteVisibility visibility = NoteVisibility.PRIVATE;
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
 
-    @Column(name = "ai_collectable", nullable = false)
-    @Builder.Default
-    private boolean aiCollectable = false;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "visibility", nullable = false, length = 20)
+	@Builder.Default
+	private NoteVisibility visibility = NoteVisibility.PRIVATE;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+	@Column(name = "ai_collectable", nullable = false)
+	@Builder.Default
+	private boolean aiCollectable = false;
 
-    // === 비즈니스 로직 ===
-    /**
-     * 글 생성 팩토리 메서드
-     * - visibility가 null이면 기본값 PRIVATE 사용
-     */
-    public static Note create(User author,
-                              String title,
-                              String content,
-                              NoteVisibility visibility,
-                              Boolean aiCollectable) {
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
-        if (author == null || author.getId() == null) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-        if (title == null || title.isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
-        if (content == null || content.isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
+	// === 비즈니스 로직 ===
 
-        NoteVisibility finalVisibility =
-                (visibility != null) ? visibility : NoteVisibility.PRIVATE;
+	/**
+	 * 글 생성 팩토리 메서드 - visibility가 null이면 기본값 PRIVATE 사용
+	 */
+	public static Note create(
+			User author,
+			Folder folder,
+			String title,
+			String content,
+			NoteVisibility visibility,
+			Boolean aiCollectable
+	) {
+		if (author == null || author.getId() == null) {
+			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+		if (folder != null) {
+			folder.validateOwner(author.getId());
+		}
+		if (title == null || title.isBlank()) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT);
+		}
+		if (content == null || content.isBlank()) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT);
+		}
 
-        boolean finalAiCollectable =
-                (aiCollectable != null) && aiCollectable;
+		NoteVisibility finalVisibility =
+				(visibility != null) ? visibility : NoteVisibility.PRIVATE;
 
-        return Note.builder()
-                .author(author)
-                .title(title)
-                .content(content)
-                .visibility(finalVisibility)
-                .aiCollectable(finalAiCollectable)
-                .build();
-    }
+		boolean finalAiCollectable =
+				(aiCollectable != null) && aiCollectable;
 
-    /**
-     * 글 내용 수정
-     */
-    public void update(String title,
-                       String content,
-                       NoteVisibility visibility,
-                       boolean aiCollectable) {
-        this.title = title;
-        this.content = content;
-        this.visibility = visibility;
-        this.aiCollectable = aiCollectable;
-    }
+		return Note.builder()
+				.author(author)
+				.folder(folder)
+				.title(title)
+				.content(content)
+				.visibility(finalVisibility)
+				.aiCollectable(finalAiCollectable)
+				.build();
+	}
 
-    /**
-     * 소프트 삭제
-     */
-    public void softDelete() {
-        if (this.deletedAt == null) {
-            this.deletedAt = LocalDateTime.now();
-        }
-    }
+	/**
+	 * 글 내용 수정
+	 */
+	public void update(String title,
+	                   String content,
+	                   NoteVisibility visibility,
+	                   boolean aiCollectable) {
+		this.title = title;
+		this.content = content;
+		this.visibility = visibility;
+		this.aiCollectable = aiCollectable;
+	}
 
-    /**
-     * 삭제 처리된 게시글인지 여부
-     */
-    public boolean isDeleted() {
-        return deletedAt != null;
-    }
+	/**
+	 * 소프트 삭제
+	 */
+	public void softDelete() {
+		if (this.deletedAt == null) {
+			this.deletedAt = LocalDateTime.now();
+		}
+	}
 
-    /**
-     * 작성자 권한 검증
-     */
-    public void validateAuthor(Long authorId) {
-        if (!isAuthor(authorId)) {
-            throw new BusinessException(ErrorCode.NOTE_ACCESS_DENIED);
-        }
-    }
+	/**
+	 * 삭제 처리된 게시글인지 여부
+	 */
+	public boolean isDeleted() {
+		return deletedAt != null;
+	}
 
-    /**
-     * 이 글의 작성자 여부
-     * */
-    public boolean isAuthor(Long authorId) {
-        return this.author != null
-                && this.author.getId() != null
-                && this.author.getId().equals(authorId);
-    }
+	/**
+	 * 작성자 권한 검증
+	 */
+	public void validateAuthor(Long authorId) {
+		if (!isAuthor(authorId)) {
+			throw new BusinessException(ErrorCode.NOTE_ACCESS_DENIED);
+		}
+	}
 
-    /**
-     * 작성자 ID 가져오기
-     */
-    public Long getAuthorId() {
-        if (this.author == null || this.author.getId() == null) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-        return this.author.getId();
-    }
+	/**
+	 * 이 글의 작성자 여부
+	 *
+	 */
+	public boolean isAuthor(Long authorId) {
+		return this.author != null
+				&& this.author.getId() != null
+				&& this.author.getId().equals(authorId);
+	}
+
+	/**
+	 * 작성자 ID 가져오기
+	 */
+	public Long getAuthorId() {
+		if (this.author == null || this.author.getId() == null) {
+			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+		return this.author.getId();
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -1,5 +1,7 @@
 package com.keepgoing.keepgoing.note.service;
 
+import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.Note;
@@ -18,29 +20,37 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class NoteService {
 
 	private final NoteRepository noteRepository;
 	private final UserRepository userRepository;
+	private final FolderRepository folderRepository;
 
 	/**
-	 * 포스트 생성
+	 * 노트 생성
 	 */
+	@Transactional
 	public NoteDetailResult createNote(NoteCreateCommand command) {
 		User author = userRepository.findById(command.userId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+		Folder folder = null;
+		if (command.folderId() != null) {
+			folder = folderRepository.findByIdAndDeletedAtIsNull(command.folderId())
+					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+		}
+
 		Note note = Note.create(
 				author,
+				folder,
 				command.title(),
 				command.content(),
 				command.visibility(),
 				command.aiCollectable()
 		);
 		Note saved = noteRepository.save(note);
-		return toDetailResult(saved);
+		return NoteDetailResult.from(saved);
 	}
 
 	/**
@@ -50,7 +60,7 @@ public class NoteService {
 	public NoteDetailResult getNote(Long noteId) {
 		Note note = noteRepository.findById(noteId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
-		return toDetailResult(note);
+		return NoteDetailResult.from(note);
 	}
 
 	/**
@@ -59,12 +69,13 @@ public class NoteService {
 	@Transactional(readOnly = true)
 	public Page<NoteSummaryResult> getNotes(Long userId, Pageable pageable) {
 		return noteRepository.findByAuthor_Id(userId, pageable)
-				.map(this::toSummaryResult);
+				.map(NoteSummaryResult::from);
 	}
 
 	/**
-	 * 포스트 수정
+	 * 노트 수정
 	 */
+	@Transactional
 	public NoteDetailResult updateNote(NoteUpdateCommand command) {
 		Note note = noteRepository.findById(command.noteId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
@@ -78,12 +89,13 @@ public class NoteService {
 				command.aiCollectable()
 		);
 
-		return toDetailResult(note);
+		return NoteDetailResult.from(note);
 	}
 
 	/**
 	 * 포스트 삭제 (soft delete)
 	 */
+	@Transactional
 	public void deleteNote(Long userId, Long noteId) {
 		Note note = noteRepository.findById(noteId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
@@ -102,7 +114,7 @@ public class NoteService {
 		}
 
 		return noteRepository.searchMyNotes(userId, query.keyword(), query.pageable())
-				.map(this::toSummaryResult);
+				.map(NoteSummaryResult::from);
 	}
 
 	/**
@@ -120,29 +132,6 @@ public class NoteService {
 				query.pageable()
 		);
 
-		return page.map(this::toSummaryResult);
-	}
-
-	private NoteDetailResult toDetailResult(Note note) {
-		return new NoteDetailResult(
-				note.getId(),
-				note.getAuthor().getId(),
-				note.getTitle(),
-				note.getContent(),
-				note.getVisibility(),
-				note.isAiCollectable(),
-				note.getCreatedAt(),
-				note.getUpdatedAt()
-		);
-	}
-
-	private NoteSummaryResult toSummaryResult(Note note) {
-		return new NoteSummaryResult(
-				note.getId(),
-				note.getTitle(),
-				note.getVisibility(),
-				note.isAiCollectable(),
-				note.getCreatedAt()
-		);
+		return page.map(NoteSummaryResult::from);
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteCreateCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteCreateCommand.java
@@ -1,18 +1,22 @@
 package com.keepgoing.keepgoing.note.service.dto;
 
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
+import lombok.Builder;
 
 /**
  * 노트 생성에 필요한 서비스 계층 전용 커맨드입니다.
  *
  * @param userId        작성자 ID
+ * @param folderId      폴더 ID
  * @param title         노트 제목
  * @param content       노트 본문 내용
  * @param visibility    공개 범위
  * @param aiCollectable AI 학습/수집에 활용 가능한지 여부
  */
+@Builder
 public record NoteCreateCommand(
 		Long userId,
+		Long folderId,
 		String title,
 		String content,
 		NoteVisibility visibility,

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteDetailResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteDetailResult.java
@@ -1,11 +1,13 @@
 package com.keepgoing.keepgoing.note.service.dto;
 
+import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 
 import java.time.LocalDateTime;
 
 public record NoteDetailResult(
 		Long noteId,
+		Long folderId,
 		Long userId,
 		String title,
 		String content,
@@ -14,4 +16,17 @@ public record NoteDetailResult(
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
 ) {
+	public static NoteDetailResult from(Note note) {
+		return new NoteDetailResult(
+				note.getId(),
+				note.getFolder() != null ? note.getFolder().getId() : null,
+				note.getAuthor().getId(),
+				note.getTitle(),
+				note.getContent(),
+				note.getVisibility(),
+				note.isAiCollectable(),
+				note.getCreatedAt(),
+				note.getUpdatedAt()
+		);
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSummaryResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteSummaryResult.java
@@ -1,14 +1,26 @@
 package com.keepgoing.keepgoing.note.service.dto;
 
+import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 
 import java.time.LocalDateTime;
 
 public record NoteSummaryResult(
-        Long noteId,
-        String title,
-        NoteVisibility visibility,
-        boolean aiCollectable,
-        LocalDateTime createdAt
+		Long noteId,
+		Long folderId,
+		String title,
+		NoteVisibility visibility,
+		boolean aiCollectable,
+		LocalDateTime createdAt
 ) {
+	public static NoteSummaryResult from(Note note) {
+		return new NoteSummaryResult(
+				note.getId(),
+				note.getFolder() != null ? note.getFolder().getId() : null,
+				note.getTitle(),
+				note.getVisibility(),
+				note.isAiCollectable(),
+				note.getCreatedAt()
+		);
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -78,10 +78,12 @@ public class NoteControllerTest {
 	// ========== Note ==========
 
 	@Test
-	@DisplayName("POST /api/notes - 글 생성 성공 시 201 Created 반환")
-	void createNote_success() throws Exception {
+	@DisplayName("POST /api/notes - folderId가 null이면 루트 노트 생성 요청이 서비스로 전달된다")
+	void createNote_successWhenFolderIdIsNull() throws Exception {
 		//given
+		Long userId = 1L;
 		NoteCreateRequest request = new NoteCreateRequest(
+				null,
 				"테스트 제목",
 				"테스트 내용",
 				NoteVisibility.PRIVATE,
@@ -90,7 +92,8 @@ public class NoteControllerTest {
 
 		NoteDetailResult result = new NoteDetailResult(
 				1L,
-				1L,
+				null,
+				userId,
 				"테스트 제목",
 				"테스트 내용",
 				NoteVisibility.PRIVATE,
@@ -102,6 +105,10 @@ public class NoteControllerTest {
 		given(noteService.createNote(any(NoteCreateCommand.class)))
 				.willReturn(result);
 
+		SecurityContextHolder.getContext().setAuthentication(
+				new UsernamePasswordAuthenticationToken(userId, null, List.of())
+		);
+
 		String json = objectMapper.writeValueAsString(request);
 
 		//when & then
@@ -110,7 +117,68 @@ public class NoteControllerTest {
 						.content(json))
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.noteId").value(1L))
+				.andExpect(jsonPath("$.data.title").value("테스트 제목"))
+				.andExpect(jsonPath("$.data.folderId").isEmpty())
+				.andExpect(jsonPath("$.data.userId").value(1L));
+
+		ArgumentCaptor<NoteCreateCommand> captor = ArgumentCaptor.forClass(NoteCreateCommand.class);
+		verify(noteService).createNote(captor.capture());
+		assertThat(captor.getValue().userId()).isEqualTo(userId);
+		assertThat(captor.getValue().folderId()).isNull();
+		assertThat(captor.getValue().title()).isEqualTo("테스트 제목");
+	}
+
+	@Test
+	@DisplayName("POST /api/notes - folderId가 있으면 해당 값이 서비스와 응답에 반영된다")
+	void createNote_successWhenFolderIdIsProvided() throws Exception {
+		//given
+		Long userId = 1L;
+		Long folderId = 10L;
+		NoteCreateRequest request = new NoteCreateRequest(
+				folderId,
+				"테스트 제목",
+				"테스트 내용",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		NoteDetailResult result = new NoteDetailResult(
+				1L,
+				folderId,
+				userId,
+				"테스트 제목",
+				"테스트 내용",
+				NoteVisibility.PRIVATE,
+				true,
+				null,
+				null
+		);
+
+		given(noteService.createNote(any(NoteCreateCommand.class)))
+				.willReturn(result);
+
+		SecurityContextHolder.getContext().setAuthentication(
+				new UsernamePasswordAuthenticationToken(userId, null, List.of())
+		);
+
+		String json = objectMapper.writeValueAsString(request);
+
+		//when & then
+		mockMvc.perform(post("/api/notes")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(json))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.noteId").value(1L))
+				.andExpect(jsonPath("$.data.folderId").value(folderId))
+				.andExpect(jsonPath("$.data.userId").value(userId))
 				.andExpect(jsonPath("$.data.title").value("테스트 제목"));
+
+		ArgumentCaptor<NoteCreateCommand> captor = ArgumentCaptor.forClass(NoteCreateCommand.class);
+		verify(noteService).createNote(captor.capture());
+		assertThat(captor.getValue().userId()).isEqualTo(userId);
+		assertThat(captor.getValue().folderId()).isEqualTo(folderId);
 	}
 
 	@Test
@@ -118,6 +186,7 @@ public class NoteControllerTest {
 	void createNote_failsWithEmptyTitle() throws Exception {
 		//given
 		NoteCreateRequest request = new NoteCreateRequest(
+				null,
 				"",
 				"테스트 내용",
 				NoteVisibility.PRIVATE,
@@ -133,6 +202,68 @@ public class NoteControllerTest {
 				.andExpect(status().isBadRequest()); // HTTP 400 Bad Request를 기대
 	}
 
+	@Test
+	@DisplayName("POST /api/notes - 존재하지 않는 폴더면 404 에러 응답")
+	void createNote_returnsNotFoundWhenFolderDoesNotExist() throws Exception {
+		// given
+		Long userId = 1L;
+		NoteCreateRequest request = new NoteCreateRequest(
+				10L,
+				"테스트 제목",
+				"테스트 내용",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		given(noteService.createNote(any(NoteCreateCommand.class)))
+				.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+		SecurityContextHolder.getContext().setAuthentication(
+				new UsernamePasswordAuthenticationToken(userId, null, List.of())
+		);
+
+		String json = objectMapper.writeValueAsString(request);
+
+		// when & then
+		mockMvc.perform(post("/api/notes")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(json))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.error.code").value("FOLDER_NOT_FOUND"));
+	}
+
+	@Test
+	@DisplayName("POST /api/notes - 다른 사용자의 폴더면 403 에러 응답")
+	void createNote_returnsForbiddenWhenFolderOwnedByAnotherUser() throws Exception {
+		// given
+		Long userId = 1L;
+		NoteCreateRequest request = new NoteCreateRequest(
+				10L,
+				"테스트 제목",
+				"테스트 내용",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		given(noteService.createNote(any(NoteCreateCommand.class)))
+				.willThrow(new BusinessException(ErrorCode.FOLDER_ACCESS_DENIED));
+
+		SecurityContextHolder.getContext().setAuthentication(
+				new UsernamePasswordAuthenticationToken(userId, null, List.of())
+		);
+
+		String json = objectMapper.writeValueAsString(request);
+
+		// when & then
+		mockMvc.perform(post("/api/notes")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(json))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.error.code").value("FOLDER_ACCESS_DENIED"));
+	}
+
 	// ========== GET ==========
 
 	@Test
@@ -142,8 +273,9 @@ public class NoteControllerTest {
 		Long noteId = 1L;
 
 		NoteDetailResult result = new NoteDetailResult(
-				1L,
 				noteId,
+				1L,
+				null,
 				"테스트 제목",
 				"테스트 내용",
 				NoteVisibility.PRIVATE,
@@ -184,8 +316,8 @@ public class NoteControllerTest {
 		Long userId = 1L; // TODO: Security 붙으면 현재 로그인 유저로 교체
 
 		var notes = List.of(
-				new NoteSummaryResult(1L, "제목1", NoteVisibility.PRIVATE, true, null),
-				new NoteSummaryResult(2L, "제목2", NoteVisibility.PUBLIC, true, null)
+				new NoteSummaryResult(1L, null, "제목1", NoteVisibility.PRIVATE, true, null),
+				new NoteSummaryResult(2L, null, "제목2", NoteVisibility.PUBLIC, true, null)
 		);
 
 		// 페이지 정보 (0페이지, size=10, createdAt DESC 정렬)
@@ -264,6 +396,7 @@ public class NoteControllerTest {
 		NoteDetailResult result = new NoteDetailResult(
 				userId,
 				noteId,
+				null,
 				"수정된 제목",
 				"수정된 내용",
 				NoteVisibility.PUBLIC,
@@ -373,8 +506,8 @@ public class NoteControllerTest {
 		Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<NoteSummaryResult> results = List.of(
-				new NoteSummaryResult(1L, "spring 제목", NoteVisibility.PUBLIC, true, null),
-				new NoteSummaryResult(2L, "기타 제목", NoteVisibility.PRIVATE, false, null)
+				new NoteSummaryResult(1L, null, "spring 제목", NoteVisibility.PUBLIC, true, null),
+				new NoteSummaryResult(2L, null, "기타 제목", NoteVisibility.PRIVATE, false, null)
 		);
 
 		Page<NoteSummaryResult> page = new PageImpl<>(results, pageable, results.size());

--- a/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
@@ -1,224 +1,361 @@
 package com.keepgoing.keepgoing.note.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class NoteTest {
 
-    // ========== create ==========
-    @Test
-    @DisplayName("create: 기본값이 잘 세팅 되는지 테스트")
-    void create_setsDefault() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .build();
+	public static final String DIR_NAME = "backend";
+	public static final String TITLE = "제목";
+	public static final String CONTENT = "내용";
 
-        String title = "제목";
-        String content = "내용";
+	private User createUser(Long id, String email, String name) {
+		return User.builder()
+				.id(id)
+				.email(email)
+				.name(name)
+				.build();
+	}
 
-        // when
-        Note note = Note.create(
-                author,
-                title,
-                content,
-                null,
-                true
-        );
+	// ========== create ==========
+	@Nested
+	@DisplayName("create")
+	class Create {
+		@Test
+		@DisplayName("기본값이 잘 세팅 되는지 테스트")
+		void create_setsDefault() {
+			// given
+			User author = User.builder()
+					.id(1L)
+					.build();
 
-        // then
-        assertThat(note.getAuthor()).isEqualTo(author);
-        assertThat(note.getTitle()).isEqualTo(title);
-        assertThat(note.getContent()).isEqualTo(content);
-        assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PRIVATE); // null일 때 기본값
-        assertThat(note.isAiCollectable()).isTrue();
-    }
+			String title = TITLE;
+			String content = CONTENT;
 
-    @Test
-    @DisplayName("create: visibility가 null이면 PRIVATE 기본값")
-    void create_defaultVisibilityWhenNull() {
-        //given
-        User author = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .name("테스트유저")
-                .build();
+			// when
+			Note note = Note.create(
+					author,
+					null,
+					title,
+					content,
+					null,
+					true
+			);
 
-        String title = "제목";
-        String content = "내용";
-        NoteVisibility visibility = null;
-        boolean aiCollectable = false;
+			// then
+			assertThat(note.getAuthor()).isEqualTo(author);
+			assertThat(note.getFolder()).isNull();
+			assertThat(note.getTitle()).isEqualTo(title);
+			assertThat(note.getContent()).isEqualTo(content);
+			assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PRIVATE); // null일 때 기본값
+			assertThat(note.isAiCollectable()).isTrue();
+		}
 
-        //when
-        Note note = Note.create(
-                author,
-                title,
-                content,
-                visibility,
-                aiCollectable
-        );
+		@Test
+		@DisplayName("visibility가 null이면 PRIVATE 기본값")
+		void create_defaultVisibilityWhenNull() {
+			//given
+			User author = User.builder()
+					.id(1L)
+					.email("test@example.com")
+					.name("테스트유저")
+					.build();
 
-        //then
-        assertThat(note.getAuthorId()).isEqualTo(1L);
-        assertThat(note.getTitle()).isEqualTo(title);
-        assertThat(note.getContent()).isEqualTo(content);
-        assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PRIVATE);
-        assertThat(note.isAiCollectable()).isFalse();
-    }
+			String title = TITLE;
+			String content = CONTENT;
+			boolean aiCollectable = false;
 
-    @Test
-    @DisplayName("create: visibility가 주어지면 그 값을 사용")
-    void create_useGivenVisibility() {
-        //given
-        User author = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .name("테스트유저")
-                .build();
+			//when
+			Note note = Note.create(
+					author,
+					null,
+					title,
+					content,
+					null,
+					aiCollectable
+			);
 
-        String title = "제목";
-        String content = "내용";
-        NoteVisibility visibility = NoteVisibility.PUBLIC;
-        boolean aiCollectable = false;
+			//then
+			assertThat(note.getAuthorId()).isEqualTo(1L);
+			assertThat(note.getTitle()).isEqualTo(title);
+			assertThat(note.getContent()).isEqualTo(content);
+			assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PRIVATE);
+			assertThat(note.isAiCollectable()).isFalse();
+		}
 
-        //when
-        Note note = Note.create(author, title, content, visibility, aiCollectable);
+		@Test
+		@DisplayName("visibility가 주어지면 그 값을 사용")
+		void create_useGivenVisibility() {
+			//given
+			User author = User.builder()
+					.id(1L)
+					.email("test@example.com")
+					.name("테스트유저")
+					.build();
 
-        //then
-        assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PUBLIC);
-        assertThat(note.isAiCollectable()).isFalse();
-    }
+			String title = TITLE;
+			String content = CONTENT;
+			NoteVisibility visibility = NoteVisibility.PUBLIC;
+			boolean aiCollectable = false;
 
-    // ========== update ==========
-    @Test
-    @DisplayName("update: 제목/내용/visibility/aiCollectable 변경")
-    void update_changeFields() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .build();
+			//when
+			Note note = Note.create(author, null, title, content, visibility, aiCollectable);
 
-        Note note = Note.create(
-                author,
-                "old title",
-                "old content",
-                NoteVisibility.PRIVATE,
-                true
-        );
+			//then
+			assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PUBLIC);
+			assertThat(note.isAiCollectable()).isFalse();
+		}
 
-        // when
-        note.update(
-                "new title",
-                "new content",
-                NoteVisibility.PUBLIC,
-                false);
+		@Test
+		@DisplayName("폴더 owner와 작성자가 같으면 해당 폴더로 노트를 생성한다.")
+		void create_createsNoteWhenFolderOwnerMatchesAuthor() {
+			// given
+			User author = createUser(1L, "test@example.com", "test");
+			Folder folder = Folder.create(author, null, DIR_NAME);
 
-        // then
-        assertThat(note.getTitle()).isEqualTo("new title");
-        assertThat(note.getContent()).isEqualTo("new content");
-        assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PUBLIC);
-        assertThat(note.isAiCollectable()).isFalse();
-    }
+			// when
+			Note note = Note.create(
+					author,
+					folder,
+					TITLE,
+					CONTENT,
+					NoteVisibility.PRIVATE,
+					false
+			);
 
-    // ========== softDelete ==========
-    @Test
-    @DisplayName("softDelete: deletedAt 채워지고 isDeleted true 반환")
-    void softDelete_setsDeletedAt() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .name("테스트유저")
-                .build();
+			// then
+			assertThat(note.getAuthor()).isEqualTo(author);
+			assertThat(note.getFolder()).isEqualTo(folder);
+			assertThat(note.getTitle()).isEqualTo(TITLE);
+			assertThat(note.getContent()).isEqualTo(CONTENT);
+			assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PRIVATE);
+			assertThat(note.isAiCollectable()).isFalse();
+		}
 
-        Note note = Note.create(
-                author,
-                "title",
-                "content",
-                NoteVisibility.PRIVATE,
-                true
-        );
+		@Test
+		@DisplayName("폴더 owner와 작성자가 다르면 FOLDER_ACCESS_DENIED 예외가 발생한다.")
+		void create_throwsWhenFolderOwnerDoesNotMatchAuthor() {
+			// given
+			Long authorId = 1L;
+			User author = createUser(authorId, "test@test.com", "test");
 
-        // when
-        note.softDelete();
+			Long otherAuthorId = 2L;
+			User otherAuthor = createUser(otherAuthorId, "other@other.com", "other");
 
-        // then
-        assertThat(note.isDeleted()).isTrue();
-        assertThat(note.getDeletedAt()).isNotNull();
-    }
+			Folder otherUserFolder = Folder.create(otherAuthor, null, DIR_NAME);
 
-    // ========== validateAuthor ==========
-    @Test
-    @DisplayName("validateAuthor: 작성자가 아니면 예외 발생")
-    void validateAuthor_throws_whenNotAuthor() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .email("a@a.com")
-                .name("작성자")
-                .build();
+			// when & then
+			assertThatThrownBy(() ->
+			{
+				Note.create(
+						author,
+						otherUserFolder,
+						TITLE,
+						CONTENT,
+						NoteVisibility.PRIVATE,
+						false
+				);
+			})
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+		}
 
-        Note note = Note.create(
-                author,
-                "title",
-                "content",
-                NoteVisibility.PRIVATE,
-                true
-        );
+		@Test
+		@DisplayName("작성자 ID가 없으면 INTERNAL_SERVER_ERROR 예외가 발생한다.")
+		void create_throwsWhenAuthorIdIsNull() {
+			// given
+			User author = User.create("test@test.com", "test");
 
-        // when & then
-        assertThatThrownBy(() -> note.validateAuthor(2L))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-    }
+			// when & then
+			assertThatThrownBy(() -> Note.create(
+					author,
+					null,
+					TITLE,
+					CONTENT,
+					NoteVisibility.PRIVATE,
+					false
+			))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+		}
 
-    // ========== isAuthor ==========
-    @Test
-    @DisplayName("isAuthor: 작성자인지 여부를 반환")
-    void isAuthor_returnsTrueOnlyForAuthor() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .email("a@a.com")
-                .name("작성자")
-                .build();
+		@Test
+		@DisplayName("제목이 비어있으면 INVALID_INPUT 예외가 발생한다.")
+		void create_throwsWhenTitleIsBlank() {
+			// given
+			User author = createUser(1L, "test@test.com", "test");
 
-        Note note = Note.create(
-                author,
-                "title",
-                "content",
-                NoteVisibility.PRIVATE,
-                true
-        );
+			// when & then
+			assertThatThrownBy(() -> Note.create(
+					author,
+					null,
+					"   ",
+					CONTENT,
+					NoteVisibility.PRIVATE,
+					false
+			))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+		}
 
-        // expect
-        assertThat(note.isAuthor(1L)).isTrue();
-        assertThat(note.isAuthor(2L)).isFalse();
-    }
+		@Test
+		@DisplayName("본문이 비어있으면 INVALID_INPUT 예외가 발생한다.")
+		void create_throwsWhenContentIsBlank() {
+			// given
+			User author = createUser(1L, "test@test.com", "test");
 
-    // ========== getAuthorId ==========
-    @Test
-    @DisplayName("getAuthorId: 작성자 ID를 정상적으로 반환")
-    void getAuthorId_returnsAuthorId() {
-        // given
-        User author = User.builder()
-                .id(1L)
-                .build();
+			// when & then
+			assertThatThrownBy(() -> Note.create(
+					author,
+					null,
+					TITLE,
+					"   ",
+					NoteVisibility.PRIVATE,
+					false
+			))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+		}
 
-        Note note = Note.create(
-                author,
-                "title",
-                "content",
-                NoteVisibility.PRIVATE,
-                true);
+	}
 
-        // when & then
-        assertThat(note.getAuthorId()).isEqualTo(1L);
-    }
+	// ========== update ==========
+	@Test
+	@DisplayName("update: 제목/내용/visibility/aiCollectable 변경")
+	void update_changeFields() {
+		// given
+		User author = User.builder()
+				.id(1L)
+				.build();
+
+		Note note = Note.create(
+				author,
+				null,
+				"old title",
+				"old content",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		// when
+		note.update(
+				"new title",
+				"new content",
+				NoteVisibility.PUBLIC,
+				false);
+
+		// then
+		assertThat(note.getTitle()).isEqualTo("new title");
+		assertThat(note.getContent()).isEqualTo("new content");
+		assertThat(note.getVisibility()).isEqualTo(NoteVisibility.PUBLIC);
+		assertThat(note.isAiCollectable()).isFalse();
+	}
+
+	// ========== softDelete ==========
+	@Test
+	@DisplayName("softDelete: deletedAt 채워지고 isDeleted true 반환")
+	void softDelete_setsDeletedAt() {
+		// given
+		User author = User.builder()
+				.id(1L)
+				.email("test@example.com")
+				.name("테스트유저")
+				.build();
+
+		Note note = Note.create(
+				author,
+				null,
+				"title",
+				"content",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		// when
+		note.softDelete();
+
+		// then
+		assertThat(note.isDeleted()).isTrue();
+		assertThat(note.getDeletedAt()).isNotNull();
+	}
+
+	// ========== validateAuthor ==========
+	@Test
+	@DisplayName("validateAuthor: 작성자가 아니면 예외 발생")
+	void validateAuthor_throws_whenNotAuthor() {
+		// given
+		User author = User.builder()
+				.id(1L)
+				.email("a@a.com")
+				.name("작성자")
+				.build();
+
+		Note note = Note.create(
+				author,
+				null,
+				"title",
+				"content",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		// when & then
+		assertThatThrownBy(() -> note.validateAuthor(2L))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+	}
+
+	// ========== isAuthor ==========
+	@Test
+	@DisplayName("isAuthor: 작성자인지 여부를 반환")
+	void isAuthor_returnsTrueOnlyForAuthor() {
+		// given
+		User author = User.builder()
+				.id(1L)
+				.email("a@a.com")
+				.name("작성자")
+				.build();
+
+		Note note = Note.create(
+				author,
+				null,
+				"title",
+				"content",
+				NoteVisibility.PRIVATE,
+				true
+		);
+
+		// expect
+		assertThat(note.isAuthor(1L)).isTrue();
+		assertThat(note.isAuthor(2L)).isFalse();
+	}
+
+	// ========== getAuthorId ==========
+	@Test
+	@DisplayName("getAuthorId: 작성자 ID를 정상적으로 반환")
+	void getAuthorId_returnsAuthorId() {
+		// given
+		User author = User.builder()
+				.id(1L)
+				.build();
+
+		Note note = Note.create(
+				author,
+				null,
+				"title",
+				"content",
+				NoteVisibility.PRIVATE,
+				true);
+
+		// when & then
+		assertThat(note.getAuthorId()).isEqualTo(1L);
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/repository/NoteRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/repository/NoteRepositoryTest.java
@@ -23,146 +23,150 @@ import org.springframework.data.domain.Sort;
 @Import(JpaAuditingConfig.class)
 class NoteRepositoryTest {
 
-    @Autowired
-    private NoteRepository noteRepository;
+	@Autowired
+	private NoteRepository noteRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+	@Autowired
+	private UserRepository userRepository;
 
-    private User user1;
-    private User user2;
+	private User user1;
+	private User user2;
 
-    @BeforeEach
-    void setUp() {
-        // 각 테스트 전에 데이터 초기화 및 설정
-        user1 = userRepository.save(User.builder().email("user1@test.com").name("유저1").build());
-        user2 = userRepository.save(User.builder().email("user2@test.com").name("유저2").build());
-    }
+	@BeforeEach
+	void setUp() {
+		// 각 테스트 전에 데이터 초기화 및 설정
+		user1 = userRepository.save(User.builder().email("user1@test.com").name("유저1").build());
+		user2 = userRepository.save(User.builder().email("user2@test.com").name("유저2").build());
+	}
 
-    private Pageable sortedByCreatedAtDesc(int size) {
-        return PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-    }
+	private Pageable sortedByCreatedAtDesc(int size) {
+		return PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+	}
 
-    // ========== findByAuthor_Id ==========
+	// ========== findByAuthor_Id ==========
 
-    @Test
-    @DisplayName("findByAuthor_Id: 특정 작성자의 게시글을 createdAt 내림차순으로 페이징 조회한다")
-    void findByAuthorId_returnsNotesSortedByCreatedAtDesc() {
-        // given
-        noteRepository.save(Note.create(user1, "제목1-1", "내용", NoteVisibility.PUBLIC, true));
+	@Test
+	@DisplayName("findByAuthor_Id: 특정 작성자의 게시글을 createdAt 내림차순으로 페이징 조회한다")
+	void findByAuthorId_returnsNotesSortedByCreatedAtDesc() {
+		// given
+		noteRepository.save(Note.create(user1, null, "제목1-1", "내용", NoteVisibility.PUBLIC, true));
 
-        // NOTE: createdAt 정렬 보장용 (나중에 id 정렬 등으로 리팩터링 후보)
-        try { Thread.sleep(10); } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        noteRepository.save(Note.create(user2, "제목2-1", "내용", NoteVisibility.PUBLIC, true)); // 다른 유저의 글
-        try { Thread.sleep(10); } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        noteRepository.save(Note.create(user1, "제목1-2", "내용", NoteVisibility.PUBLIC, true));
+		// NOTE: createdAt 정렬 보장용 (나중에 id 정렬 등으로 리팩터링 후보)
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		noteRepository.save(Note.create(user2, null, "제목2-1", "내용", NoteVisibility.PUBLIC, true)); // 다른 유저의 글
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		noteRepository.save(Note.create(user1, null, "제목1-2", "내용", NoteVisibility.PUBLIC, true));
 
-        Pageable pageable = sortedByCreatedAtDesc(10);
+		Pageable pageable = sortedByCreatedAtDesc(10);
 
-        // when
-        Page<Note> page = noteRepository.findByAuthor_Id(user1.getId(), pageable);
-        List<Note> result = page.getContent();
+		// when
+		Page<Note> page = noteRepository.findByAuthor_Id(user1.getId(), pageable);
+		List<Note> result = page.getContent();
 
-        // then
-        assertThat(page.getTotalElements()).isEqualTo(2);
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("제목1-2"); // 최신
-        assertThat(result.get(1).getTitle()).isEqualTo("제목1-1");
-    }
+		// then
+		assertThat(page.getTotalElements()).isEqualTo(2);
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).getTitle()).isEqualTo("제목1-2"); // 최신
+		assertThat(result.get(1).getTitle()).isEqualTo("제목1-1");
+	}
 
-    @Test
-    @DisplayName("findByAuthor_Id: 작성자의 게시글이 없으면 빈 리스트를 반환한다")
-    void findByAuthorId_returnsEmptyList_WhenNoPNote() {
-        // given
-        // user1이 작성한 글 없음
+	@Test
+	@DisplayName("findByAuthor_Id: 작성자의 게시글이 없으면 빈 리스트를 반환한다")
+	void findByAuthorId_returnsEmptyList_WhenNoPNote() {
+		// given
+		// user1이 작성한 글 없음
 
-        Pageable pageable = sortedByCreatedAtDesc(10);
+		Pageable pageable = sortedByCreatedAtDesc(10);
 
-        // when
-        List<Note> result = noteRepository.findByAuthor_Id(user1.getId(), pageable)
-                .getContent();
+		// when
+		List<Note> result = noteRepository.findByAuthor_Id(user1.getId(), pageable)
+				.getContent();
 
-        // then
-        assertThat(result).isEmpty();
-    }
+		// then
+		assertThat(result).isEmpty();
+	}
 
-    @Test
-    @DisplayName("findByAuthor_Id: soft delete 된 게시글은 조회되지 않는다")
-    void findByAuthorId_excludesSoftDeletedNotes() {
-        // given
-        Note note1 = noteRepository.save(Note.create(user1, "살아있는 글", "내용", NoteVisibility.PUBLIC, true));
-        Note note2 = noteRepository.save(Note.create(user1, "삭제된 글", "내용", NoteVisibility.PUBLIC, true));
+	@Test
+	@DisplayName("findByAuthor_Id: soft delete 된 게시글은 조회되지 않는다")
+	void findByAuthorId_excludesSoftDeletedNotes() {
+		// given
+		Note note1 = noteRepository.save(Note.create(user1, null, "살아있는 글", "내용", NoteVisibility.PUBLIC, true));
+		Note note2 = noteRepository.save(Note.create(user1, null, "삭제된 글", "내용", NoteVisibility.PUBLIC, true));
 
-        // soft delete
-        note2.softDelete();
-        noteRepository.save(note2); // 변경사항 반영
+		// soft delete
+		note2.softDelete();
+		noteRepository.save(note2); // 변경사항 반영
 
-        Pageable pageable = sortedByCreatedAtDesc(10);
+		Pageable pageable = sortedByCreatedAtDesc(10);
 
-        // when
-        List<Note> result = noteRepository.findByAuthor_Id(user1.getId(), pageable)
-                .getContent();
+		// when
+		List<Note> result = noteRepository.findByAuthor_Id(user1.getId(), pageable)
+				.getContent();
 
-        // then
-        assertThat(result)
-                .hasSize(1)
-                .extracting(Note::getTitle)
-                .containsExactly("살아있는 글");
-    }
+		// then
+		assertThat(result)
+				.hasSize(1)
+				.extracting(Note::getTitle)
+				.containsExactly("살아있는 글");
+	}
 
-    // ========== findById ==========
+	// ========== findById ==========
 
-    @Test
-    @DisplayName("findById: findById는 author를 함께 로딩한다(@EntityGraph)")
-    void findById_loadsAuthorWithEntityGraph() {
-        // given
-        User author = user1;
+	@Test
+	@DisplayName("findById: findById는 author를 함께 로딩한다(@EntityGraph)")
+	void findById_loadsAuthorWithEntityGraph() {
+		// given
+		User author = user1;
 
-        Note saved = noteRepository.save(Note.create(author, "title", "content", NoteVisibility.PRIVATE, true));
+		Note saved = noteRepository.save(Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true));
 
-        // when
-        Note found = noteRepository.findById(saved.getId())
-                .orElseThrow();
+		// when
+		Note found = noteRepository.findById(saved.getId())
+				.orElseThrow();
 
-        // then
-        assertThat(found.getAuthor().getId()).isEqualTo(author.getId());
-    }
+		// then
+		assertThat(found.getAuthor().getId()).isEqualTo(author.getId());
+	}
 
-    // ========== findByVisibilityOrderByCreatedAtDesc ==========
+	// ========== findByVisibilityOrderByCreatedAtDesc ==========
 
-    @Test
-    @DisplayName("findByVisibilityOrderByCreatedAtDesc: 공개 범위에 따라 필터링하고 최신순으로 정렬한다")
-    void findByVisibilityOrderByCreatedAtDesc() {
-        // given
-        noteRepository.save(Note.create(user1, "비공개글1", "내용", NoteVisibility.PRIVATE, true));
-        noteRepository.save(Note.create(user1, "비공개글2", "내용", NoteVisibility.PRIVATE, true));
-        noteRepository.save(Note.create(user1, "공개글1", "내용", NoteVisibility.PUBLIC, true));
-        noteRepository.save(Note.create(user2, "공개글2", "내용", NoteVisibility.PUBLIC, true));
+	@Test
+	@DisplayName("findByVisibilityOrderByCreatedAtDesc: 공개 범위에 따라 필터링하고 최신순으로 정렬한다")
+	void findByVisibilityOrderByCreatedAtDesc() {
+		// given
+		noteRepository.save(Note.create(user1, null, "비공개글1", "내용", NoteVisibility.PRIVATE, true));
+		noteRepository.save(Note.create(user1, null, "비공개글2", "내용", NoteVisibility.PRIVATE, true));
+		noteRepository.save(Note.create(user1, null, "공개글1", "내용", NoteVisibility.PUBLIC, true));
+		noteRepository.save(Note.create(user2, null, "공개글2", "내용", NoteVisibility.PUBLIC, true));
 
-        // when
-        List<Note> result = noteRepository.findByVisibilityOrderByCreatedAtDesc(NoteVisibility.PUBLIC);
+		// when
+		List<Note> result = noteRepository.findByVisibilityOrderByCreatedAtDesc(NoteVisibility.PUBLIC);
 
-        // then
-        assertThat(result).hasSize(2);
-        // 최신순 보장 (생성 순서의 역순)
-        assertThat(result.get(0).getTitle()).isEqualTo("공개글2");
-        assertThat(result.get(1).getTitle()).isEqualTo("공개글1");
-    }
+		// then
+		assertThat(result).hasSize(2);
+		// 최신순 보장 (생성 순서의 역순)
+		assertThat(result.get(0).getTitle()).isEqualTo("공개글2");
+		assertThat(result.get(1).getTitle()).isEqualTo("공개글1");
+	}
 
-    @Test
-    @DisplayName("findByVisibilityOrderByCreatedAtDesc: 해당 공개 범위의 게시글이 없으면 빈 리스트를 반환한다")
-    void findByVisibilityOrderByCreatedAtDesc_returnsEmptyListWhenNoNotes() {
-        // given
-        // PUBLIC 글 없음
+	@Test
+	@DisplayName("findByVisibilityOrderByCreatedAtDesc: 해당 공개 범위의 게시글이 없으면 빈 리스트를 반환한다")
+	void findByVisibilityOrderByCreatedAtDesc_returnsEmptyListWhenNoNotes() {
+		// given
+		// PUBLIC 글 없음
 
-        // when
-        List<Note> result = noteRepository.findByVisibilityOrderByCreatedAtDesc(NoteVisibility.PUBLIC);
+		// when
+		List<Note> result = noteRepository.findByVisibilityOrderByCreatedAtDesc(NoteVisibility.PUBLIC);
 
-        // then
-        assertThat(result).isEmpty();
-    }
+		// then
+		assertThat(result).isEmpty();
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -5,11 +5,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.Note;
@@ -20,9 +21,9 @@ import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
-import java.util.List;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,434 +37,567 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class NoteServiceTest {
 
-    @Mock
-    NoteRepository noteRepository;
-
-    @Mock
-    UserRepository userRepository;
-
-    @InjectMocks
-    NoteService noteService;
-
-    // ===== 테스트용 헬퍼 메서드들 =====
-
-    private User createUser(Long id) {
-        return User.builder()
-                .id(id)
-                .email("test@example.com")
-                .name("테스트유저")
-                .build();
-    }
-
-    // ========== createNote ==========
-
-    @Test
-    @DisplayName("createNote: 유저가 존재하면 게시글을 생성한다")
-    void createNote_createsNoteWhenUserExists() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-
-        String title = "제목";
-        String content = "내용";
-        NoteVisibility visibility = NoteVisibility.PRIVATE;
-        boolean aiCollectable = false;
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-        Note note = Note.create(
-                user,
-                title,
-                content,
-                visibility,
-                aiCollectable
-        );
-        given(noteRepository.save(any(Note.class))).willReturn(note);
-
-        NoteCreateCommand command = new NoteCreateCommand(
-                userId,
-                title,
-                content,
-                visibility,
-                aiCollectable
-        );
-
-        // when
-        NoteDetailResult result = noteService.createNote(command);
-
-        // then
-        assertThat(result.title()).isEqualTo(title);
-        assertThat(result.content()).isEqualTo(content);
-        assertThat(result.visibility()).isEqualTo(visibility);
-        assertThat(result.aiCollectable()).isEqualTo(aiCollectable);
-        verify(userRepository).findById(userId);
-        verify(noteRepository).save(any(Note.class));
-        verifyNoMoreInteractions(userRepository, noteRepository);
-    }
-
-    @Test
-    @DisplayName("createNote: 유저가 없으면 USER_NOT_FOUND 예외 발생")
-    void createNote_throwsWhenUserNotFound() {
-        // given
-        Long userId = 1L;
-        String title = "제목";
-        String content = "내용";
-        NoteVisibility visibility = NoteVisibility.PRIVATE;
-        boolean aiCollectable = false;
-
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
-
-        NoteCreateCommand command = new NoteCreateCommand(
-                userId,
-                title,
-                content,
-                visibility,
-                aiCollectable
-        );
-        // when & then
-        assertThatThrownBy(() -> noteService.createNote(command))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
-        verify(userRepository).findById(userId);
-        verifyNoInteractions(noteRepository);
-    }
-
-    // ========== getNote ==========
-
-    @Test
-    @DisplayName("getNote: 게시글이 존재하면 반환한다")
-    void getNote_returnsNoteWhenExists() {
-        // given
-        Long noteId = 1L;
-        User user = createUser(1L);
-        Note note = Note.create(user, "제목", "내용", NoteVisibility.PRIVATE, true);
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-        // when
-        NoteDetailResult result = noteService.getNote(noteId);
-
-        // then
-        assertThat(result.title()).isEqualTo("제목");
-        assertThat(result.content()).isEqualTo("내용");
-        assertThat(result.visibility()).isEqualTo(NoteVisibility.PRIVATE);
-
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("getNote: 게시글이 없으면 NOTE_NOT_FOUND 예외 발생")
-    void getNote_throwsWhenNotFound() {
-        // given
-        Long noteId = 1L;
-        given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> noteService.getNote(noteId))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-
-    }
-
-    // ========== getNotes ==========
-
-    @Test
-    @DisplayName("getNotes: 작성자 ID와 Pageable로 게시글 페이지를 가져온다")
-    void getNotes_returnsPage() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-
-        Note note1 = Note.create(user, "제목1", "내용1", NoteVisibility.PRIVATE, true);
-        Note note2 = Note.create(user, "제목2", "내용2", NoteVisibility.PUBLIC, true);
-        var notes = java.util.List.of(note1, note2);
-
-        Pageable pageable = PageRequest.of(
-                0,
-                10,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
-        Page<Note> notePage = new PageImpl<>(
-                notes,
-                pageable,
-                notes.size()
-        );
-
-        // 저장소가 페이지를 반환하는 동작을 스텁
-        given(noteRepository.findByAuthor_Id(userId, pageable))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.getNotes(userId, pageable);
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).title()).isEqualTo("제목1");
-        assertThat(result.getContent().get(1).title()).isEqualTo("제목2");
-        verify(noteRepository).findByAuthor_Id(userId, pageable);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    // ========== updateNote ==========
-
-    @Test
-    @DisplayName("updateNote: 작성자가 맞으면 게시글이 수정된다")
-    void updateNote_updatesWhenAuthorMatches() {
-        // given
-        Long userId = 1L;
-        Long noteId = 10L;
-
-        User user = createUser(userId);
-        Note note = Note.create(user, "old", "old", NoteVisibility.PRIVATE, true);
-
-        String newTitle = "수정 제목";
-        String newContent = "수정 내용";
-        NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-        boolean newAiCollectable = false;
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-        NoteUpdateCommand command = new NoteUpdateCommand(
-                noteId,
-                userId,
-                newTitle,
-                newContent,
-                newVisibility,
-                newAiCollectable
-        );
-
-        // when
-        NoteDetailResult result = noteService.updateNote(command);
-
-        // then
-        assertThat(result.title()).isEqualTo(newTitle);
-        assertThat(result.content()).isEqualTo(newContent);
-        assertThat(result.visibility()).isEqualTo(newVisibility);
-        assertThat(result.aiCollectable()).isEqualTo(newAiCollectable);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("updateNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
-    void updateNote_throwsWhenNoteNotFound() {
-        // given
-        Long userId = 1L;
-        Long noteId = 10L;
-
-        String newTitle = "수정 제목";
-        String newContent = "수정 내용";
-        NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-        boolean newAiCollectable = false;
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-        NoteUpdateCommand command = new NoteUpdateCommand(
-                noteId,
-                userId,
-                newTitle,
-                newContent,
-                newVisibility,
-                newAiCollectable
-        );
-
-        // when & then
-        assertThatThrownBy(() -> noteService.updateNote(command))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("updateNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
-    void updateNote_throwsWhenNotAuthor() {
-        // given
-        Long userId = 1L;
-        Long othersId = 2L;
-        Long noteId = 10L;
-
-        User user = createUser(othersId); // 실제 작성자는 2번
-        Note note = Note.create(user, "old", "old", NoteVisibility.PRIVATE, true);
-
-        String newTitle = "수정 제목";
-        String newContent = "수정 내용";
-        NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-        boolean newAiCollectable = false;
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-        NoteUpdateCommand command = new NoteUpdateCommand(
-                noteId,
-                userId,
-                newTitle,
-                newContent,
-                newVisibility,
-                newAiCollectable
-        );
-
-        // when & then
-        assertThatThrownBy(() -> noteService.updateNote(command))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    // ========== deleteNote ==========
-
-    @Test
-    @DisplayName("deleteNote: 작성자가 맞으면 softDelete 된다")
-    void deleteNote_softDeletesWhenAuthorMatches() {
-        // given
-        Long userId = 1L;
-        Long noteId = 10L;
-
-        User user = createUser(userId);
-        Note note = Note.create(user, "title", "content", NoteVisibility.PRIVATE, true);
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-        // when
-        noteService.deleteNote(userId, noteId);
-
-        // then
-        assertThat(note.isDeleted()).isTrue(); // isDeleted 없으면 deletedAt != null 로 체크
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("deleteNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
-    void deleteNote_throwsWhenNoteNotFound() {
-        // given
-        Long userId = 1L;
-        Long noteId = 10L;
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("deleteNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
-    void deleteNote_throwsWhenNotAuthor() {
-        // given
-        Long userId = 1L;
-        Long othersId = 2L;
-        Long noteId = 10L;
-
-        User user = createUser(othersId); // 작성자는 2번
-        Note note = Note.create(user, "title", "content", NoteVisibility.PRIVATE, true);
-
-        given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-        // when & then
-        assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-        verify(noteRepository).findById(noteId);
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    // ========== searchMyNotes ==========
-
-    @Test
-    @DisplayName("searchMyNotes: keyword가 있으면 검색 결과를 페이지로 반환한다")
-    void searchMyNotes_returnsPageWhenKeywordProvided() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-
-        Note note1 = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-        Note note2 = Note.create(user, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
-
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
-
-        NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
-
-        given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent()).hasSize(2);
-        verify(noteRepository).searchMyNotes(eq(userId), eq("spring"), any(Pageable.class));
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("searchMyNotes: keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외")
-    void searchMyNotes_throwsWhenKeywordBlank() {
-        // given
-        Long userId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
-
-        // when & then
-        assertThatThrownBy(() -> noteService.searchMyNotes(userId, query))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-
-        verifyNoInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
-    @Test
-    @DisplayName("searchMyNotes: keyword 앞뒤 공백은 trim되어 검색된다")
-    void searchMyNotes_trimsKeywordBeforeSearching() {
-        // given
-        Long userId = 1L;
-        User user = createUser(userId);
-        Note note = Note.create(user, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
-
-        NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
-
-        given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
-                .willReturn(notePage);
-
-        // when
-        Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(1);
-
-        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
-        verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
-        assertThat(keywordCaptor.getValue()).isEqualTo("spring");
-
-        verifyNoMoreInteractions(noteRepository);
-        verifyNoInteractions(userRepository);
-    }
-
+	public static final String DIRECTORY_NAME = "backend";
+	@Mock
+	NoteRepository noteRepository;
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	FolderRepository folderRepository;
+
+	@InjectMocks
+	NoteService noteService;
+
+	// ===== 테스트용 헬퍼 메서드들 =====
+
+	private User createUser(Long id) {
+		return User.builder()
+				.id(id)
+				.email("test@example.com")
+				.name("테스트유저")
+				.build();
+	}
+
+	// ========== createNote ==========
+
+	@Test
+	@DisplayName("createNote: folderId가 null이면 루트 노트를 생성한다.")
+	void createNote_createsRootNoteWhenFolderIdIsNull() {
+		// given
+		Long userId = 1L;
+		var command = NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(null)
+				.title("제목")
+				.content("내용")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(true)
+				.build();
+		User author = createUser(userId);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(author));
+		given(noteRepository.save(any(Note.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		NoteDetailResult result = noteService.createNote(command);
+
+		// then
+		ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
+		verify(noteRepository).save(noteCaptor.capture());
+
+		Note savedNote = noteCaptor.getValue();
+		assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
+		assertThat(savedNote.getFolder()).isNull();
+		assertThat(savedNote.getTitle()).isEqualTo(command.title());
+		assertThat(savedNote.getContent()).isEqualTo(command.content());
+		assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
+		assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
+
+		assertThat(result.userId()).isEqualTo(userId);
+		assertThat(result.title()).isEqualTo(command.title());
+		assertThat(result.folderId()).isNull();
+		assertThat(result.content()).isEqualTo(command.content());
+		assertThat(result.visibility()).isEqualTo(command.visibility());
+		assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
+
+		verify(userRepository).findById(userId);
+		verifyNoInteractions(folderRepository);
+		verifyNoMoreInteractions(userRepository, noteRepository);
+	}
+
+	@Test
+	@DisplayName("createNote: 유저가 없으면 USER_NOT_FOUND 예외 발생")
+	void createNote_throwsWhenUserNotFound() {
+		// given
+		Long userId = 1L;
+		String title = "제목";
+		String content = "내용";
+		NoteVisibility visibility = NoteVisibility.PRIVATE;
+		boolean aiCollectable = false;
+
+		given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+		NoteCreateCommand command = new NoteCreateCommand(
+				userId,
+				null,
+				title,
+				content,
+				visibility,
+				aiCollectable
+		);
+		// when & then
+		assertThatThrownBy(() -> noteService.createNote(command))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+		verify(userRepository).findById(userId);
+		verifyNoInteractions(noteRepository);
+	}
+
+
+	@Test
+	@DisplayName("createNote: 내 폴더가 주어지면 해당 폴더에 노트를 생성한다.")
+	void createNote_createsNoteWhenFolderExists() {
+		// given
+		Long userId = 1L;
+		User author = createUser(1L);
+
+		Folder folder = Folder.create(author, null, DIRECTORY_NAME);
+		ReflectionTestUtils.setField(folder, "id", 2L);
+
+		var command = NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(folder.getId())
+				.title("제목")
+				.content("내용")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(false)
+				.build();
+
+		given(userRepository.findById(command.userId()))
+				.willReturn(Optional.of(author));
+		given(folderRepository.findByIdAndDeletedAtIsNull(command.folderId()))
+				.willReturn(Optional.of(folder));
+		given(noteRepository.save(any(Note.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		NoteDetailResult result = noteService.createNote(command);
+
+		// then
+		ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
+		verify(noteRepository).save(noteCaptor.capture());
+
+		Note savedNote = noteCaptor.getValue();
+		assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
+		assertThat(savedNote.getFolder()).isNotNull();
+		assertThat(savedNote.getFolder().getId()).isEqualTo(folder.getId());
+		assertThat(savedNote.getTitle()).isEqualTo(command.title());
+		assertThat(savedNote.getContent()).isEqualTo(command.content());
+		assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
+		assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
+
+		assertThat(result.userId()).isEqualTo(userId);
+		assertThat(result.title()).isEqualTo(command.title());
+		assertThat(result.folderId()).isEqualTo(command.folderId());
+		assertThat(result.content()).isEqualTo(command.content());
+		assertThat(result.visibility()).isEqualTo(command.visibility());
+		assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
+		verify(userRepository).findById(userId);
+		verify(folderRepository).findByIdAndDeletedAtIsNull(folder.getId());
+		verify(noteRepository).save(any(Note.class));
+		verifyNoMoreInteractions(userRepository, noteRepository, folderRepository);
+	}
+
+	@Test
+	@DisplayName("createNote: 존재하지 않는 폴더면 FOLDER_NOT_FOUND 예외가 발생한다")
+	void createNote_throwsWhenFolderNotFound() {
+		// given
+		Long userId = 1L;
+		User author = createUser(1L);
+		var command = NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(2L)
+				.title("제목")
+				.content("내용")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(false)
+				.build();
+		given(userRepository.findById(command.userId()))
+				.willReturn(Optional.of(author));
+		given(folderRepository.findByIdAndDeletedAtIsNull(2L))
+				.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> noteService.createNote(command))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+		verify(userRepository).findById(command.userId());
+		verify(folderRepository).findByIdAndDeletedAtIsNull(2L);
+		verifyNoMoreInteractions(userRepository, folderRepository);
+		verifyNoInteractions(noteRepository);
+	}
+
+	@Test
+	@DisplayName("createNote: 다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+	void createNote_throwsWhenFolderOwnedByAnotherUser() {
+		// given
+		Long userId = 1L;
+		Long otherUserId = 2L;
+		Long folderId = 10L;
+		User author = createUser(1L);
+		User otherAuthor = createUser(otherUserId);
+		Folder folder = Folder.create(
+				otherAuthor,
+				null,
+				DIRECTORY_NAME
+		);
+		ReflectionTestUtils.setField(folder, "id", folderId);
+		var command = NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(folderId)
+				.title("제목")
+				.content("내용")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(false)
+				.build();
+		given(userRepository.findById(command.userId()))
+				.willReturn(Optional.of(author));
+		given(folderRepository.findByIdAndDeletedAtIsNull(folderId))
+				.willReturn(Optional.of(folder));
+
+		// when & then
+		assertThatThrownBy(() -> noteService.createNote(command))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+		verify(userRepository).findById(command.userId());
+		verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+		verifyNoMoreInteractions(userRepository, folderRepository);
+		verifyNoInteractions(noteRepository);
+	}
+
+	// ========== getNote ==========
+
+	@Test
+	@DisplayName("getNote: 게시글이 존재하면 반환한다")
+	void getNote_returnsNoteWhenExists() {
+		// given
+		Long noteId = 1L;
+		User user = createUser(1L);
+		Note note = Note.create(user, null, "제목", "내용", NoteVisibility.PRIVATE, true);
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+		// when
+		NoteDetailResult result = noteService.getNote(noteId);
+
+		// then
+		assertThat(result.title()).isEqualTo("제목");
+		assertThat(result.content()).isEqualTo("내용");
+		assertThat(result.visibility()).isEqualTo(NoteVisibility.PRIVATE);
+
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("getNote: 게시글이 없으면 NOTE_NOT_FOUND 예외 발생")
+	void getNote_throwsWhenNotFound() {
+		// given
+		Long noteId = 1L;
+		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> noteService.getNote(noteId))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+
+	}
+
+	// ========== getNotes ==========
+
+	@Test
+	@DisplayName("getNotes: 작성자 ID와 Pageable로 게시글 페이지를 가져온다")
+	void getNotes_returnsPage() {
+		// given
+		Long userId = 1L;
+		User user = createUser(userId);
+
+		Note note1 = Note.create(user, null, "제목1", "내용1", NoteVisibility.PRIVATE, true);
+		Note note2 = Note.create(user, null, "제목2", "내용2", NoteVisibility.PUBLIC, true);
+		var notes = java.util.List.of(note1, note2);
+
+		Pageable pageable = PageRequest.of(
+				0,
+				10,
+				Sort.by(Sort.Direction.DESC, "createdAt")
+		);
+		Page<Note> notePage = new PageImpl<>(
+				notes,
+				pageable,
+				notes.size()
+		);
+
+		// 저장소가 페이지를 반환하는 동작을 스텁
+		given(noteRepository.findByAuthor_Id(userId, pageable))
+				.willReturn(notePage);
+
+		// when
+		Page<NoteSummaryResult> result = noteService.getNotes(userId, pageable);
+
+		// then
+		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent()
+				.get(0)
+				.title()).isEqualTo("제목1");
+		assertThat(result.getContent()
+				.get(1)
+				.title()).isEqualTo("제목2");
+		verify(noteRepository).findByAuthor_Id(userId, pageable);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	// ========== updateNote ==========
+
+	@Test
+	@DisplayName("updateNote: 작성자가 맞으면 게시글이 수정된다")
+	void updateNote_updatesWhenAuthorMatches() {
+		// given
+		Long userId = 1L;
+		Long noteId = 10L;
+
+		User user = createUser(userId);
+		Note note = Note.create(user, null, "old", "old", NoteVisibility.PRIVATE, true);
+
+		String newTitle = "수정 제목";
+		String newContent = "수정 내용";
+		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
+		boolean newAiCollectable = false;
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+		NoteUpdateCommand command = new NoteUpdateCommand(
+				noteId,
+				userId,
+				newTitle,
+				newContent,
+				newVisibility,
+				newAiCollectable
+		);
+
+		// when
+		NoteDetailResult result = noteService.updateNote(command);
+
+		// then
+		assertThat(result.title()).isEqualTo(newTitle);
+		assertThat(result.content()).isEqualTo(newContent);
+		assertThat(result.visibility()).isEqualTo(newVisibility);
+		assertThat(result.aiCollectable()).isEqualTo(newAiCollectable);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("updateNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
+	void updateNote_throwsWhenNoteNotFound() {
+		// given
+		Long userId = 1L;
+		Long noteId = 10L;
+
+		String newTitle = "수정 제목";
+		String newContent = "수정 내용";
+		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
+		boolean newAiCollectable = false;
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+		NoteUpdateCommand command = new NoteUpdateCommand(
+				noteId,
+				userId,
+				newTitle,
+				newContent,
+				newVisibility,
+				newAiCollectable
+		);
+
+		// when & then
+		assertThatThrownBy(() -> noteService.updateNote(command))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("updateNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
+	void updateNote_throwsWhenNotAuthor() {
+		// given
+		Long userId = 1L;
+		Long othersId = 2L;
+		Long noteId = 10L;
+
+		User user = createUser(othersId); // 실제 작성자는 2번
+		Note note = Note.create(user, null, "old", "old", NoteVisibility.PRIVATE, true);
+
+		String newTitle = "수정 제목";
+		String newContent = "수정 내용";
+		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
+		boolean newAiCollectable = false;
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+		NoteUpdateCommand command = new NoteUpdateCommand(
+				noteId,
+				userId,
+				newTitle,
+				newContent,
+				newVisibility,
+				newAiCollectable
+		);
+
+		// when & then
+		assertThatThrownBy(() -> noteService.updateNote(command))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	// ========== deleteNote ==========
+
+	@Test
+	@DisplayName("deleteNote: 작성자가 맞으면 softDelete 된다")
+	void deleteNote_softDeletesWhenAuthorMatches() {
+		// given
+		Long userId = 1L;
+		Long noteId = 10L;
+
+		User user = createUser(userId);
+		Note note = Note.create(user, null, "title", "content", NoteVisibility.PRIVATE, true);
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+		// when
+		noteService.deleteNote(userId, noteId);
+
+		// then
+		assertThat(note.isDeleted()).isTrue(); // isDeleted 없으면 deletedAt != null 로 체크
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("deleteNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
+	void deleteNote_throwsWhenNoteNotFound() {
+		// given
+		Long userId = 1L;
+		Long noteId = 10L;
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("deleteNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
+	void deleteNote_throwsWhenNotAuthor() {
+		// given
+		Long userId = 1L;
+		Long othersId = 2L;
+		Long noteId = 10L;
+
+		User user = createUser(othersId); // 작성자는 2번
+		Note note = Note.create(user, null, "title", "content", NoteVisibility.PRIVATE, true);
+
+		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+		// when & then
+		assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+		verify(noteRepository).findById(noteId);
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	// ========== searchMyNotes ==========
+
+	@Test
+	@DisplayName("searchMyNotes: keyword가 있으면 검색 결과를 페이지로 반환한다")
+	void searchMyNotes_returnsPageWhenKeywordProvided() {
+		// given
+		Long userId = 1L;
+		User user = createUser(userId);
+
+		Note note1 = Note.create(user, null, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+		Note note2 = Note.create(user, null, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
+
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
+
+		NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
+
+		given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
+				.willReturn(notePage);
+
+		// when
+		Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
+
+		// then
+		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(result.getContent()).hasSize(2);
+		verify(noteRepository).searchMyNotes(eq(userId), eq("spring"), any(Pageable.class));
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("searchMyNotes: keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외")
+	void searchMyNotes_throwsWhenKeywordBlank() {
+		// given
+		Long userId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
+		NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
+
+		// when & then
+		assertThatThrownBy(() -> noteService.searchMyNotes(userId, query))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
+
+		verifyNoInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	@DisplayName("searchMyNotes: keyword 앞뒤 공백은 trim되어 검색된다")
+	void searchMyNotes_trimsKeywordBeforeSearching() {
+		// given
+		Long userId = 1L;
+		User user = createUser(userId);
+		Note note = Note.create(user, null, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+
+		Pageable pageable = PageRequest.of(0, 10);
+		Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
+
+		NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
+
+		given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
+				.willReturn(notePage);
+
+		// when
+		Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
+
+		// then
+		assertThat(result.getTotalElements()).isEqualTo(1);
+
+		ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+		verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
+		assertThat(keywordCaptor.getValue()).isEqualTo("spring");
+
+		verifyNoMoreInteractions(noteRepository);
+		verifyNoInteractions(userRepository);
+	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #57

### ✨ 반영 브랜치
feat/57 -> develop

### 📝 변경 사항
- [x] 노트 생성 요청에 optional `folderId`를 추가했습니다.
- [x] `folderId = null`이면 루트 노트로 생성되도록 반영했습니다.
- [x] 노트 생성 시 폴더 존재 여부 및 소유권을 검증하도록 반영했습니다.
- [x] 노트 상세/목록 응답에 `folderId`를 포함하도록 반영했습니다.
- [x] note-folder create 경로 관련 테스트와 OpenAPI 문서를 갱신했습니다.

### ➕ 추가 메모
- 이번 PR은 #57의 1차 범위로, note-folder 연관관계 중 create 중심 변경을 우선 반영합니다.
- note 수정 시 folder 변경 정책과 folder 기준 조회/검색은 후속 작업으로 분리합니다.
- `folderId`는 선택값이며, 미전달 또는 `null`이면 최상위 루트 소속으로 처리합니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- `./gradlew test --tests "*Note*"`
- 결과: BUILD SUCCESSFUL