### PR TITLE
[Folder] 폴더 트리 조회 API 추가

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
@@ -3,9 +3,11 @@ package com.keepgoing.keepgoing.folder.controller;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateResponse;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderSummaryResponse;
+import com.keepgoing.keepgoing.folder.controller.dto.FolderTreeNodeResponse;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +47,19 @@ public class FolderController {
 
 		List<FolderSummaryResponse> responses = results.stream()
 				.map(FolderSummaryResponse::from)
+				.toList();
+
+		return ResponseEntity.ok(ApiResponse.success(responses));
+	}
+
+	@GetMapping("/tree")
+	public ResponseEntity<ApiResponse<List<FolderTreeNodeResponse>>> getFolderTree(
+			@AuthenticationPrincipal Long userId
+	) {
+		List<FolderTreeNodeResult> results = folderService.getFolderTree(userId);
+
+		List<FolderTreeNodeResponse> responses = results.stream()
+				.map(FolderTreeNodeResponse::from)
 				.toList();
 
 		return ResponseEntity.ok(ApiResponse.success(responses));

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
@@ -5,10 +5,10 @@ import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
 import java.util.List;
 
 public record FolderTreeNodeResponse(
-        Long folderId,
-        Long parentId,
-        String name,
-        List<FolderTreeNodeResponse> children
+		Long folderId,
+		Long parentId,
+		String name,
+		List<FolderTreeNodeResponse> children
 ) {
 	private static final int DEFAULT_MAX_DEPTH = 200;
 
@@ -38,7 +38,8 @@ public record FolderTreeNodeResponse(
 
 		List<FolderTreeNodeResponse> children = (result.children() == null)
 				? List.of()
-				: result.children().stream()
+				: result.children()
+						.stream()
 						.map(child -> from(child, maxDepth, depth + 1))
 						.toList();
 

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
@@ -1,0 +1,21 @@
+package com.keepgoing.keepgoing.folder.controller.dto;
+
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
+
+import java.util.List;
+
+public record FolderTreeNodeResponse(
+        Long folderId,
+        Long parentId,
+        String name,
+        List<FolderTreeNodeResponse> children
+) {
+    public static FolderTreeNodeResponse from(FolderTreeNodeResult result) {
+        return new FolderTreeNodeResponse(
+                result.folderId(),
+                result.parentId(),
+                result.name(),
+                result.children().stream().map(FolderTreeNodeResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderTreeNodeResponse.java
@@ -10,12 +10,43 @@ public record FolderTreeNodeResponse(
         String name,
         List<FolderTreeNodeResponse> children
 ) {
-    public static FolderTreeNodeResponse from(FolderTreeNodeResult result) {
-        return new FolderTreeNodeResponse(
-                result.folderId(),
-                result.parentId(),
-                result.name(),
-                result.children().stream().map(FolderTreeNodeResponse::from).toList()
-        );
-    }
+	private static final int DEFAULT_MAX_DEPTH = 200;
+
+	public static FolderTreeNodeResponse from(FolderTreeNodeResult result) {
+		return from(result, DEFAULT_MAX_DEPTH);
+	}
+
+	public static FolderTreeNodeResponse from(FolderTreeNodeResult result, int maxDepth) {
+		return from(result, maxDepth, 0);
+	}
+
+	private static FolderTreeNodeResponse from(FolderTreeNodeResult result, int maxDepth, int depth) {
+		if (result == null) {
+			return null;
+		}
+		if (maxDepth < 0) {
+			throw new IllegalArgumentException("maxDepth must be >= 0");
+		}
+		if (depth >= maxDepth) {
+			return new FolderTreeNodeResponse(
+					result.folderId(),
+					result.parentId(),
+					result.name(),
+					List.of()
+			);
+		}
+
+		List<FolderTreeNodeResponse> children = (result.children() == null)
+				? List.of()
+				: result.children().stream()
+						.map(child -> from(child, maxDepth, depth + 1))
+						.toList();
+
+		return new FolderTreeNodeResponse(
+				result.folderId(),
+				result.parentId(),
+				result.name(),
+				children
+		);
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -1,7 +1,7 @@
 package com.keepgoing.keepgoing.folder.repository;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
-import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
+import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,7 +31,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			order by f.name ASC
 			""")
 	List<Folder> findChildFolders(@Param("ownerId") Long ownerId,
-								  @Param("parentId") Long parentId);
+	                              @Param("parentId") Long parentId);
 
 	@Query("""
 			select count(f) > 0
@@ -42,7 +42,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			 and f.deletedAt is null
 			""")
 	boolean existsRootFolder(@Param("userId") Long userId,
-							 @Param("name") String name);
+	                         @Param("name") String name);
 
 	@Query("""
 			select count(f) > 0
@@ -53,16 +53,16 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			 and f.deletedAt is null
 			""")
 	boolean existsChildFolder(@Param("userId") Long userId,
-							  @Param("parentId") Long parentId,
-							  @Param("name") String name);
+	                          @Param("parentId") Long parentId,
+	                          @Param("name") String name);
 
 	@Query("""
-    select new com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow(f.id, p.id, f.name)
-    from Folder f
-    left join f.parent p
-    where f.owner.id = :ownerId
-      and f.deletedAt is null
-    order by f.name asc
-    """)
+			select new com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow(f.id, p.id, f.name)
+			from Folder f
+			left join f.parent p
+			where f.owner.id = :ownerId
+			  and f.deletedAt is null
+			order by f.name asc
+			""")
 	List<FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -1,12 +1,12 @@
 package com.keepgoing.keepgoing.folder.repository;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
@@ -57,12 +57,12 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 							  @Param("name") String name);
 
 	@Query("""
-    select new com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow(f.id, p.id, f.name)
+    select new com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow(f.id, p.id, f.name)
     from Folder f
     left join f.parent p
     where f.owner.id = :ownerId
       and f.deletedAt is null
     order by f.name asc
     """)
-	List<com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
+	List<FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -55,4 +55,14 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	boolean existsChildFolder(@Param("userId") Long userId,
 							  @Param("parentId") Long parentId,
 							  @Param("name") String name);
+
+	@Query("""
+    select new com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow(f.id, p.id, f.name)
+    from Folder f
+    left join f.parent p
+    where f.owner.id = :ownerId
+      and f.deletedAt is null
+    order by f.name asc
+    """)
+	List<com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/dto/FolderTreeRow.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/dto/FolderTreeRow.java
@@ -1,0 +1,7 @@
+package com.keepgoing.keepgoing.folder.repository.dto;
+
+public record FolderTreeRow(
+		Long folderId,
+		Long parentId,
+		String name) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -2,18 +2,14 @@ package com.keepgoing.keepgoing.folder.service;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
-import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -21,13 +17,20 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FolderService {
 
 	private final UserRepository userRepository;
 	private final FolderRepository folderRepository;
+	private static final int MAX_TREE_DEPTH = 200;
 
 	@Transactional
 	public FolderSummaryResult createFolder(FolderCreateCommand command) {
@@ -54,7 +57,8 @@ public class FolderService {
 
 		return new FolderSummaryResult(
 				saved.getId(),
-				saved.getParent() != null ? saved.getParent().getId() : null,
+				saved.getParent() != null ? saved.getParent()
+						.getId() : null,
 				saved.getName());
 	}
 
@@ -75,7 +79,8 @@ public class FolderService {
 		return folders.stream()
 				.map(f -> new FolderSummaryResult(
 						f.getId(),
-						f.getParent() != null ? f.getParent().getId() : null,
+						f.getParent() != null ? f.getParent()
+								.getId() : null,
 						f.getName()
 				))
 				.toList();
@@ -114,9 +119,14 @@ public class FolderService {
 		}
 
 		roots.sort(Comparator.comparing(n -> n.name));
+		AtomicBoolean truncated = new AtomicBoolean(false);
 		List<FolderTreeNodeResult> results = roots.stream()
-				.map(r -> toResult(r, new HashSet<>()))
+				.map(r -> toResult(r, new HashSet<>(), 0, truncated))
 				.toList();
+
+		if (truncated.get()) {
+			log.warn("folder tree truncated: userId={}, maxDepth={} (children cut)", userId, MAX_TREE_DEPTH);
+		}
 
 		return List.copyOf(results);
 	}
@@ -135,14 +145,23 @@ public class FolderService {
 	}
 
 
-	private FolderTreeNodeResult toResult(Node node, Set<Long> visiting) {
+	private FolderTreeNodeResult toResult(Node node, Set<Long> visiting, int depth, AtomicBoolean truncated) {
+		// depth guard
+		if (depth >= MAX_TREE_DEPTH) {
+			truncated.set(true);
+			return new FolderTreeNodeResult(node.id, node.parentId, node.name, List.of());
+		}
+
+		// cycle guard
 		if (!visiting.add(node.id)) {
+			truncated.set(true);
+			log.warn("folder tree cycle detected: nodeId={} (children cut)", node.id);
 			return new FolderTreeNodeResult(node.id, node.parentId, node.name, List.of());
 		}
 
 		node.children.sort(Comparator.comparing(n -> n.name));
 		List<FolderTreeNodeResult> children = node.children.stream()
-				.map(c -> toResult(c, visiting))
+				.map(c -> toResult(c, visiting, depth + 1, truncated))
 				.toList();
 
 		visiting.remove(node.id);

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -4,6 +4,8 @@ import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -12,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -71,5 +76,51 @@ public class FolderService {
 						f.getName()
 				))
 				.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<FolderTreeNodeResult> getFolderTree(Long userId) {
+		List<FolderTreeRow> rows = folderRepository.findTreeRows(userId);
+
+		Map<Long, FolderTreeNodeResult> nodes = new LinkedHashMap<>();
+		for (FolderTreeRow r : rows) {
+			nodes.put(r.folderId(), new FolderTreeNodeResult(
+					r.folderId(),
+					r.parentId(),
+					r.name(),
+					new ArrayList<>()
+			));
+		}
+
+		List<FolderTreeNodeResult> roots = new ArrayList<>();
+		for (FolderTreeNodeResult node : nodes.values()) {
+			Long parentId = node.parentId();
+			if (parentId == null) {
+				roots.add(node);
+				continue;
+			}
+
+			FolderTreeNodeResult parent = nodes.get(parentId);
+			// 부모가 soft delete 등으로 조회 대상에서 빠졌다면(데이터 불일치), 루트로 취급
+			if (parent == null) {
+				roots.add(node);
+				continue;
+			}
+
+			parent.children().add(node);
+		}
+
+		// 4) 정렬 보장: Repository 정렬에 의존하지 않고, 각 레벨에서 name ASC로 정렬
+		sortTreeByName(roots);
+
+		return roots;
+	}
+
+
+	private void sortTreeByName(List<FolderTreeNodeResult> nodes) {
+		nodes.sort(java.util.Comparator.comparing(FolderTreeNodeResult::name));
+		for (FolderTreeNodeResult n : nodes) {
+			sortTreeByName(n.children());
+		}
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -15,9 +15,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -82,45 +85,67 @@ public class FolderService {
 	public List<FolderTreeNodeResult> getFolderTree(Long userId) {
 		List<FolderTreeRow> rows = folderRepository.findTreeRows(userId);
 
-		Map<Long, FolderTreeNodeResult> nodes = new LinkedHashMap<>();
+		if (rows == null || rows.isEmpty()) {
+			return List.of();
+		}
+		Map<Long, Node> nodes = new LinkedHashMap<>();
 		for (FolderTreeRow r : rows) {
-			nodes.put(r.folderId(), new FolderTreeNodeResult(
-					r.folderId(),
-					r.parentId(),
-					r.name(),
-					new ArrayList<>()
-			));
+			nodes.put(r.folderId(), new Node(r.folderId(), r.parentId(), r.name()));
 		}
 
-		List<FolderTreeNodeResult> roots = new ArrayList<>();
-		for (FolderTreeNodeResult node : nodes.values()) {
-			Long parentId = node.parentId();
+		// 2) parentId 기반으로 children 연결
+		List<Node> roots = new ArrayList<>();
+		for (Node node : nodes.values()) {
+			Long parentId = node.parentId;
+
 			if (parentId == null) {
 				roots.add(node);
 				continue;
 			}
+			Node parent = nodes.get(parentId);
 
-			FolderTreeNodeResult parent = nodes.get(parentId);
 			// 부모가 soft delete 등으로 조회 대상에서 빠졌다면(데이터 불일치), 루트로 취급
 			if (parent == null) {
 				roots.add(node);
 				continue;
 			}
 
-			parent.children().add(node);
+			parent.children.add(node);
 		}
 
-		// 4) 정렬 보장: Repository 정렬에 의존하지 않고, 각 레벨에서 name ASC로 정렬
-		sortTreeByName(roots);
+		roots.sort(Comparator.comparing(n -> n.name));
+		List<FolderTreeNodeResult> results = roots.stream()
+				.map(r -> toResult(r, new HashSet<>()))
+				.toList();
 
-		return roots;
+		return List.copyOf(results);
+	}
+
+	private static class Node {
+		final Long id;
+		final Long parentId;
+		final String name;
+		final List<Node> children = new ArrayList<>();
+
+		Node(Long id, Long parentId, String name) {
+			this.id = id;
+			this.parentId = parentId;
+			this.name = name;
+		}
 	}
 
 
-	private void sortTreeByName(List<FolderTreeNodeResult> nodes) {
-		nodes.sort(java.util.Comparator.comparing(FolderTreeNodeResult::name));
-		for (FolderTreeNodeResult n : nodes) {
-			sortTreeByName(n.children());
+	private FolderTreeNodeResult toResult(Node node, Set<Long> visiting) {
+		if (!visiting.add(node.id)) {
+			return new FolderTreeNodeResult(node.id, node.parentId, node.name, List.of());
 		}
+
+		node.children.sort(Comparator.comparing(n -> n.name));
+		List<FolderTreeNodeResult> children = node.children.stream()
+				.map(c -> toResult(c, visiting))
+				.toList();
+
+		visiting.remove(node.id);
+		return new FolderTreeNodeResult(node.id, node.parentId, node.name, List.copyOf(children));
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderSummaryResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderSummaryResult.java
@@ -5,5 +5,4 @@ public record FolderSummaryResult(
 		Long parentId,
 		String name
 ) {
-
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeNodeResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeNodeResult.java
@@ -1,0 +1,11 @@
+package com.keepgoing.keepgoing.folder.service.dto;
+
+import java.util.List;
+
+public record FolderTreeNodeResult (
+        Long folderId,
+        Long parentId,
+        String name,
+        List<FolderTreeNodeResult> children
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeRow.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeRow.java
@@ -1,0 +1,8 @@
+package com.keepgoing.keepgoing.folder.service.dto;
+
+public record FolderTreeRow(
+        Long folderId,
+        Long parentId,
+        String name
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeRow.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderTreeRow.java
@@ -1,8 +1,0 @@
-package com.keepgoing.keepgoing.folder.service.dto;
-
-public record FolderTreeRow(
-        Long folderId,
-        Long parentId,
-        String name
-) {
-}

--- a/src/test/http/folder-api.http
+++ b/src/test/http/folder-api.http
@@ -51,3 +51,7 @@ Cookie: {{cookies}}
 ### 5) 특정 parentId의 자식 목록 조회
 GET {{host}}/api/folders?parentId=1
 Cookie: {{cookies}}
+
+### 6) 폴더 트리 조회
+GET {{host}}/api/folders/tree
+Cookie: {{cookies}}

--- a/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
@@ -15,6 +15,7 @@ import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
@@ -220,6 +221,35 @@ class FolderControllerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("GET /api/folders/tree")
+	class GetFolderTree {
+
+		@Test
+		@DisplayName("전체 트리 조회를 200 OK로 반환한다.")
+		void getFolderTree_returnOk() throws Exception {
+			//given
+			Long userId = 1L;
+			mockLoginUser(userId);
+
+			FolderTreeNodeResult spring = new FolderTreeNodeResult(2L, 1L, "spring", List.of());
+			FolderTreeNodeResult study = new FolderTreeNodeResult(1L, null, "공부", List.of(spring));
+
+			given(folderService.getFolderTree(userId)).willReturn(List.of(study));
+
+			//when & then
+			mockMvc.perform(get("/api/folders/tree"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data[0].folderId").value(1L))
+					.andExpect(jsonPath("$.data[0].name").value("공부"))
+					.andExpect(jsonPath("$.data[0].children[0].folderId").value(2L))
+					.andExpect(jsonPath("$.data[0].children[0].parentId").value(1L))
+					.andExpect(jsonPath("$.data[0].children[0].name").value("spring"));
+
+			verify(folderService).getFolderTree(userId);
+		}
+	}
 
 	private void mockLoginUser(Long userId) {
 

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -43,8 +43,8 @@ public class FolderRepositoryTest {
 	}
 
 	@Nested
-	@DisplayName("findFolders")
-	class findFolders {
+	@DisplayName("FindFolders")
+	class FindFolders {
 
 		@Test
 		@DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -4,7 +4,7 @@ package com.keepgoing.keepgoing.folder.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
-import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
+import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.config.JpaAuditingConfig;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
@@ -120,7 +120,8 @@ public class FolderRepositoryTest {
 			List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
 
 			// then
-			assertThat(rows).extracting(FolderTreeRow::name).containsExactly("A", "AA", "B");
+			assertThat(rows).extracting(FolderTreeRow::name)
+					.containsExactly("A", "AA", "B");
 
 			FolderTreeRow aRow = rows.stream()
 					.filter(r -> r.folderId()

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -1,0 +1,140 @@
+package com.keepgoing.keepgoing.folder.repository;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
+import com.keepgoing.keepgoing.global.config.JpaAuditingConfig;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+public class FolderRepositoryTest {
+
+	@Autowired
+	private FolderRepository folderRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private User user1;
+	private User user2;
+
+	@BeforeEach
+	void setUp() {
+		user1 = userRepository.save(User.builder()
+				.email("user1@test.com")
+				.name("유저1")
+				.build());
+		user2 = userRepository.save(User.builder()
+				.email("user2@test.com")
+				.name("유저2")
+				.build());
+	}
+
+	@Nested
+	@DisplayName("findFolders")
+	class findFolders {
+
+		@Test
+		@DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+		void findRootFolders_ordersByName_and_excludesDeleted() {
+			// given
+			Folder a = folderRepository.save(Folder.create(user1, null, "a"));
+			Folder b = folderRepository.save(Folder.create(user1, null, "b"));
+			Folder other = folderRepository.save(Folder.create(user2, null, "aa"));
+
+			Folder deleted = folderRepository.save(Folder.create(user1, null, "c"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
+
+			// when
+			List<Folder> result = folderRepository.findRootFolders(user1.getId());
+
+			// then
+			assertThat(result).extracting(Folder::getName)
+					.containsExactly("a", "b");
+		}
+
+		@Test
+		@DisplayName("findChildFolders: 특정 parent의 자식 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+		void findChildFolders_ordersByName_and_excludesDeleted() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+
+			Folder c1 = folderRepository.save(Folder.create(user1, parent, "backend"));
+			Folder c2 = folderRepository.save(Folder.create(user1, parent, "frontend"));
+			Folder otherUserChild = folderRepository.save(Folder.create(user2, parent, "zzz"));
+
+			Folder deleted = folderRepository.save(Folder.create(user1, parent, "old"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
+
+			// when
+			List<Folder> result = folderRepository.findChildFolders(user1.getId(), parent.getId());
+
+			// then
+			assertThat(result).extracting(Folder::getName)
+					.containsExactly("backend", "frontend");
+
+		}
+
+		@Test
+		@DisplayName("existChildFolder: 내 동일 parent 아래 같은 이름이 있으면 true를 반환한다")
+		void existsChildFolder_works() {
+			//given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+			folderRepository.save(Folder.create(user1, parent, "spring"));
+
+			// expect
+			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "spring")).isTrue();
+			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "DB")).isFalse();
+			assertThat(folderRepository.existsChildFolder(user2.getId(), parent.getId(), "spring")).isFalse();
+		}
+
+		@Test
+		@DisplayName("findTreeRows: 루트 포함 + parentId 매핑 + name ASC + soft delete 제외")
+		void findTreeRows_includesRoot_and_mapsParentId_and_ordersByName() {
+			// given
+			Folder rootA = folderRepository.save(Folder.create(user1, null, "A"));
+			Folder rootB = folderRepository.save(Folder.create(user1, null, "B"));
+			Folder child = folderRepository.save(Folder.create(user1, rootA, "AA"));
+
+			Folder deleted = folderRepository.save(Folder.create(user1, null, "C"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
+
+			folderRepository.save(Folder.create(user2, null, "2"));
+
+			// when
+			List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
+
+			// then
+			assertThat(rows).extracting(FolderTreeRow::name).containsExactly("A", "AA", "B");
+
+			FolderTreeRow aRow = rows.stream()
+					.filter(r -> r.folderId()
+							.equals(rootA.getId()))
+					.findFirst()
+					.orElseThrow();
+			assertThat(aRow.parentId()).isNull();
+
+			FolderTreeRow aaRow = rows.stream()
+					.filter(r -> r.folderId()
+							.equals(child.getId()))
+					.findFirst()
+					.orElseThrow();
+			assertThat(aaRow.parentId()).isEqualTo(rootA.getId());
+		}
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -5,6 +5,8 @@ import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
+import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -341,6 +343,87 @@ class FolderServiceTest {
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
 			verifyNoMoreInteractions(folderRepository);
+		}
+	}
+	@Nested
+	@DisplayName("getFolderTree()")
+	class GetFolderTree {
+
+		@Test
+		@DisplayName("전체 폴더를 1번 조회해서 parentId 기반 트리 구조로 조립한다.")
+		void getFolderTree_buildsTreeFromRows() {
+			// given
+			Long userId = 1L;
+
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(1L, null, "공부"),
+					new FolderTreeRow(2L, 1L, "Spring"),
+					new FolderTreeRow(3L, 1L, "DB"),
+					new FolderTreeRow(4L, null, "개인"),
+					new FolderTreeRow(5L, 4L, "일기")
+			));
+
+			// when
+			var roots = folderService.getFolderTree(userId);
+
+			// then
+			assertThat(roots).hasSize(2);
+
+			assertThat(roots).extracting(FolderTreeNodeResult::folderId)
+					.containsExactlyInAnyOrder(1L, 4L);
+
+			FolderTreeNodeResult study = roots.stream()
+					.filter(r -> r.folderId().equals(1L))
+					.findFirst()
+					.orElseThrow();
+			assertThat(study.children()).extracting(FolderTreeNodeResult::folderId)
+					.containsExactly(3L, 2L);
+
+			FolderTreeNodeResult personal = roots.stream()
+					.filter(r -> r.folderId().equals(4L))
+					.findFirst()
+					.orElseThrow();
+			assertThat(personal.children()).extracting(FolderTreeNodeResult::folderId)
+					.containsExactly(5L);
+
+			verify(folderRepository).findTreeRows(userId);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 빈 트리를 반환한다.")
+		void getFolderTree_returnsEmptyWhenNoFolders() {
+			// given
+			Long userId = 1L;
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of());
+
+			// when
+			var roots = folderService.getFolderTree(userId);
+
+			// then
+			assertThat(roots).isEmpty();
+			verify(folderRepository).findTreeRows(userId);
+		}
+
+		@Test
+		@DisplayName("부모가 조회 대상에 없으면(데이터 불일치) 해당 노드를 루트로 취급한다.")
+		void getFolderTree_treatsOrphanAsRootWhenParentMissing() {
+			// given
+			Long userId = 1L;
+			// parentId=999는 rows에 없음
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(1L, null, "A"),
+					new FolderTreeRow(2L, 999L, "Orphan")
+			));
+
+			// when
+			var roots = folderService.getFolderTree(userId);
+
+			// then
+			assertThat(roots).hasSize(2);
+			assertThat(roots).extracting(FolderTreeNodeResult::folderId).containsExactly(1L, 2L);
+			assertThat(roots.get(1).parentId()).isEqualTo(999L);
+			assertThat(roots.get(1).children()).isEmpty();
+			verify(folderRepository).findTreeRows(userId);
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -1,16 +1,27 @@
 package com.keepgoing.keepgoing.folder.service;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
-import com.keepgoing.keepgoing.folder.service.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,16 +30,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class FolderServiceTest {
@@ -264,10 +265,14 @@ class FolderServiceTest {
 
 			//then
 			assertThat(results).hasSize(2);
-			assertThat(results.get(0).name()).isEqualTo("a");
-			assertThat(results.get(1).name()).isEqualTo("b");
-			assertThat(results.get(0).parentId()).isNull();
-			assertThat(results.get(1).parentId()).isNull();
+			assertThat(results.get(0)
+					.name()).isEqualTo("a");
+			assertThat(results.get(1)
+					.name()).isEqualTo("b");
+			assertThat(results.get(0)
+					.parentId()).isNull();
+			assertThat(results.get(1)
+					.parentId()).isNull();
 
 			verify(folderRepository).findRootFolders(userId);
 			verifyNoMoreInteractions(folderRepository);
@@ -297,10 +302,14 @@ class FolderServiceTest {
 
 			//then
 			assertThat(results).hasSize(2);
-			assertThat(results.get(0).parentId()).isEqualTo(parentId);
-			assertThat(results.get(1).parentId()).isEqualTo(parentId);
-			assertThat(results.get(0).name()).isEqualTo("backend");
-			assertThat(results.get(1).name()).isEqualTo("frontend");
+			assertThat(results.get(0)
+					.parentId()).isEqualTo(parentId);
+			assertThat(results.get(1)
+					.parentId()).isEqualTo(parentId);
+			assertThat(results.get(0)
+					.name()).isEqualTo("backend");
+			assertThat(results.get(1)
+					.name()).isEqualTo("frontend");
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
 			verify(folderRepository).findChildFolders(userId, parentId);
@@ -345,6 +354,7 @@ class FolderServiceTest {
 			verifyNoMoreInteractions(folderRepository);
 		}
 	}
+
 	@Nested
 	@DisplayName("getFolderTree()")
 	class GetFolderTree {
@@ -373,14 +383,16 @@ class FolderServiceTest {
 					.containsExactlyInAnyOrder(1L, 4L);
 
 			FolderTreeNodeResult study = roots.stream()
-					.filter(r -> r.folderId().equals(1L))
+					.filter(r -> r.folderId()
+							.equals(1L))
 					.findFirst()
 					.orElseThrow();
 			assertThat(study.children()).extracting(FolderTreeNodeResult::folderId)
 					.containsExactly(3L, 2L);
 
 			FolderTreeNodeResult personal = roots.stream()
-					.filter(r -> r.folderId().equals(4L))
+					.filter(r -> r.folderId()
+							.equals(4L))
 					.findFirst()
 					.orElseThrow();
 			assertThat(personal.children()).extracting(FolderTreeNodeResult::folderId)
@@ -420,9 +432,48 @@ class FolderServiceTest {
 
 			// then
 			assertThat(roots).hasSize(2);
-			assertThat(roots).extracting(FolderTreeNodeResult::folderId).containsExactly(1L, 2L);
-			assertThat(roots.get(1).parentId()).isEqualTo(999L);
-			assertThat(roots.get(1).children()).isEmpty();
+			assertThat(roots).extracting(FolderTreeNodeResult::folderId)
+					.containsExactly(1L, 2L);
+			assertThat(roots.get(1)
+					.parentId()).isEqualTo(999L);
+			assertThat(roots.get(1)
+					.children()).isEmpty();
+			verify(folderRepository).findTreeRows(userId);
+		}
+
+		@Test
+		@DisplayName("트리 깊이가 비정상적으로 깊으면 MAX_TREE_DEPTH에서 잘라서 반환한다.")
+		void getFolderTree_truncatesWhenDepthTooDeep() {
+			// given
+			Long userId = 1L;
+			int maxDepth = (int) ReflectionTestUtils.getField(FolderService.class, "MAX_TREE_DEPTH");
+			int chainLen = maxDepth + 5;
+
+			List<FolderTreeRow> rows = new ArrayList<>(chainLen);
+			rows.add(new FolderTreeRow(1L, null, "root"));
+			for (int i = 2; i <= chainLen; i++) {
+				rows.add(new FolderTreeRow((long) i, (long) (i - 1), "n" + i));
+			}
+
+			given(folderRepository.findTreeRows(userId)).willReturn(rows);
+
+			// when
+			List<FolderTreeNodeResult> roots = folderService.getFolderTree(userId);
+
+			// then
+			assertThat(roots).hasSize(1);
+
+			FolderTreeNodeResult current = roots.get(0);
+
+			for (int d = 0; d < maxDepth; d++) {
+				assertThat(current.children())
+						.as("depth=%s에서 child가 1개 존재해야 한다", d)
+						.hasSize(1);
+				current = current.children().get(0);
+			}
+
+			assertThat(current.children()).isEmpty();
+
 			verify(folderRepository).findTreeRows(userId);
 		}
 	}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #52 

### ✨ 반영 브랜치
feat/52-folder-tree -> develop

### 📝 변경 사항
- [x] 폴더 트리 조회 API 추가
  - `GET /api/folders/tree`
  - 내 폴더 전체를 1회 조회한 뒤(parentId 기반) 트리 구조로 조립하여 반환
- [x] 트리 조회용 Repository Query 추가
  - `findTreeRows(ownerId)` : `LEFT JOIN` 기반으로 루트(parent=null) 포함
  - soft delete(`deletedAt is null`) 조건 포함
- [x] 트리 응답/서비스 DTO 추가
  - `FolderTreeRow`, `FolderTreeNodeResult`, `FolderTreeNodeResponse`
- [x] 정렬 안정성 보강
  - 각 레벨에서 `name ASC`로 정렬을 보장하도록 서비스에서 트리 정렬 처리
- [x] 테스트 보강
  - Service: 트리 조립/빈 결과/고아 노드(부모 누락) 처리 검증
  - Controller: `/api/folders/tree` 응답 포맷 및 200 OK 검증
  - Repository: 트리 row 조회 계약(루트 포함/parentId 매핑/정렬) 검증
- [x] HTTP 스크립트 보강
  - `src/test/http/folder-api.http`에 트리 조회 요청 추가

### ➕ 추가 메모
- Repository에서 `order by name asc`로 기본 정렬을 제공하고,
  Service에서 레벨별 정렬을 한 번 더 적용하여 결과 정렬을 확실히 보장했습니다(방어적 구현).
- 트리 조회는 “전체 트리 반환” 방식이며, 추후 폴더 규모가 커질 경우 `depth` 옵션 또는 lazy-load 방식으로 확장 가능합니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- [x] `./gradlew test --tests "*Folder*"` 성공
