### PR TITLE
[Note] #69 public 노트 조회 정책 반영

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
@@ -67,8 +67,11 @@ public class NoteController {
      * 단일 노트 조회
      */
     @GetMapping("/{noteId}")
-    public ResponseEntity<ApiResponse<NoteDetailResponse>> getNote(@PathVariable Long noteId) {
-        NoteDetailResult note = noteService.getNote(noteId);
+    public ResponseEntity<ApiResponse<NoteDetailResponse>> getNote(
+			@PathVariable Long noteId,
+			@AuthenticationPrincipal Long userId
+    ) {
+        NoteDetailResult note = noteService.getNote(userId, noteId);
 
         return ResponseEntity.ok(ApiResponse.success(NoteDetailResponse.from(note)));
     }
@@ -156,7 +159,7 @@ public class NoteController {
     ) {
         Pageable safePageable = safePageableUnsorted(pageable);
 
-        Page<NoteSummaryResult> page = noteService.searchNote(
+        Page<NoteSummaryResult> page = noteService.searchPublicNote(
                 new NoteSearchQuery(keyword, safePageable)
         );
 

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
@@ -159,7 +159,7 @@ public class NoteController {
 	) {
 		Pageable safePageable = safePageableUnsorted(pageable);
 
-		Page<NoteSummaryResult> page = noteService.searchPublicNote(
+		Page<NoteSummaryResult> page = noteService.searchPublicNotes(
 				new NoteSearchQuery(keyword, safePageable)
 		);
 

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
@@ -43,164 +43,164 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class NoteController {
 
-    private static final int MAX_PAGE_SIZE = 100;
+	private static final int MAX_PAGE_SIZE = 100;
 
-    private final NoteService noteService;
+	private final NoteService noteService;
 
-    /**
-     * 노트 생성
-     */
-    @PostMapping
-    public ResponseEntity<ApiResponse<NoteDetailResponse>> createNote(
-            @RequestBody @Valid NoteCreateRequest request,
-            @AuthenticationPrincipal Long userId
-    ) {
-        NoteCreateCommand command = request.toCommand(userId);
+	/**
+	 * 노트 생성
+	 */
+	@PostMapping
+	public ResponseEntity<ApiResponse<NoteDetailResponse>> createNote(
+			@RequestBody @Valid NoteCreateRequest request,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteCreateCommand command = request.toCommand(userId);
 
-        NoteDetailResult created = noteService.createNote(command);
+		NoteDetailResult created = noteService.createNote(command);
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(NoteDetailResponse.from(created)));
-    }
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(ApiResponse.success(NoteDetailResponse.from(created)));
+	}
 
-    /**
-     * 단일 노트 조회
-     */
-    @GetMapping("/{noteId}")
-    public ResponseEntity<ApiResponse<NoteDetailResponse>> getNote(
+	/**
+	 * 단일 노트 조회
+	 */
+	@GetMapping("/{noteId}")
+	public ResponseEntity<ApiResponse<NoteDetailResponse>> getNote(
 			@PathVariable Long noteId,
 			@AuthenticationPrincipal Long userId
-    ) {
-        NoteDetailResult note = noteService.getNote(userId, noteId);
+	) {
+		NoteDetailResult note = noteService.getNote(userId, noteId);
 
-        return ResponseEntity.ok(ApiResponse.success(NoteDetailResponse.from(note)));
-    }
+		return ResponseEntity.ok(ApiResponse.success(NoteDetailResponse.from(note)));
+	}
 
-    /**
-     * 노트 목록 조회
-     */
-    @GetMapping("/me")
-    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> getNotes(
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable,
-            @AuthenticationPrincipal Long userId
-    ) {
-        Pageable safePageable = safePageable(pageable);
+	/**
+	 * 노트 목록 조회
+	 */
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> getNotes(
+			@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+			Pageable pageable,
+			@AuthenticationPrincipal Long userId
+	) {
+		Pageable safePageable = safePageable(pageable);
 
-        Page<NoteSummaryResult> page = noteService.getNotes(userId, safePageable);
+		Page<NoteSummaryResult> page = noteService.getNotes(userId, safePageable);
 
-        List<NoteSummaryResponse> contents = page.getContent().stream()
-                .map(NoteSummaryResponse::from)
-                .toList();
+		List<NoteSummaryResponse> contents = page.getContent().stream()
+				.map(NoteSummaryResponse::from)
+				.toList();
 
-        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
-    }
+		return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
+	}
 
-    /**
-     * 노트 수정
-     */
-    @PutMapping("/{noteId}")
-    public ResponseEntity<ApiResponse<NoteDetailResponse>> updateNote(
-            @PathVariable Long noteId,
-            @RequestBody @Valid NoteUpdateRequest request,
-            @AuthenticationPrincipal Long userId
-    ) {
-        NoteUpdateCommand command = request.toCommand(noteId, userId);
+	/**
+	 * 노트 수정
+	 */
+	@PutMapping("/{noteId}")
+	public ResponseEntity<ApiResponse<NoteDetailResponse>> updateNote(
+			@PathVariable Long noteId,
+			@RequestBody @Valid NoteUpdateRequest request,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteUpdateCommand command = request.toCommand(noteId, userId);
 
-        NoteDetailResult updated = noteService.updateNote(command);
+		NoteDetailResult updated = noteService.updateNote(command);
 
-        return ResponseEntity.ok(ApiResponse.success(NoteDetailResponse.from(updated)));
-    }
+		return ResponseEntity.ok(ApiResponse.success(NoteDetailResponse.from(updated)));
+	}
 
-    /**
-     * 노트 삭제
-     */
-    @DeleteMapping("/{noteId}")
-    public ResponseEntity<Void> deleteNote(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long noteId
-    ) {
-        noteService.deleteNote(userId, noteId);
-        return ResponseEntity.noContent().build();
-    }
+	/**
+	 * 노트 삭제
+	 */
+	@DeleteMapping("/{noteId}")
+	public ResponseEntity<Void> deleteNote(
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long noteId
+	) {
+		noteService.deleteNote(userId, noteId);
+		return ResponseEntity.noContent().build();
+	}
 
-    /**
-     * 내 노트 검색
-     */
-    @GetMapping("/me/search")
-    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> searchMyNotes(
-            @RequestParam String keyword,
-            @PageableDefault(size = 10)
-            Pageable pageable,
-            @AuthenticationPrincipal Long userId
-    ) {
-        Pageable safePageable = safePageableUnsorted(pageable);
+	/**
+	 * 내 노트 검색
+	 */
+	@GetMapping("/me/search")
+	public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> searchMyNotes(
+			@RequestParam String keyword,
+			@PageableDefault(size = 10)
+			Pageable pageable,
+			@AuthenticationPrincipal Long userId
+	) {
+		Pageable safePageable = safePageableUnsorted(pageable);
 
-        Page<NoteSummaryResult> page = noteService.searchMyNotes(
-                userId,
-                new NoteSearchQuery(keyword, safePageable)
-        );
+		Page<NoteSummaryResult> page = noteService.searchMyNotes(
+				userId,
+				new NoteSearchQuery(keyword, safePageable)
+		);
 
-        List<NoteSummaryResponse> contents = page.getContent().stream()
-                .map(NoteSummaryResponse::from)
-                .toList();
+		List<NoteSummaryResponse> contents = page.getContent().stream()
+				.map(NoteSummaryResponse::from)
+				.toList();
 
-        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
-    }
+		return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
+	}
 
-    /**
-     * 전체 노트 검색
-     */
-    @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> search(
-            @RequestParam String keyword,
-            @PageableDefault(size = 10)
-            Pageable pageable
-    ) {
-        Pageable safePageable = safePageableUnsorted(pageable);
+	/**
+	 * 전체 노트 검색
+	 */
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<PagedResponse<NoteSummaryResponse>>> search(
+			@RequestParam String keyword,
+			@PageableDefault(size = 10)
+			Pageable pageable
+	) {
+		Pageable safePageable = safePageableUnsorted(pageable);
 
-        Page<NoteSummaryResult> page = noteService.searchPublicNote(
-                new NoteSearchQuery(keyword, safePageable)
-        );
+		Page<NoteSummaryResult> page = noteService.searchPublicNote(
+				new NoteSearchQuery(keyword, safePageable)
+		);
 
-        List<NoteSummaryResponse> contents = page.getContent().stream()
-                .map(NoteSummaryResponse::from)
-                .toList();
+		List<NoteSummaryResponse> contents = page.getContent().stream()
+				.map(NoteSummaryResponse::from)
+				.toList();
 
-        return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
-    }
+		return ResponseEntity.ok(ApiResponse.success(PagedResponse.of(page, contents)));
+	}
 
-    /**
-     * 노트 이동
-     */
-    @PatchMapping("/{noteId}/folder")
-    public ResponseEntity<ApiResponse<NoteDetailResponse>> moveNote(
-            @PathVariable Long noteId,
-            @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody NoteMoveRequest request
-    ) {
-        NoteMoveCommand command = request.toCommand(noteId, userId);
-        NoteDetailResult noteDetailResult = noteService.moveNote(command);
+	/**
+	 * 노트 이동
+	 */
+	@PatchMapping("/{noteId}/folder")
+	public ResponseEntity<ApiResponse<NoteDetailResponse>> moveNote(
+			@PathVariable Long noteId,
+			@AuthenticationPrincipal Long userId,
+			@Valid @RequestBody NoteMoveRequest request
+	) {
+		NoteMoveCommand command = request.toCommand(noteId, userId);
+		NoteDetailResult noteDetailResult = noteService.moveNote(command);
 
-        NoteDetailResponse response = NoteDetailResponse.from(noteDetailResult);
+		NoteDetailResponse response = NoteDetailResponse.from(noteDetailResult);
 
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
 
-    private Pageable safePageable(Pageable pageable) {
-        int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
-        return PageRequest.of(
-                pageable.getPageNumber(),
-                safeSize,
-                pageable.getSort()
-        );
-    }
+	private Pageable safePageable(Pageable pageable) {
+		int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
+		return PageRequest.of(
+				pageable.getPageNumber(),
+				safeSize,
+				pageable.getSort()
+		);
+	}
 
-    private Pageable safePageableUnsorted(Pageable pageable) {
-        int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
-        return PageRequest.of(
-                pageable.getPageNumber(),
-                safeSize
-        );
-    }
+	private Pageable safePageableUnsorted(Pageable pageable) {
+		int safeSize = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
+		return PageRequest.of(
+				pageable.getPageNumber(),
+				safeSize
+		);
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -38,7 +38,7 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 			    lower(n.title) like concat('%', lower(:keyword), '%')
 				  OR lower(n.content) like concat('%', lower(:keyword), '%')
 			  )
-			ORDER BY n.createdAt DESC , n.id DESC
+			ORDER BY n.createdAt DESC, n.id DESC
 			""")
 	Page<Note> searchPublicNotes(
 			@Param("keyword") String keyword,

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -2,6 +2,8 @@ package com.keepgoing.keepgoing.note.repository;
 
 import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -9,46 +11,50 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
-    @Override
-    @EntityGraph(attributePaths = {"author"})
-    Optional<Note> findById(Long id);
+	@Override
+	@EntityGraph(attributePaths = {"author"})
+	Optional<Note> findById(Long id);
 
-    /**
-     * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
-     */
-    @EntityGraph(attributePaths = {"author"})
-    Page<Note> findByAuthor_Id(Long authorId, Pageable pageable);
+	/**
+	 * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
+	 */
+	@EntityGraph(attributePaths = {"author"})
+	Page<Note> findByAuthor_Id(Long authorId, Pageable pageable);
 
-    /**
-     * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
-     */
-    @EntityGraph(attributePaths = {"author"})
-    List<Note> findByVisibilityOrderByCreatedAtDesc(NoteVisibility visibility);
+	/**
+	 * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
+	 */
+	@EntityGraph(attributePaths = {"author"})
+	List<Note> findByVisibilityOrderByCreatedAtDesc(NoteVisibility visibility);
 
 	// TODO: 기존 성능 최적화(Mysql 기반)을 단순 검색으로 전환했으므로 이를 Postgres에 맞게 전환하는 작업 필요
-    // 전체 검색(derived query)
-    @EntityGraph(attributePaths = {"author"})
-    Page<Note> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-            String titleKeyword,
-            String contentKeyword,
-            Pageable pageable
-    );
+	@Query("""
+			SELECT n
+			FROM Note n
+			WHERE n.visibility = com.keepgoing.keepgoing.note.domain.NoteVisibility.PUBLIC
+			  AND (
+			    lower(n.title) like concat('%', lower(:keyword), '%')
+				  OR lower(n.content) like concat('%', lower(:keyword), '%')
+			  )
+			ORDER BY n.createdAt DESC , n.id DESC
+			""")
+	Page<Note> searchPublicNotes(
+			@Param("keyword") String keyword,
+			Pageable pageable
+	);
 
-    // 내 글 검색(작성자 조건 포함)
-    @Query("""
-             SELECT n
-            FROM Note n
-            WHERE n.author.id = :authorId
-              AND (LOWER(n.title) LIKE CONCAT('%', LOWER(:keyword), '%')
-                   OR LOWER(n.content) LIKE CONCAT('%', LOWER(:keyword), '%'))
-              ORDER BY n.createdAt DESC, n.id DESC
-            """)
-    Page<Note> searchMyNotes(@Param("authorId") Long authorId,
-                             @Param("keyword") String keyword,
-                             Pageable pageable);
+	// 내 글 검색(작성자 조건 포함)
+	@Query("""
+			SELECT n
+			FROM Note n
+			WHERE n.author.id = :authorId
+			  AND (LOWER(n.title) LIKE CONCAT('%', LOWER(:keyword), '%')
+			       OR LOWER(n.content) LIKE CONCAT('%', LOWER(:keyword), '%'))
+			  ORDER BY n.createdAt DESC, n.id DESC
+			""")
+	Page<Note> searchMyNotes(@Param("authorId") Long authorId,
+	                         @Param("keyword") String keyword,
+	                         Pageable pageable);
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -56,7 +56,7 @@ public class NoteService {
 	}
 
 	/**
-	 * 단일 포스트 조회
+	 * 단일 노트 조회
 	 */
 	@Transactional(readOnly = true)
 	public NoteDetailResult getNote(Long viewerId, Long noteId) {
@@ -69,7 +69,7 @@ public class NoteService {
 	}
 
 	/**
-	 * 포스트 목록 조회
+	 * 노트 목록 조회
 	 */
 	@Transactional(readOnly = true)
 	public Page<NoteSummaryResult> getNotes(Long userId, Pageable pageable) {
@@ -98,7 +98,7 @@ public class NoteService {
 	}
 
 	/**
-	 * 포스트 삭제 (soft delete)
+	 * 노트 삭제 (soft delete)
 	 */
 	@Transactional
 	public void deleteNote(Long userId, Long noteId) {

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -5,6 +5,7 @@ import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.Note;
+import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
@@ -58,9 +59,12 @@ public class NoteService {
 	 * 단일 포스트 조회
 	 */
 	@Transactional(readOnly = true)
-	public NoteDetailResult getNote(Long noteId) {
+	public NoteDetailResult getNote(Long viewerId, Long noteId) {
 		Note note = noteRepository.findById(noteId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
+
+		ensureReadable(note, viewerId);
+
 		return NoteDetailResult.from(note);
 	}
 
@@ -110,28 +114,21 @@ public class NoteService {
 	 */
 	@Transactional(readOnly = true)
 	public Page<NoteSummaryResult> searchMyNotes(Long userId, NoteSearchQuery query) {
-		if (query == null || !query.hasKeyword()) {
-			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-		}
+		validateSearchQuery(query);
 
 		return noteRepository.searchMyNotes(userId, query.keyword(), query.pageable())
 				.map(NoteSummaryResult::from);
 	}
 
+
 	/**
 	 * 전체(공개) 검색
 	 */
 	@Transactional(readOnly = true)
-	public Page<NoteSummaryResult> searchNote(NoteSearchQuery query) {
-		if (query == null || !query.hasKeyword()) {
-			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-		}
+	public Page<NoteSummaryResult> searchPublicNote(NoteSearchQuery query) {
+		validateSearchQuery(query);
 
-		Page<Note> page = noteRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-				query.keyword(),
-				query.keyword(),
-				query.pageable()
-		);
+		Page<Note> page = noteRepository.searchPublicNotes(query.keyword(), query.pageable());
 
 		return page.map(NoteSummaryResult::from);
 	}
@@ -152,5 +149,23 @@ public class NoteService {
 
 		note.changeFolder(command.userId(), targetFolder);
 		return NoteDetailResult.from(note);
+	}
+
+	private void ensureReadable(Note note, Long viewerId) {
+		if (viewerId != null && note.isAuthor(viewerId)) {
+			return;
+		}
+
+		if (note.getVisibility() == NoteVisibility.PUBLIC) {
+			return;
+		}
+
+		throw new BusinessException(ErrorCode.NOTE_ACCESS_DENIED);
+	}
+
+	private static void validateSearchQuery(NoteSearchQuery query) {
+		if (query == null || !query.hasKeyword()) {
+			throw new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
+		}
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -125,7 +125,7 @@ public class NoteService {
 	 * 전체(공개) 검색
 	 */
 	@Transactional(readOnly = true)
-	public Page<NoteSummaryResult> searchPublicNote(NoteSearchQuery query) {
+	public Page<NoteSummaryResult> searchPublicNotes(NoteSearchQuery query) {
 		validateSearchQuery(query);
 
 		Page<Note> page = noteRepository.searchPublicNotes(query.keyword(), query.pageable());

--- a/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
@@ -137,7 +137,7 @@ class SecurityConfigTest {
 		@DisplayName("노트 공개 조회 경로는 익명 접근을 허용한다")
 		void noteReadEndpoints_allowAnonymous() throws Exception {
 			given(noteService.getNote(isNull(), eq(1L))).willReturn(noteDetail(1L));
-			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+			given(noteService.searchPublicNotes(any(NoteSearchQuery.class)))
 					.willReturn(new PageImpl<>(List.of(noteSummary(1L))));
 
 			mockMvc.perform(get("/api/notes/{noteId}", 1L))

--- a/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepgoing.global.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -135,8 +136,8 @@ class SecurityConfigTest {
 		@Test
 		@DisplayName("노트 공개 조회 경로는 익명 접근을 허용한다")
 		void noteReadEndpoints_allowAnonymous() throws Exception {
-			given(noteService.getNote(1L)).willReturn(noteDetail(1L));
-			given(noteService.searchNote(any(NoteSearchQuery.class)))
+			given(noteService.getNote(isNull(), eq(1L))).willReturn(noteDetail(1L));
+			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
 					.willReturn(new PageImpl<>(List.of(noteSummary(1L))));
 
 			mockMvc.perform(get("/api/notes/{noteId}", 1L))

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -870,7 +870,7 @@ public class NoteControllerTest {
 
 			Page<NoteSummaryResult> page = new PageImpl<>(results, pageable, results.size());
 
-			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+			given(noteService.searchPublicNotes(any(NoteSearchQuery.class)))
 					.willReturn(page);
 
 			mockMvc.perform(get("/api/notes/search")
@@ -886,7 +886,7 @@ public class NoteControllerTest {
 					.andExpect(jsonPath("$.data.contents[1].folderId").isEmpty());
 
 			ArgumentCaptor<NoteSearchQuery> captor = ArgumentCaptor.forClass(NoteSearchQuery.class);
-			verify(noteService).searchPublicNote(captor.capture());
+			verify(noteService).searchPublicNotes(captor.capture());
 			assertThat(captor.getValue().keyword()).isEqualTo("spring");
 			assertThat(captor.getValue().pageable().getPageSize()).isEqualTo(10);
 		}
@@ -894,7 +894,7 @@ public class NoteControllerTest {
 		@Test
 		@DisplayName("size가 MAX_PAGE_SIZE보다 크면 상한(100)으로 제한된다")
 		void clampsPageSize() throws Exception {
-			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+			given(noteService.searchPublicNotes(any(NoteSearchQuery.class)))
 					.willReturn(Page.empty());
 
 			mockMvc.perform(get("/api/notes/search")
@@ -905,7 +905,7 @@ public class NoteControllerTest {
 					.andExpect(jsonPath("$.success").value(true));
 
 			ArgumentCaptor<NoteSearchQuery> captor = ArgumentCaptor.forClass(NoteSearchQuery.class);
-			verify(noteService).searchPublicNote(captor.capture());
+			verify(noteService).searchPublicNotes(captor.capture());
 			assertThat(captor.getValue().keyword()).isEqualTo("spring");
 			assertThat(captor.getValue().pageable().getPageSize()).isEqualTo(100);
 		}
@@ -913,7 +913,7 @@ public class NoteControllerTest {
 		@Test
 		@DisplayName("keyword가 공백이면 400 + NOTE_SEARCH_KEYWORD_REQUIRED 반환")
 		void blankKeywordReturns400() throws Exception {
-			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+			given(noteService.searchPublicNotes(any(NoteSearchQuery.class)))
 					.willThrow(new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED));
 
 			mockMvc.perform(get("/api/notes/search")

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepgoing.note.controller;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
@@ -286,20 +287,63 @@ public class NoteControllerTest {
 	// ========== GET ==========
 
 	@Nested
-	@DisplayName("GET /api/notes/{notedId}")
+	@DisplayName("GET /api/notes/{noteId}")
 	class Get {
 
 		@Test
-		@DisplayName("단일 게시글 조회 성공")
-		void getNote_success() throws Exception {
-			// given
+		@DisplayName("익명 사용자는 공개 노트를 조회할 수 있다")
+		void anonymousUser_canReadPublicNote() throws Exception {
 			Long noteId = 1L;
 
 			NoteDetailResult result = new NoteDetailResult(
 					noteId,
 					1L,
-					null,
+					2L,
 					"테스트 제목",
+					"테스트 내용",
+					NoteVisibility.PUBLIC,
+					true,
+					null,
+					null
+			);
+
+			given(noteService.getNote(isNull(), eq(noteId))).willReturn(result);
+
+			mockMvc.perform(get("/api/notes/{noteId}", noteId))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.title").value("테스트 제목"))
+					.andExpect(jsonPath("$.data.visibility").value("PUBLIC"));
+		}
+
+		@Test
+		@DisplayName("익명 사용자가 비공개 노트를 조회하면 403을 반환한다")
+		void anonymousUser_cannotReadPrivateNote() throws Exception {
+			Long noteId = 1L;
+
+			given(noteService.getNote(isNull(), eq(noteId)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_ACCESS_DENIED));
+
+			mockMvc.perform(get("/api/notes/{noteId}", noteId))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_ACCESS_DENIED"));
+		}
+
+		@Test
+		@DisplayName("인증 사용자는 본인 비공개 노트를 조회할 수 있다")
+		void authenticatedUser_canReadOwnPrivateNote() throws Exception {
+			Long userId = 1L;
+			Long noteId = 1L;
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			NoteDetailResult result = new NoteDetailResult(
+					noteId,
+					1L,
+					userId,
+					"내 비공개 노트",
 					"테스트 내용",
 					NoteVisibility.PRIVATE,
 					true,
@@ -307,25 +351,69 @@ public class NoteControllerTest {
 					null
 			);
 
-			given(noteService.getNote(noteId)).willReturn(result);
+			given(noteService.getNote(eq(userId), eq(noteId))).willReturn(result);
 
-			// when & then
 			mockMvc.perform(get("/api/notes/{noteId}", noteId))
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$.success").value(true))
-					.andExpect(jsonPath("$.data.title").value("테스트 제목"));
+					.andExpect(jsonPath("$.data.visibility").value("PRIVATE"));
+		}
+
+		@Test
+		@DisplayName("인증 사용자는 타인의 공개 노트를 조회할 수 있다")
+		void authenticatedUser_canReadOthersPublicNote() throws Exception {
+			Long userId = 1L;
+			Long noteId = 2L;
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			NoteDetailResult result = new NoteDetailResult(
+					noteId,
+					null,
+					2L,
+					"타인 공개 노트",
+					"테스트 내용",
+					NoteVisibility.PUBLIC,
+					true,
+					null,
+					null
+			);
+
+			given(noteService.getNote(eq(userId), eq(noteId))).willReturn(result);
+
+			mockMvc.perform(get("/api/notes/{noteId}", noteId))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.visibility").value("PUBLIC"));
+		}
+
+		@Test
+		@DisplayName("인증 사용자가 타인의 비공개 노트를 조회하면 403을 반환한다")
+		void authenticatedUser_cannotReadOthersPrivateNote() throws Exception {
+			Long userId = 1L;
+			Long noteId = 2L;
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			given(noteService.getNote(eq(userId), eq(noteId)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_ACCESS_DENIED));
+
+			mockMvc.perform(get("/api/notes/{noteId}", noteId))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_ACCESS_DENIED"));
 		}
 
 		@Test
 		@DisplayName("없는 게시글이면 NOTE_NOT_FOUND 에러 응답")
-		void getNote_notFound() throws Exception {
-			// given
+		void returnsNotFoundWhenNoteDoesNotExist() throws Exception {
 			Long noteId = 999L;
 
-			given(noteService.getNote(noteId))
+			given(noteService.getNote(isNull(), eq(noteId)))
 					.willThrow(new BusinessException(ErrorCode.NOTE_NOT_FOUND));
 
-			// when & then
 			mockMvc.perform(get("/api/notes/{noteId}", noteId))
 					.andExpect(status().isNotFound())
 					.andExpect(jsonPath("$.success").value(false))
@@ -761,6 +849,80 @@ public class NoteControllerTest {
 					.andExpect(status().isForbidden())
 					.andExpect(jsonPath("$.success").value(false))
 					.andExpect(jsonPath("$.error.code").value("FOLDER_ACCESS_DENIED"));
+		}
+	}
+
+	// ========== GET /api/notes/search ==========
+
+	@Nested
+	@DisplayName("GET /api/notes/search")
+	class SearchPublic {
+
+		@Test
+		@DisplayName("공개 노트 검색 성공 시 200 OK 및 contents 반환")
+		void success() throws Exception {
+			Pageable pageable = PageRequest.of(0, 10);
+
+			List<NoteSummaryResult> results = List.of(
+					new NoteSummaryResult(1L, 10L, "spring 공개 제목", NoteVisibility.PUBLIC, true, null),
+					new NoteSummaryResult(2L, null, "다른 공개 제목", NoteVisibility.PUBLIC, false, null)
+			);
+
+			Page<NoteSummaryResult> page = new PageImpl<>(results, pageable, results.size());
+
+			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+					.willReturn(page);
+
+			mockMvc.perform(get("/api/notes/search")
+							.param("keyword", "spring")
+							.param("page", "0")
+							.param("size", "10"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.contents").isArray())
+					.andExpect(jsonPath("$.data.contents.length()").value(2))
+					.andExpect(jsonPath("$.data.contents[0].title").value("spring 공개 제목"))
+					.andExpect(jsonPath("$.data.contents[0].visibility").value("PUBLIC"))
+					.andExpect(jsonPath("$.data.contents[1].folderId").isEmpty());
+
+			ArgumentCaptor<NoteSearchQuery> captor = ArgumentCaptor.forClass(NoteSearchQuery.class);
+			verify(noteService).searchPublicNote(captor.capture());
+			assertThat(captor.getValue().keyword()).isEqualTo("spring");
+			assertThat(captor.getValue().pageable().getPageSize()).isEqualTo(10);
+		}
+
+		@Test
+		@DisplayName("size가 MAX_PAGE_SIZE보다 크면 상한(100)으로 제한된다")
+		void clampsPageSize() throws Exception {
+			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+					.willReturn(Page.empty());
+
+			mockMvc.perform(get("/api/notes/search")
+							.param("keyword", "spring")
+							.param("page", "0")
+							.param("size", "1000"))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true));
+
+			ArgumentCaptor<NoteSearchQuery> captor = ArgumentCaptor.forClass(NoteSearchQuery.class);
+			verify(noteService).searchPublicNote(captor.capture());
+			assertThat(captor.getValue().keyword()).isEqualTo("spring");
+			assertThat(captor.getValue().pageable().getPageSize()).isEqualTo(100);
+		}
+
+		@Test
+		@DisplayName("keyword가 공백이면 400 + NOTE_SEARCH_KEYWORD_REQUIRED 반환")
+		void blankKeywordReturns400() throws Exception {
+			given(noteService.searchPublicNote(any(NoteSearchQuery.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED));
+
+			mockMvc.perform(get("/api/notes/search")
+							.param("keyword", "   ")
+							.param("page", "0")
+							.param("size", "10"))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_SEARCH_KEYWORD_REQUIRED"));
 		}
 	}
 

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -746,7 +746,7 @@ class NoteServiceTest {
 			given(noteRepository.searchPublicNotes(eq("spring"), eq(pageable)))
 					.willReturn(notePage);
 
-			Page<NoteSummaryResult> result = noteService.searchPublicNote(query);
+			Page<NoteSummaryResult> result = noteService.searchPublicNotes(query);
 
 			assertThat(result.getTotalElements()).isEqualTo(2);
 			assertThat(result.getContent()).hasSize(2);
@@ -764,7 +764,7 @@ class NoteServiceTest {
 			Pageable pageable = PageRequest.of(0, 10);
 			NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
 
-			assertThatThrownBy(() -> noteService.searchPublicNote(query))
+			assertThatThrownBy(() -> noteService.searchPublicNotes(query))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
 
@@ -783,7 +783,7 @@ class NoteServiceTest {
 			given(noteRepository.searchPublicNotes(eq("spring"), eq(pageable)))
 					.willReturn(notePage);
 
-			Page<NoteSummaryResult> result = noteService.searchPublicNote(query);
+			Page<NoteSummaryResult> result = noteService.searchPublicNotes(query);
 
 			assertThat(result.getTotalElements()).isEqualTo(1);
 

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -257,6 +257,78 @@ class NoteServiceTest {
 		}
 
 		@Test
+		@DisplayName("익명 사용자는 공개 노트를 조회할 수 있다")
+		void returnsPublicNoteForAnonymousViewer() {
+			Long noteId = 1L;
+			User author = user(2L);
+			Note note = Note.create(author, null, "제목", "내용", NoteVisibility.PUBLIC, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.getNote(null, noteId);
+
+			assertThat(result.title()).isEqualTo("제목");
+			assertThat(result.visibility()).isEqualTo(NoteVisibility.PUBLIC);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("익명 사용자가 비공개 노트를 조회하면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenAnonymousViewerRequestsPrivateNote() {
+			Long noteId = 1L;
+			User author = user(2L);
+			Note note = Note.create(author, null, "제목", "내용", NoteVisibility.PRIVATE, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.getNote(null, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자는 공개 노트를 조회할 수 있다")
+		void returnsPublicNoteForDifferentViewer() {
+			Long noteId = 1L;
+			Long viewerId = 1L;
+			User author = user(2L);
+			Note note = Note.create(author, null, "제목", "내용", NoteVisibility.PUBLIC, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.getNote(viewerId, noteId);
+
+			assertThat(result.title()).isEqualTo("제목");
+			assertThat(result.visibility()).isEqualTo(NoteVisibility.PUBLIC);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자가 비공개 노트를 조회하면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenDifferentViewerRequestsPrivateNote() {
+			Long noteId = 1L;
+			Long viewerId = 1L;
+			User author = user(2L);
+			Note note = Note.create(author, null, "제목", "내용", NoteVisibility.PRIVATE, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.getNote(viewerId, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
 		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
 		void throwsWhenNotFound() {
 			Long viewerId = 1L;
@@ -650,6 +722,76 @@ class NoteServiceTest {
 			ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
 			verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
 			assertThat(keywordCaptor.getValue()).isEqualTo("spring");
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("공개 노트 검색")
+	class SearchPublicNote {
+
+		@Test
+		@DisplayName("keyword가 있으면 공개 검색 결과를 페이지로 반환한다")
+		void returnsPageWhenKeywordProvided() {
+			User author1 = user(1L);
+			User author2 = user(2L);
+			Folder folder = folder(author1, 10L);
+			Note note1 = Note.create(author1, folder, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+			Note note2 = Note.create(author2, null, "제목", "spring 내용", NoteVisibility.PUBLIC, false);
+			Pageable pageable = PageRequest.of(0, 10);
+			Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
+			NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
+
+			given(noteRepository.searchPublicNotes(eq("spring"), eq(pageable)))
+					.willReturn(notePage);
+
+			Page<NoteSummaryResult> result = noteService.searchPublicNote(query);
+
+			assertThat(result.getTotalElements()).isEqualTo(2);
+			assertThat(result.getContent()).hasSize(2);
+			assertThat(result.getContent().get(0).folderId()).isEqualTo(10L);
+			assertThat(result.getContent().get(0).visibility()).isEqualTo(NoteVisibility.PUBLIC);
+			assertThat(result.getContent().get(1).folderId()).isNull();
+			verify(noteRepository).searchPublicNotes(eq("spring"), eq(pageable));
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외가 발생한다")
+		void throwsWhenKeywordBlank() {
+			Pageable pageable = PageRequest.of(0, 10);
+			NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
+
+			assertThatThrownBy(() -> noteService.searchPublicNote(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
+
+			verifyNoInteractions(noteRepository, userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("keyword 앞뒤 공백은 trim되어 공개 검색된다")
+		void trimsKeywordBeforeSearching() {
+			User author = user(1L);
+			Note note = Note.create(author, null, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+			Pageable pageable = PageRequest.of(0, 10);
+			Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
+			NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
+
+			given(noteRepository.searchPublicNotes(eq("spring"), eq(pageable)))
+					.willReturn(notePage);
+
+			Page<NoteSummaryResult> result = noteService.searchPublicNote(query);
+
+			assertThat(result.getTotalElements()).isEqualTo(1);
+
+			ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+			verify(noteRepository).searchPublicNotes(keywordCaptor.capture(), pageableCaptor.capture());
+			assertThat(keywordCaptor.getValue()).isEqualTo("spring");
+			assertThat(pageableCaptor.getValue()).isEqualTo(pageable);
 			verifyNoMoreInteractions(noteRepository);
 			verifyNoInteractions(userRepository, folderRepository);
 		}

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -28,6 +28,7 @@ import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -42,9 +43,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-public class NoteServiceTest {
+class NoteServiceTest {
 
-	public static final String DIRECTORY_NAME = "backend";
+	private static final String DIRECTORY_NAME = "backend";
+
 	@Mock
 	NoteRepository noteRepository;
 
@@ -57,712 +59,605 @@ public class NoteServiceTest {
 	@InjectMocks
 	NoteService noteService;
 
-	// ========== createNote ==========
+	@Nested
+	@DisplayName("노트 생성")
+	class CreateNote {
 
-	@Test
-	@DisplayName("createNote: folderId가 null이면 루트 노트를 생성한다.")
-	void createNote_createsRootNoteWhenFolderIdIsNull() {
-		// given
-		Long userId = 1L;
-		var command = NoteCreateCommand.builder()
-				.userId(userId)
-				.folderId(null)
-				.title("제목")
-				.content("내용")
-				.visibility(NoteVisibility.PRIVATE)
-				.aiCollectable(true)
-				.build();
-		User author = user(userId, "test@example.com", "테스트유저");
+		@Test
+		@DisplayName("folderId가 null이면 루트 노트를 생성한다")
+		void createsRootNoteWhenFolderIdIsNull() {
+			Long userId = 1L;
+			NoteCreateCommand command = NoteCreateCommand.builder()
+					.userId(userId)
+					.folderId(null)
+					.title("제목")
+					.content("내용")
+					.visibility(NoteVisibility.PRIVATE)
+					.aiCollectable(true)
+					.build();
+			User author = user(userId, "test@example.com", "테스트유저");
 
-		given(userRepository.findById(userId)).willReturn(Optional.of(author));
-		given(noteRepository.save(any(Note.class)))
-				.willAnswer(invocation -> invocation.getArgument(0));
+			given(userRepository.findById(userId)).willReturn(Optional.of(author));
+			given(noteRepository.save(any(Note.class)))
+					.willAnswer(invocation -> invocation.getArgument(0));
 
-		// when
-		NoteDetailResult result = noteService.createNote(command);
+			NoteDetailResult result = noteService.createNote(command);
 
-		// then
-		ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
-		verify(noteRepository).save(noteCaptor.capture());
+			ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
+			verify(noteRepository).save(noteCaptor.capture());
 
-		Note savedNote = noteCaptor.getValue();
-		assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
-		assertThat(savedNote.getFolder()).isNull();
-		assertThat(savedNote.getTitle()).isEqualTo(command.title());
-		assertThat(savedNote.getContent()).isEqualTo(command.content());
-		assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
-		assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
+			Note savedNote = noteCaptor.getValue();
+			assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
+			assertThat(savedNote.getFolder()).isNull();
+			assertThat(savedNote.getTitle()).isEqualTo(command.title());
+			assertThat(savedNote.getContent()).isEqualTo(command.content());
+			assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
+			assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
 
-		assertThat(result.userId()).isEqualTo(userId);
-		assertThat(result.title()).isEqualTo(command.title());
-		assertThat(result.folderId()).isNull();
-		assertThat(result.content()).isEqualTo(command.content());
-		assertThat(result.visibility()).isEqualTo(command.visibility());
-		assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
+			assertThat(result.userId()).isEqualTo(userId);
+			assertThat(result.title()).isEqualTo(command.title());
+			assertThat(result.folderId()).isNull();
+			assertThat(result.content()).isEqualTo(command.content());
+			assertThat(result.visibility()).isEqualTo(command.visibility());
+			assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
 
-		verify(userRepository).findById(userId);
-		verifyNoInteractions(folderRepository);
-		verifyNoMoreInteractions(userRepository, noteRepository);
+			verify(userRepository).findById(userId);
+			verifyNoInteractions(folderRepository);
+			verifyNoMoreInteractions(userRepository, noteRepository);
+		}
+
+		@Test
+		@DisplayName("유저가 없으면 USER_NOT_FOUND 예외가 발생한다")
+		void throwsWhenUserNotFound() {
+			Long userId = 1L;
+			NoteCreateCommand command = new NoteCreateCommand(
+					userId,
+					null,
+					"제목",
+					"내용",
+					NoteVisibility.PRIVATE,
+					false
+			);
+
+			given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.createNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+			verify(userRepository).findById(userId);
+			verifyNoInteractions(noteRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("내 폴더가 주어지면 해당 폴더에 노트를 생성한다")
+		void createsNoteWhenFolderExists() {
+			Long userId = 1L;
+			User author = user(userId, "test@example.com", "테스트유저");
+			Folder folder = folder(author, 2L);
+			NoteCreateCommand command = NoteCreateCommand.builder()
+					.userId(userId)
+					.folderId(folder.getId())
+					.title("제목")
+					.content("내용")
+					.visibility(NoteVisibility.PRIVATE)
+					.aiCollectable(false)
+					.build();
+
+			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
+			given(folderRepository.findByIdAndDeletedAtIsNull(command.folderId()))
+					.willReturn(Optional.of(folder));
+			given(noteRepository.save(any(Note.class)))
+					.willAnswer(invocation -> invocation.getArgument(0));
+
+			NoteDetailResult result = noteService.createNote(command);
+
+			ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
+			verify(noteRepository).save(noteCaptor.capture());
+
+			Note savedNote = noteCaptor.getValue();
+			assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
+			assertThat(savedNote.getFolder()).isNotNull();
+			assertThat(savedNote.getFolder().getId()).isEqualTo(folder.getId());
+			assertThat(savedNote.getTitle()).isEqualTo(command.title());
+			assertThat(savedNote.getContent()).isEqualTo(command.content());
+			assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
+			assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
+
+			assertThat(result.userId()).isEqualTo(userId);
+			assertThat(result.title()).isEqualTo(command.title());
+			assertThat(result.folderId()).isEqualTo(command.folderId());
+			assertThat(result.content()).isEqualTo(command.content());
+			assertThat(result.visibility()).isEqualTo(command.visibility());
+			assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
+			verify(userRepository).findById(userId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folder.getId());
+			verify(noteRepository).save(any(Note.class));
+			verifyNoMoreInteractions(userRepository, noteRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 폴더면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void throwsWhenFolderNotFound() {
+			Long userId = 1L;
+			User author = user(userId);
+			NoteCreateCommand command = NoteCreateCommand.builder()
+					.userId(userId)
+					.folderId(2L)
+					.title("제목")
+					.content("내용")
+					.visibility(NoteVisibility.PRIVATE)
+					.aiCollectable(false)
+					.build();
+
+			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
+			given(folderRepository.findByIdAndDeletedAtIsNull(2L)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.createNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+			verify(userRepository).findById(command.userId());
+			verify(folderRepository).findByIdAndDeletedAtIsNull(2L);
+			verifyNoMoreInteractions(userRepository, folderRepository);
+			verifyNoInteractions(noteRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenFolderOwnedByAnotherUser() {
+			Long userId = 1L;
+			Long otherUserId = 2L;
+			Long folderId = 10L;
+			User author = user(userId);
+			User otherAuthor = user(otherUserId);
+			Folder folder = folder(otherAuthor, folderId);
+			NoteCreateCommand command = NoteCreateCommand.builder()
+					.userId(userId)
+					.folderId(folderId)
+					.title("제목")
+					.content("내용")
+					.visibility(NoteVisibility.PRIVATE)
+					.aiCollectable(false)
+					.build();
+
+			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			assertThatThrownBy(() -> noteService.createNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+			verify(userRepository).findById(command.userId());
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(userRepository, folderRepository);
+			verifyNoInteractions(noteRepository);
+		}
 	}
 
-	@Test
-	@DisplayName("createNote: 유저가 없으면 USER_NOT_FOUND 예외 발생")
-	void createNote_throwsWhenUserNotFound() {
-		// given
-		Long userId = 1L;
-		String title = "제목";
-		String content = "내용";
-		NoteVisibility visibility = NoteVisibility.PRIVATE;
-		boolean aiCollectable = false;
+	@Nested
+	@DisplayName("단건 조회")
+	class GetNote {
 
-		given(userRepository.findById(userId)).willReturn(Optional.empty());
+		@Test
+		@DisplayName("작성자 본인은 비공개 노트를 조회할 수 있다")
+		void returnsPrivateNoteForAuthor() {
+			Long noteId = 1L;
+			Long viewerId = 1L;
+			User author = user(viewerId);
+			Note note = Note.create(author, null, "제목", "내용", NoteVisibility.PRIVATE, true);
 
-		NoteCreateCommand command = new NoteCreateCommand(
-				userId,
-				null,
-				title,
-				content,
-				visibility,
-				aiCollectable
-		);
-		// when & then
-		assertThatThrownBy(() -> noteService.createNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
-		verify(userRepository).findById(userId);
-		verifyNoInteractions(noteRepository);
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.getNote(viewerId, noteId);
+
+			assertThat(result.title()).isEqualTo("제목");
+			assertThat(result.content()).isEqualTo("내용");
+			assertThat(result.visibility()).isEqualTo(NoteVisibility.PRIVATE);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		void throwsWhenNotFound() {
+			Long viewerId = 1L;
+			Long noteId = 1L;
+			given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.getNote(viewerId, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
 	}
 
+	@Nested
+	@DisplayName("목록 조회")
+	class GetNotes {
 
-	@Test
-	@DisplayName("createNote: 내 폴더가 주어지면 해당 폴더에 노트를 생성한다.")
-	void createNote_createsNoteWhenFolderExists() {
-		// given
-		Long userId = 1L;
-		User author = user(1L, "test@example.com", "테스트유저");
+		@Test
+		@DisplayName("작성자 ID와 Pageable로 게시글 페이지를 가져온다")
+		void returnsPage() {
+			Long userId = 1L;
+			User user = user(userId);
+			Folder folder = folder(user, 10L);
+			Note note1 = Note.create(user, folder, "제목1", "내용1", NoteVisibility.PRIVATE, true);
+			Note note2 = Note.create(user, null, "제목2", "내용2", NoteVisibility.PUBLIC, true);
+			List<Note> notes = List.of(note1, note2);
+			Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+			Page<Note> notePage = new PageImpl<>(notes, pageable, notes.size());
 
-		Folder folder = Folder.create(author, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(folder, "id", 2L);
+			given(noteRepository.findByAuthor_Id(userId, pageable)).willReturn(notePage);
 
-		var command = NoteCreateCommand.builder()
-				.userId(userId)
-				.folderId(folder.getId())
-				.title("제목")
-				.content("내용")
-				.visibility(NoteVisibility.PRIVATE)
-				.aiCollectable(false)
-				.build();
+			Page<NoteSummaryResult> result = noteService.getNotes(userId, pageable);
 
-		given(userRepository.findById(command.userId()))
-				.willReturn(Optional.of(author));
-		given(folderRepository.findByIdAndDeletedAtIsNull(command.folderId()))
-				.willReturn(Optional.of(folder));
-		given(noteRepository.save(any(Note.class)))
-				.willAnswer(invocation -> invocation.getArgument(0));
-
-		// when
-		NoteDetailResult result = noteService.createNote(command);
-
-		// then
-		ArgumentCaptor<Note> noteCaptor = ArgumentCaptor.forClass(Note.class);
-		verify(noteRepository).save(noteCaptor.capture());
-
-		Note savedNote = noteCaptor.getValue();
-		assertThat(savedNote.getAuthor().getId()).isEqualTo(userId);
-		assertThat(savedNote.getFolder()).isNotNull();
-		assertThat(savedNote.getFolder().getId()).isEqualTo(folder.getId());
-		assertThat(savedNote.getTitle()).isEqualTo(command.title());
-		assertThat(savedNote.getContent()).isEqualTo(command.content());
-		assertThat(savedNote.getVisibility()).isEqualTo(command.visibility());
-		assertThat(savedNote.isAiCollectable()).isEqualTo(command.aiCollectable());
-
-		assertThat(result.userId()).isEqualTo(userId);
-		assertThat(result.title()).isEqualTo(command.title());
-		assertThat(result.folderId()).isEqualTo(command.folderId());
-		assertThat(result.content()).isEqualTo(command.content());
-		assertThat(result.visibility()).isEqualTo(command.visibility());
-		assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
-		verify(userRepository).findById(userId);
-		verify(folderRepository).findByIdAndDeletedAtIsNull(folder.getId());
-		verify(noteRepository).save(any(Note.class));
-		verifyNoMoreInteractions(userRepository, noteRepository, folderRepository);
+			assertThat(result.getTotalElements()).isEqualTo(2);
+			assertThat(result.getContent()).hasSize(2);
+			assertThat(result.getContent().get(0).title()).isEqualTo("제목1");
+			assertThat(result.getContent().get(0).folderId()).isEqualTo(10L);
+			assertThat(result.getContent().get(1).title()).isEqualTo("제목2");
+			assertThat(result.getContent().get(1).folderId()).isNull();
+			verify(noteRepository).findByAuthor_Id(userId, pageable);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
 	}
 
-	@Test
-	@DisplayName("createNote: 존재하지 않는 폴더면 FOLDER_NOT_FOUND 예외가 발생한다")
-	void createNote_throwsWhenFolderNotFound() {
-		// given
-		Long userId = 1L;
-		User author = user(1L);
-		var command = NoteCreateCommand.builder()
-				.userId(userId)
-				.folderId(2L)
-				.title("제목")
-				.content("내용")
-				.visibility(NoteVisibility.PRIVATE)
-				.aiCollectable(false)
-				.build();
-		given(userRepository.findById(command.userId()))
-				.willReturn(Optional.of(author));
-		given(folderRepository.findByIdAndDeletedAtIsNull(2L))
-				.willReturn(Optional.empty());
+	@Nested
+	@DisplayName("노트 수정")
+	class UpdateNote {
 
-		// when & then
-		assertThatThrownBy(() -> noteService.createNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
-		verify(userRepository).findById(command.userId());
-		verify(folderRepository).findByIdAndDeletedAtIsNull(2L);
-		verifyNoMoreInteractions(userRepository, folderRepository);
-		verifyNoInteractions(noteRepository);
+		@Test
+		@DisplayName("작성자가 맞으면 게시글이 수정된다")
+		void updatesWhenAuthorMatches() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			User user = user(userId);
+			Note note = Note.create(user, null, "old", "old", NoteVisibility.PRIVATE, true);
+			String newTitle = "수정 제목";
+			String newContent = "수정 내용";
+			NoteVisibility newVisibility = NoteVisibility.PUBLIC;
+			boolean newAiCollectable = false;
+			NoteUpdateCommand command = new NoteUpdateCommand(
+					noteId,
+					userId,
+					newTitle,
+					newContent,
+					newVisibility,
+					newAiCollectable
+			);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.updateNote(command);
+
+			assertThat(result.title()).isEqualTo(newTitle);
+			assertThat(result.content()).isEqualTo(newContent);
+			assertThat(result.visibility()).isEqualTo(newVisibility);
+			assertThat(result.aiCollectable()).isEqualTo(newAiCollectable);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		void throwsWhenNoteNotFound() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			NoteUpdateCommand command = new NoteUpdateCommand(
+					noteId,
+					userId,
+					"수정 제목",
+					"수정 내용",
+					NoteVisibility.PUBLIC,
+					false
+			);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.updateNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenNotAuthor() {
+			Long requesterId = 1L;
+			Long authorId = 2L;
+			Long noteId = 10L;
+			User author = user(authorId);
+			Note note = Note.create(author, null, "old", "old", NoteVisibility.PRIVATE, true);
+			NoteUpdateCommand command = new NoteUpdateCommand(
+					noteId,
+					requesterId,
+					"수정 제목",
+					"수정 내용",
+					NoteVisibility.PUBLIC,
+					false
+			);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.updateNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
 	}
 
-	@Test
-	@DisplayName("createNote: 다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
-	void createNote_throwsWhenFolderOwnedByAnotherUser() {
-		// given
-		Long userId = 1L;
-		Long otherUserId = 2L;
-		Long folderId = 10L;
-		User author = user(1L);
-		User otherAuthor = user(otherUserId);
-		Folder folder = Folder.create(
-				otherAuthor,
-				null,
-				DIRECTORY_NAME
-		);
+	@Nested
+	@DisplayName("노트 삭제")
+	class DeleteNote {
+
+		@Test
+		@DisplayName("작성자가 맞으면 soft delete 된다")
+		void softDeletesWhenAuthorMatches() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			User user = user(userId);
+			Note note = Note.create(user, null, "title", "content", NoteVisibility.PRIVATE, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			noteService.deleteNote(userId, noteId);
+
+			assertThat(note.isDeleted()).isTrue();
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		void throwsWhenNoteNotFound() {
+			Long userId = 1L;
+			Long noteId = 10L;
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenNotAuthor() {
+			Long requesterId = 1L;
+			Long authorId = 2L;
+			Long noteId = 10L;
+			User author = user(authorId);
+			Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.deleteNote(requesterId, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("노트 이동")
+	class MoveNote {
+
+		@Test
+		@DisplayName("내 폴더로 이동하면 folderId가 변경된다")
+		void movesToOwnedFolder() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			Long folderId = 20L;
+			User author = user(userId);
+			Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
+			Folder folder = folder(author, folderId);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			NoteDetailResult result = noteService.moveNote(command);
+
+			assertThat(note.getFolder()).isEqualTo(folder);
+			assertThat(result.folderId()).isEqualTo(folderId);
+			verify(noteRepository).findById(noteId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verifyNoInteractions(userRepository);
+		}
+
+		@Test
+		@DisplayName("folderId가 null이면 루트로 이동한다")
+		void movesToRootWhenFolderIdIsNull() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			Long existingFolderId = 30L;
+			User author = user(userId);
+			Folder existingFolder = folder(author, existingFolderId);
+			Note note = Note.create(author, existingFolder, "title", "content", NoteVisibility.PRIVATE, true);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, null);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.moveNote(command);
+
+			assertThat(note.getFolder()).isNull();
+			assertThat(result.folderId()).isNull();
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(folderRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("노트가 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		void throwsWhenNoteNotFound() {
+			Long noteId = 10L;
+			Long userId = 1L;
+			Long folderId = 20L;
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.moveNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(folderRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("대상 폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void throwsWhenFolderNotFound() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			Long folderId = 20L;
+			User author = user(userId);
+			Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.moveNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verifyNoInteractions(userRepository);
+		}
+
+		@Test
+		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenRequesterIsNotAuthor() {
+			Long requesterId = 1L;
+			Long authorId = 2L;
+			Long noteId = 10L;
+			User author = user(authorId);
+			Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, requesterId, null);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.moveNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(folderRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		void throwsWhenTargetFolderOwnedByAnotherUser() {
+			Long userId = 1L;
+			Long otherUserId = 2L;
+			Long noteId = 10L;
+			Long folderId = 20L;
+			User author = user(userId);
+			User otherAuthor = user(otherUserId);
+			Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
+			Folder otherFolder = folder(otherAuthor, folderId);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(otherFolder));
+
+			assertThatThrownBy(() -> noteService.moveNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verifyNoInteractions(userRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("내 노트 검색")
+	class SearchMyNotes {
+
+		@Test
+		@DisplayName("keyword가 있으면 검색 결과를 페이지로 반환한다")
+		void returnsPageWhenKeywordProvided() {
+			Long userId = 1L;
+			User user = user(userId);
+			Folder folder = folder(user, 10L);
+			Note note1 = Note.create(user, folder, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+			Note note2 = Note.create(user, null, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
+			Pageable pageable = PageRequest.of(0, 10);
+			Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
+			NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
+
+			given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
+					.willReturn(notePage);
+
+			Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
+
+			assertThat(result.getTotalElements()).isEqualTo(2);
+			assertThat(result.getContent()).hasSize(2);
+			assertThat(result.getContent().get(0).folderId()).isEqualTo(10L);
+			assertThat(result.getContent().get(1).folderId()).isNull();
+			verify(noteRepository).searchMyNotes(eq(userId), eq("spring"), any(Pageable.class));
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외가 발생한다")
+		void throwsWhenKeywordBlank() {
+			Long userId = 1L;
+			Pageable pageable = PageRequest.of(0, 10);
+			NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
+
+			assertThatThrownBy(() -> noteService.searchMyNotes(userId, query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
+
+			verifyNoInteractions(noteRepository, userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("keyword 앞뒤 공백은 trim되어 검색된다")
+		void trimsKeywordBeforeSearching() {
+			Long userId = 1L;
+			User user = user(userId);
+			Note note = Note.create(user, null, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
+			Pageable pageable = PageRequest.of(0, 10);
+			Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
+			NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
+
+			given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
+					.willReturn(notePage);
+
+			Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
+
+			assertThat(result.getTotalElements()).isEqualTo(1);
+			ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+			verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
+			assertThat(keywordCaptor.getValue()).isEqualTo("spring");
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+	}
+
+	private Folder folder(User owner, Long folderId) {
+		Folder folder = Folder.create(owner, null, DIRECTORY_NAME);
 		ReflectionTestUtils.setField(folder, "id", folderId);
-		var command = NoteCreateCommand.builder()
-				.userId(userId)
-				.folderId(folderId)
-				.title("제목")
-				.content("내용")
-				.visibility(NoteVisibility.PRIVATE)
-				.aiCollectable(false)
-				.build();
-		given(userRepository.findById(command.userId()))
-				.willReturn(Optional.of(author));
-		given(folderRepository.findByIdAndDeletedAtIsNull(folderId))
-				.willReturn(Optional.of(folder));
-
-		// when & then
-		assertThatThrownBy(() -> noteService.createNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
-		verify(userRepository).findById(command.userId());
-		verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-		verifyNoMoreInteractions(userRepository, folderRepository);
-		verifyNoInteractions(noteRepository);
-	}
-
-	// ========== getNote ==========
-
-	@Test
-	@DisplayName("getNote: 게시글이 존재하면 반환한다")
-	void getNote_returnsNoteWhenExists() {
-		// given
-		Long noteId = 1L;
-		User user = user(1L);
-		Note note = Note.create(user, null, "제목", "내용", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		// when
-		NoteDetailResult result = noteService.getNote(noteId);
-
-		// then
-		assertThat(result.title()).isEqualTo("제목");
-		assertThat(result.content()).isEqualTo("내용");
-		assertThat(result.visibility()).isEqualTo(NoteVisibility.PRIVATE);
-
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("getNote: 게시글이 없으면 NOTE_NOT_FOUND 예외 발생")
-	void getNote_throwsWhenNotFound() {
-		// given
-		Long noteId = 1L;
-		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-		// when & then
-		assertThatThrownBy(() -> noteService.getNote(noteId))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-
-	}
-
-	// ========== getNotes ==========
-
-	@Test
-	@DisplayName("getNotes: 작성자 ID와 Pageable로 게시글 페이지를 가져온다")
-	void getNotes_returnsPage() {
-		// given
-		Long userId = 1L;
-		User user = user(userId);
-		Folder folder = Folder.create(user, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(folder, "id", 10L);
-
-		Note note1 = Note.create(user, folder, "제목1", "내용1", NoteVisibility.PRIVATE, true);
-		Note note2 = Note.create(user, null, "제목2", "내용2", NoteVisibility.PUBLIC, true);
-		var notes = java.util.List.of(note1, note2);
-
-		Pageable pageable = PageRequest.of(
-				0,
-				10,
-				Sort.by(Sort.Direction.DESC, "createdAt")
-		);
-		Page<Note> notePage = new PageImpl<>(
-				notes,
-				pageable,
-				notes.size()
-		);
-
-		// 저장소가 페이지를 반환하는 동작을 스텁
-		given(noteRepository.findByAuthor_Id(userId, pageable))
-				.willReturn(notePage);
-
-		// when
-		Page<NoteSummaryResult> result = noteService.getNotes(userId, pageable);
-
-		// then
-		assertThat(result.getTotalElements()).isEqualTo(2);
-		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent()
-				.get(0)
-				.title()).isEqualTo("제목1");
-		assertThat(result.getContent()
-				.get(0)
-				.folderId()).isEqualTo(10L);
-		assertThat(result.getContent()
-				.get(1)
-				.title()).isEqualTo("제목2");
-		assertThat(result.getContent()
-				.get(1)
-				.folderId()).isNull();
-		verify(noteRepository).findByAuthor_Id(userId, pageable);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	// ========== updateNote ==========
-
-	@Test
-	@DisplayName("updateNote: 작성자가 맞으면 게시글이 수정된다")
-	void updateNote_updatesWhenAuthorMatches() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-
-		User user = user(userId);
-		Note note = Note.create(user, null, "old", "old", NoteVisibility.PRIVATE, true);
-
-		String newTitle = "수정 제목";
-		String newContent = "수정 내용";
-		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-		boolean newAiCollectable = false;
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		NoteUpdateCommand command = new NoteUpdateCommand(
-				noteId,
-				userId,
-				newTitle,
-				newContent,
-				newVisibility,
-				newAiCollectable
-		);
-
-		// when
-		NoteDetailResult result = noteService.updateNote(command);
-
-		// then
-		assertThat(result.title()).isEqualTo(newTitle);
-		assertThat(result.content()).isEqualTo(newContent);
-		assertThat(result.visibility()).isEqualTo(newVisibility);
-		assertThat(result.aiCollectable()).isEqualTo(newAiCollectable);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("updateNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
-	void updateNote_throwsWhenNoteNotFound() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-
-		String newTitle = "수정 제목";
-		String newContent = "수정 내용";
-		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-		boolean newAiCollectable = false;
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-		NoteUpdateCommand command = new NoteUpdateCommand(
-				noteId,
-				userId,
-				newTitle,
-				newContent,
-				newVisibility,
-				newAiCollectable
-		);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.updateNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("updateNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
-	void updateNote_throwsWhenNotAuthor() {
-		// given
-		Long userId = 1L;
-		Long othersId = 2L;
-		Long noteId = 10L;
-
-		User user = user(othersId); // 실제 작성자는 2번
-		Note note = Note.create(user, null, "old", "old", NoteVisibility.PRIVATE, true);
-
-		String newTitle = "수정 제목";
-		String newContent = "수정 내용";
-		NoteVisibility newVisibility = NoteVisibility.PUBLIC;
-		boolean newAiCollectable = false;
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		NoteUpdateCommand command = new NoteUpdateCommand(
-				noteId,
-				userId,
-				newTitle,
-				newContent,
-				newVisibility,
-				newAiCollectable
-		);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.updateNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	// ========== deleteNote ==========
-
-	@Test
-	@DisplayName("deleteNote: 작성자가 맞으면 softDelete 된다")
-	void deleteNote_softDeletesWhenAuthorMatches() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-
-		User user = user(userId);
-		Note note = Note.create(user, null, "title", "content", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		// when
-		noteService.deleteNote(userId, noteId);
-
-		// then
-		assertThat(note.isDeleted()).isTrue(); // isDeleted 없으면 deletedAt != null 로 체크
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("deleteNote: 게시글이 없으면 NOTE_NOT_FOUND 예외")
-	void deleteNote_throwsWhenNoteNotFound() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-		// when & then
-		assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("deleteNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
-	void deleteNote_throwsWhenNotAuthor() {
-		// given
-		Long userId = 1L;
-		Long othersId = 2L;
-		Long noteId = 10L;
-
-		User user = user(othersId); // 작성자는 2번
-		Note note = Note.create(user, null, "title", "content", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		// when & then
-		assertThatThrownBy(() -> noteService.deleteNote(userId, noteId))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	// ========== moveNote ==========
-
-	@Test
-	@DisplayName("moveNote: 내 폴더로 이동하면 folderId가 변경된다")
-	void moveNote_movesToOwnedFolder() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-		Long folderId = 20L;
-
-		User author = user(userId);
-		Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
-		Folder folder = Folder.create(author, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(folder, "id", folderId);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-		given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
-
-		// when
-		NoteDetailResult result = noteService.moveNote(command);
-
-		// then
-		assertThat(note.getFolder()).isEqualTo(folder);
-		assertThat(result.folderId()).isEqualTo(folderId);
-		verify(noteRepository).findById(noteId);
-		verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-		verifyNoMoreInteractions(noteRepository, folderRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("moveNote: folderId가 null이면 루트로 이동한다")
-	void moveNote_movesToRootWhenFolderIdIsNull() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-		Long existingFolderId = 30L;
-
-		User author = user(userId);
-		Folder existingFolder = Folder.create(author, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(existingFolder, "id", existingFolderId);
-		Note note = Note.create(author, existingFolder, "title", "content", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, userId, null);
-
-		// when
-		NoteDetailResult result = noteService.moveNote(command);
-
-		// then
-		assertThat(note.getFolder()).isNull();
-		assertThat(result.folderId()).isNull();
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(folderRepository, userRepository);
-	}
-
-	@Test
-	@DisplayName("moveNote: 노트가 없으면 NOTE_NOT_FOUND 예외")
-	void moveNote_throwsWhenNoteNotFound() {
-		// given
-		Long noteId = 10L;
-		Long userId = 1L;
-		Long folderId = 20L;
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.empty());
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.moveNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(folderRepository, userRepository);
-	}
-
-	@Test
-	@DisplayName("moveNote: 대상 폴더가 없으면 FOLDER_NOT_FOUND 예외")
-	void moveNote_throwsWhenFolderNotFound() {
-		// given
-		Long userId = 1L;
-		Long noteId = 10L;
-		Long folderId = 20L;
-
-		User author = user(userId);
-		Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-		given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.moveNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
-		verify(noteRepository).findById(noteId);
-		verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-		verifyNoMoreInteractions(noteRepository, folderRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("moveNote: 작성자가 아니면 NOTE_ACCESS_DENIED 예외")
-	void moveNote_throwsWhenRequesterIsNotAuthor() {
-		// given
-		Long requesterId = 1L;
-		Long authorId = 2L;
-		Long noteId = 10L;
-
-		User author = user(authorId);
-		Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, requesterId, null);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.moveNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
-		verify(noteRepository).findById(noteId);
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(folderRepository, userRepository);
-	}
-
-	@Test
-	@DisplayName("moveNote: 다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외")
-	void moveNote_throwsWhenTargetFolderOwnedByAnotherUser() {
-		// given
-		Long userId = 1L;
-		Long otherUserId = 2L;
-		Long noteId = 10L;
-		Long folderId = 20L;
-
-		User author = user(userId);
-		User otherAuthor = user(otherUserId);
-		Note note = Note.create(author, null, "title", "content", NoteVisibility.PRIVATE, true);
-		Folder otherFolder = Folder.create(otherAuthor, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(otherFolder, "id", folderId);
-
-		given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-		given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(otherFolder));
-
-		NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.moveNote(command))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
-		verify(noteRepository).findById(noteId);
-		verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-		verifyNoMoreInteractions(noteRepository, folderRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	// ========== searchMyNotes ==========
-
-	@Test
-	@DisplayName("searchMyNotes: keyword가 있으면 검색 결과를 페이지로 반환한다")
-	void searchMyNotes_returnsPageWhenKeywordProvided() {
-		// given
-		Long userId = 1L;
-		User user = user(userId);
-		Folder folder = Folder.create(user, null, DIRECTORY_NAME);
-		ReflectionTestUtils.setField(folder, "id", 10L);
-
-		Note note1 = Note.create(user, folder, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-		Note note2 = Note.create(user, null, "제목", "spring 내용", NoteVisibility.PUBLIC, true);
-
-		Pageable pageable = PageRequest.of(0, 10);
-		Page<Note> notePage = new PageImpl<>(List.of(note1, note2), pageable, 2);
-
-		NoteSearchQuery query = new NoteSearchQuery("spring", pageable);
-
-		given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
-				.willReturn(notePage);
-
-		// when
-		Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-		// then
-		assertThat(result.getTotalElements()).isEqualTo(2);
-		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent().get(0).folderId()).isEqualTo(10L);
-		assertThat(result.getContent().get(1).folderId()).isNull();
-		verify(noteRepository).searchMyNotes(eq(userId), eq("spring"), any(Pageable.class));
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("searchMyNotes: keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외")
-	void searchMyNotes_throwsWhenKeywordBlank() {
-		// given
-		Long userId = 1L;
-		Pageable pageable = PageRequest.of(0, 10);
-		NoteSearchQuery query = new NoteSearchQuery("   ", pageable);
-
-		// when & then
-		assertThatThrownBy(() -> noteService.searchMyNotes(userId, query))
-				.isInstanceOf(BusinessException.class)
-				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED);
-
-		verifyNoInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
-	}
-
-	@Test
-	@DisplayName("searchMyNotes: keyword 앞뒤 공백은 trim되어 검색된다")
-	void searchMyNotes_trimsKeywordBeforeSearching() {
-		// given
-		Long userId = 1L;
-		User user = user(userId);
-		Note note = Note.create(user, null, "spring 제목", "내용", NoteVisibility.PUBLIC, true);
-
-		Pageable pageable = PageRequest.of(0, 10);
-		Page<Note> notePage = new PageImpl<>(List.of(note), pageable, 1);
-
-		NoteSearchQuery query = new NoteSearchQuery("  spring  ", pageable);
-
-		given(noteRepository.searchMyNotes(eq(userId), eq("spring"), any(Pageable.class)))
-				.willReturn(notePage);
-
-		// when
-		Page<NoteSummaryResult> result = noteService.searchMyNotes(userId, query);
-
-		// then
-		assertThat(result.getTotalElements()).isEqualTo(1);
-
-		ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
-		verify(noteRepository).searchMyNotes(eq(userId), keywordCaptor.capture(), any(Pageable.class));
-		assertThat(keywordCaptor.getValue()).isEqualTo("spring");
-
-		verifyNoMoreInteractions(noteRepository);
-		verifyNoInteractions(userRepository);
+		return folder;
 	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정

### 📌 관련 이슈
- #69

### ✨ 반영 브랜치
feat/69 -> develop

### 📝 변경 사항
- [x] `GET /api/notes/{noteId}`가 viewer 기준으로 읽기 권한을 판단하도록 변경했습니다.
- [x] 익명 사용자도 `PUBLIC` 노트를 조회할 수 있도록 컨트롤러/서비스 흐름을 정리했습니다.
- [x] 타인의 `PRIVATE` 노트 조회는 `NOTE_ACCESS_DENIED`로 막도록 정책을 고정했습니다.
- [x] 공개 검색 API가 `searchPublicNote()`와 공개 노트 전용 repository 쿼리를 사용하도록 정리했습니다.
- [x] `NoteControllerTest`, `NoteServiceTest`, `SecurityConfigTest`를 public/private 조회 정책 기준으로 보강했습니다.
- [x] `NoteServiceTest`는 Nested 구조를 유지하면서 읽기 정책/공개 검색 케이스를 추가했습니다.

### ➕ 추가 메모
- 현재 public MVP 기준은 아래와 같습니다.
  - 익명 사용자: `PUBLIC` 노트 단건 조회 및 공개 검색 가능
  - 로그인 사용자: 본인 노트 전체 + 타인 `PUBLIC` 노트 조회 가능
  - 타인 `PRIVATE` 노트는 조회 불가
- `/api/notes/me`, `/api/notes/me/search`는 기존처럼 인증 사용자 전용입니다.
- 로컬 워킹트리에 `.gitignore` 변경이 남아 있지만 이번 PR에는 포함하지 않았습니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
- [x] `./gradlew test --tests 'com.keepgoing.keepgoing.note.service.NoteServiceTest' --tests 'com.keepgoing.keepgoing.note.controller.NoteControllerTest' --tests 'com.keepgoing.keepgoing.global.config.SecurityConfigTest' --no-daemon`
- [x] `./gradlew test --no-daemon`
