### PR TITLE
[Folder] #52-folder-delete 폴더 삭제 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ bin/
 .factorypath
 out/
 AGENTS.md
+GEMINI.md
+conductor/

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -83,5 +84,14 @@ public class FolderController {
 		FolderSummaryResponse response = FolderSummaryResponse.from(result);
 
 		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@DeleteMapping("/{folderId}")
+	public ResponseEntity<Void> deleteFolder(
+			@PathVariable Long folderId,
+			@AuthenticationPrincipal Long userId
+	) {
+		folderService.deleteFolder(userId, folderId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
@@ -1,11 +1,13 @@
 package com.keepgoing.keepgoing.folder.controller;
 
 import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
+import com.keepgoing.keepgoing.folder.controller.dto.FolderMoveRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderRenameRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderSummaryResponse;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderTreeNodeResponse;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -81,6 +83,19 @@ public class FolderController {
 	) {
 		FolderRenameCommand command = request.toCommand(userId, folderId);
 		FolderSummaryResult result = folderService.renameFolder(command);
+		FolderSummaryResponse response = FolderSummaryResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/{folderId}/parent")
+	public ResponseEntity<ApiResponse<FolderSummaryResponse>> moveFolder(
+			@PathVariable Long folderId,
+			@AuthenticationPrincipal Long userId,
+			@Valid @RequestBody FolderMoveRequest request
+	) {
+		FolderMoveCommand command = request.toCommand(userId, folderId);
+		FolderSummaryResult result = folderService.moveFolder(command);
 		FolderSummaryResponse response = FolderSummaryResponse.from(result);
 
 		return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderMoveRequest.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderMoveRequest.java
@@ -1,0 +1,22 @@
+package com.keepgoing.keepgoing.folder.controller.dto;
+
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
+import com.keepgoing.keepgoing.global.validation.PositiveIfPresent;
+import com.keepgoing.keepgoing.global.validation.PresentJsonNullable;
+import jakarta.validation.valueextraction.Unwrapping;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+public record FolderMoveRequest(
+		@PresentJsonNullable(payload = {Unwrapping.Skip.class})
+		@PositiveIfPresent(payload = {Unwrapping.Skip.class})
+		JsonNullable<Long> parentId
+) {
+
+	public FolderMoveCommand toCommand(Long userId, Long folderId) {
+		return new FolderMoveCommand(
+				userId,
+				folderId,
+				parentId.orElse(null)
+		);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
@@ -76,6 +76,10 @@ public class Folder extends BaseEntity {
 		this.name = name;
 	}
 
+	public void moveTo(Folder parent) {
+		this.parent = parent;
+	}
+
 	public void softDelete() {
 		if (this.deletedAt == null) {
 			this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
@@ -76,8 +76,14 @@ public class Folder extends BaseEntity {
 		this.name = name;
 	}
 
-	public void moveTo(Folder parent) {
-		this.parent = parent;
+	public void moveTo(Folder targetParent) {
+		if (targetParent != null) {
+			if (this.owner == null || this.owner.getId() == null) {
+				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+			}
+			targetParent.validateOwner(this.owner.getId());
+		}
+		this.parent = targetParent;
 	}
 
 	public void softDelete() {

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -12,6 +12,8 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 	Optional<Folder> findByIdAndDeletedAtIsNull(Long id);
 
+	boolean existsByOwner_IdAndParent_IdAndDeletedAtIsNull(Long ownerId, Long parentId);
+
 	@Query("""
 			select f
 			from Folder f
@@ -65,4 +67,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			order by f.name asc
 			""")
 	List<FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
+
+
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -67,6 +67,4 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			order by f.name asc
 			""")
 	List<FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
-
-
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -4,6 +4,7 @@ import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
@@ -159,6 +161,42 @@ public class FolderService {
 	}
 
 	@Transactional
+	public FolderSummaryResult moveFolder(FolderMoveCommand command) {
+		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(command.folderId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+		Long userId = command.userId();
+		Long folderId = command.folderId();
+		Long targetParentId = command.parentId();
+		Long currentParentId = folder.getParent() != null ? folder.getParent().getId() : null;
+
+		folder.validateOwner(userId);
+
+		if (Objects.equals(folderId, targetParentId)) {
+			throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+		}
+
+		if (Objects.equals(currentParentId, targetParentId)) {
+			return FolderSummaryResult.from(folder);
+		}
+
+		Folder targetParent = null;
+		if (targetParentId != null) {
+			targetParent = folderRepository.findByIdAndDeletedAtIsNull(targetParentId)
+					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+			targetParent.validateOwner(userId);
+			validateMoveTarget(userId, folderId, targetParentId);
+		}
+
+		if (isDuplicatedFolderName(userId, targetParent, folder.getName())) {
+			throw new BusinessException(ErrorCode.FOLDER_NAME_DUPLICATED);
+		}
+
+		folder.moveTo(targetParent);
+		return FolderSummaryResult.from(folder);
+	}
+
+	@Transactional
 	public void deleteFolder(Long userId, Long folderId) {
 		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(folderId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
@@ -176,6 +214,21 @@ public class FolderService {
 		}
 
 		folder.softDelete();
+	}
+
+	private void validateMoveTarget(Long userId, Long folderId, Long targetParentId) {
+		Map<Long, Long> parentMap = new LinkedHashMap<>();
+		for (FolderTreeRow row : folderRepository.findTreeRows(userId)) {
+			parentMap.put(row.folderId(), row.parentId());
+		}
+
+		Long currentId = targetParentId;
+		while (currentId != null) {
+			if (currentId.equals(folderId)) {
+				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+			}
+			currentId = parentMap.get(currentId);
+		}
 	}
 
 	private String normalizeName(String raw) {

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -9,6 +9,7 @@ import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class FolderService {
 
 	private final UserRepository userRepository;
 	private final FolderRepository folderRepository;
+	private final NoteRepository noteRepository;
 	private static final int MAX_TREE_DEPTH = 200;
 
 	@Transactional
@@ -154,6 +156,26 @@ public class FolderService {
 				parent != null ? parent.getId() : null,
 				folder.getName()
 		);
+	}
+
+	@Transactional
+	public void deleteFolder(Long userId, Long folderId) {
+		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(folderId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+		folder.validateOwner(userId);
+
+		boolean hasChildren = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
+		if (hasChildren) {
+			throw new BusinessException(ErrorCode.FOLDER_NOT_EMPTY);
+		}
+
+		boolean hasNotes = noteRepository.existsByFolder_IdAndDeletedAtIsNull(folderId);
+		if (hasNotes) {
+			throw new BusinessException(ErrorCode.FOLDER_NOT_EMPTY);
+		}
+
+		folder.softDelete();
 	}
 
 	private String normalizeName(String raw) {

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -222,8 +222,13 @@ public class FolderService {
 			parentMap.put(row.folderId(), row.parentId());
 		}
 
+		Set<Long> visited = new HashSet<>();
 		Long currentId = targetParentId;
+
 		while (currentId != null) {
+			if (!visited.add(currentId)) {
+				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+			}
 			if (currentId.equals(folderId)) {
 				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
 			}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
@@ -1,0 +1,8 @@
+package com.keepgoing.keepgoing.folder.service.dto;
+
+public record FolderMoveCommand(
+		Long userId,
+		Long folderId,
+		Long parentId
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -192,8 +192,7 @@ public enum ErrorCode {
 			HttpStatus.BAD_REQUEST,
 			"FOLDER_005",
 			"허용되지 않는 폴더 이동입니다."
-			)
-	,
+	),
 	FOLDER_NOT_EMPTY(
 			HttpStatus.CONFLICT,
 			"FOLDER_006",

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -188,9 +188,15 @@ public enum ErrorCode {
 			"FOLDER_004",
 			"허용되지 않는 폴더 이름입니다."
 	),
+	FOLDER_MOVE_INVALID(
+			HttpStatus.BAD_REQUEST,
+			"FOLDER_005",
+			"허용되지 않는 폴더 이동입니다."
+			)
+	,
 	FOLDER_NOT_EMPTY(
 			HttpStatus.CONFLICT,
-			"FOLDER_005",
+			"FOLDER_006",
 			"하위 폴더 또는 노트가 남아 있어 삭제할 수 없습니다."
 	)
 	;

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -186,7 +186,14 @@ public enum ErrorCode {
 	FOLDER_INVALID_NAME(
 			HttpStatus.BAD_REQUEST,
 			"FOLDER_004",
-			"허용되지 않는 폴더 이름입니다.");
+			"허용되지 않는 폴더 이름입니다."
+	),
+	FOLDER_NOT_EMPTY(
+			HttpStatus.CONFLICT,
+			"FOLDER_005",
+			"하위 폴더 또는 노트가 남아 있어 삭제할 수 없습니다."
+	)
+	;
 
 	private final HttpStatus httpStatus;
 	private final String code;        // 시스템 내부/프론트에서 쓰는 에러 코드

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -14,43 +14,43 @@ import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
-    @Override
-    @EntityGraph(attributePaths = {"author"})
-    Optional<Note> findById(Long id);
+	@Override
+	@EntityGraph(attributePaths = {"author"})
+	Optional<Note> findById(Long id);
 
 	boolean existsByFolder_IdAndDeletedAtIsNull(Long folderId);
 
-    /**
-     * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
-     */
-    @EntityGraph(attributePaths = {"author"})
-    Page<Note> findByAuthor_Id(Long authorId, Pageable pageable);
+	/**
+	 * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
+	 */
+	@EntityGraph(attributePaths = {"author"})
+	Page<Note> findByAuthor_Id(Long authorId, Pageable pageable);
 
-    /**
-     * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
-     */
-    @EntityGraph(attributePaths = {"author"})
-    List<Note> findByVisibilityOrderByCreatedAtDesc(NoteVisibility visibility);
+	/**
+	 * visibility 값으로 필터해서, createdAt 기준 내림차순으로 정렬해서 찾는다.
+	 */
+	@EntityGraph(attributePaths = {"author"})
+	List<Note> findByVisibilityOrderByCreatedAtDesc(NoteVisibility visibility);
 
 	// TODO: 기존 성능 최적화(Mysql 기반)을 단순 검색으로 전환했으므로 이를 Postgres에 맞게 전환하는 작업 필요
-    // 전체 검색(derived query)
-    @EntityGraph(attributePaths = {"author"})
-    Page<Note> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
-            String titleKeyword,
-            String contentKeyword,
-            Pageable pageable
-    );
+	// 전체 검색(derived query)
+	@EntityGraph(attributePaths = {"author"})
+	Page<Note> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(
+			String titleKeyword,
+			String contentKeyword,
+			Pageable pageable
+	);
 
-    // 내 글 검색(작성자 조건 포함)
-    @Query("""
-             SELECT n
-            FROM Note n
-            WHERE n.author.id = :authorId
-              AND (LOWER(n.title) LIKE CONCAT('%', LOWER(:keyword), '%')
-                   OR LOWER(n.content) LIKE CONCAT('%', LOWER(:keyword), '%'))
-              ORDER BY n.createdAt DESC, n.id DESC
-            """)
-    Page<Note> searchMyNotes(@Param("authorId") Long authorId,
-                             @Param("keyword") String keyword,
-                             Pageable pageable);
+	// 내 글 검색(작성자 조건 포함)
+	@Query("""
+			 SELECT n
+			FROM Note n
+			WHERE n.author.id = :authorId
+			  AND (LOWER(n.title) LIKE CONCAT('%', LOWER(:keyword), '%')
+			       OR LOWER(n.content) LIKE CONCAT('%', LOWER(:keyword), '%'))
+			  ORDER BY n.createdAt DESC, n.id DESC
+			""")
+	Page<Note> searchMyNotes(@Param("authorId") Long authorId,
+	                         @Param("keyword") String keyword,
+	                         Pageable pageable);
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -18,6 +18,8 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     @EntityGraph(attributePaths = {"author"})
     Optional<Note> findById(Long id);
 
+	boolean existsByFolder_IdAndDeletedAtIsNull(Long folderId);
+
     /**
      * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
      */

--- a/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/repository/NoteRepository.java
@@ -18,6 +18,11 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 	Optional<Note> findById(Long id);
 
 	/**
+	 * 삭제되지 않은 노트가 해당 폴더에 하나 이상 존재하는지 확인한다.
+	 */
+	boolean existsByFolder_IdAndDeletedAtIsNull(Long folderId);
+
+	/**
 	 * authorId 로 필터해서, 전달받은 Pageable 조건(페이지/정렬)에 맞게 조회한다.
 	 */
 	@EntityGraph(attributePaths = {"author"})

--- a/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
@@ -19,11 +19,14 @@ import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderRenameRequest;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
+import com.keepgoing.keepgoing.global.api.exception.GlobalExceptionHandler;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.global.config.JacksonConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import java.util.List;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -44,6 +48,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FolderController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, JacksonConfig.class})
 class FolderControllerTest {
 
 	public static final String DIRECTORY_NAME = "backend";
@@ -276,6 +281,204 @@ class FolderControllerTest {
 			mockMvc.perform(patch("/api/folders/{folderId}", folderId)
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isConflict())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NAME_DUPLICATED.toString()));
+		}
+	}
+
+	@Nested
+	@DisplayName("PATCH /api/folders/{folderId}/parent")
+	class PatchFolderParent {
+
+		@Test
+		@DisplayName("유효한 요청이면 폴더를 다른 부모 아래로 이동한다.")
+		void moveFolder_returnsOk() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long parentId = 20L;
+			var result = new FolderSummaryResult(folderId, parentId, DIRECTORY_NAME);
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willReturn(result);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.folderId").value(folderId))
+					.andExpect(jsonPath("$.data.parentId").value(parentId))
+					.andExpect(jsonPath("$.data.name").value(DIRECTORY_NAME));
+
+			verify(folderService).moveFolder(argThat(command ->
+					command.userId().equals(userId)
+							&& command.folderId().equals(folderId)
+							&& command.parentId().equals(parentId)
+			));
+		}
+
+		@Test
+		@DisplayName("parentId가 null이면 루트로 이동한다.")
+		void moveFolder_returnsOkWhenMovingToRoot() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			var result = new FolderSummaryResult(folderId, null, DIRECTORY_NAME);
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willReturn(result);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": null}
+									"""))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.folderId").value(folderId))
+					.andExpect(jsonPath("$.data.parentId").value(nullValue()))
+					.andExpect(jsonPath("$.data.name").value(DIRECTORY_NAME));
+
+			verify(folderService).moveFolder(argThat(command ->
+					command.userId().equals(userId)
+							&& command.folderId().equals(folderId)
+							&& command.parentId() == null
+			));
+		}
+
+		@Test
+		@DisplayName("parentId 필드가 없으면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenParentIdIsMissing() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("{}"))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("parentId"));
+
+			verifyNoInteractions(folderService);
+		}
+
+		@Test
+		@DisplayName("parentId가 0 이하면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenParentIdIsNotPositive() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 0}
+									"""))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("parentId"));
+
+			verifyNoInteractions(folderService);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 404 Not Found를 반환한다.")
+		void moveFolder_returnsNotFoundWhenFolderDoesNotExist() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NOT_FOUND.toString()));
+		}
+
+		@Test
+		@DisplayName("접근 권한이 없으면 403 Forbidden을 반환한다.")
+		void moveFolder_returnsForbiddenWhenAccessDenied() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_ACCESS_DENIED));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_ACCESS_DENIED.toString()));
+		}
+
+		@Test
+		@DisplayName("허용되지 않는 이동이면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenMoveIsInvalid() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_MOVE_INVALID));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_MOVE_INVALID.toString()));
+		}
+
+		@Test
+		@DisplayName("같은 이름의 폴더가 이미 있으면 409 Conflict를 반환한다.")
+		void moveFolder_returnsConflictWhenFolderNameDuplicated() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NAME_DUPLICATED));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
 					.andExpect(status().isConflict())
 					.andExpect(jsonPath("$.success").value(false))
 					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NAME_DUPLICATED.toString()));

--- a/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
@@ -4,8 +4,10 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -368,6 +370,80 @@ class FolderControllerTest {
 					.andExpect(jsonPath("$.data[0].children[0].name").value("spring"));
 
 			verify(folderService).getFolderTree(userId);
+		}
+	}
+
+	@Nested
+	@DisplayName("DELETE /api/folders/{folderId}")
+	class DeleteFolder {
+
+		@Test
+		@DisplayName("유효한 요청이면 204 No Content를 반환한다")
+		void deleteFolder_returnsNoContent() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(delete("/api/folders/{folderId}", folderId))
+					.andExpect(status().isNoContent());
+
+			verify(folderService).deleteFolder(userId, folderId);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 404 Not Found를 반환한다")
+		void deleteFolder_returnsNotFoundWhenFolderDoesNotExist() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND))
+					.given(folderService).deleteFolder(userId, folderId);
+
+			// when & then
+			mockMvc.perform(delete("/api/folders/{folderId}", folderId))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NOT_FOUND.toString()));
+		}
+
+		@Test
+		@DisplayName("접근 권한이 없으면 403 Forbidden을 반환한다")
+		void deleteFolder_returnsForbiddenWhenAccessDenied() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			willThrow(new BusinessException(ErrorCode.FOLDER_ACCESS_DENIED))
+					.given(folderService).deleteFolder(userId, folderId);
+
+			// when & then
+			mockMvc.perform(delete("/api/folders/{folderId}", folderId))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_ACCESS_DENIED.toString()));
+		}
+
+		@Test
+		@DisplayName("폴더가 비어있지 않으면 409 Conflict를 반환한다")
+		void deleteFolder_returnsConflictWhenFolderIsNotEmpty() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			willThrow(new BusinessException(ErrorCode.FOLDER_NOT_EMPTY))
+					.given(folderService).deleteFolder(userId, folderId);
+
+			// when & then
+			mockMvc.perform(delete("/api/folders/{folderId}", folderId))
+					.andExpect(status().isConflict())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NOT_EMPTY.toString()));
 		}
 	}
 

--- a/src/test/java/com/keepgoing/keepgoing/folder/domain/FolderTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/domain/FolderTest.java
@@ -166,6 +166,46 @@ class FolderTest {
 	}
 
 	@Test
+	@DisplayName("같은 사용자의 부모 폴더로 이동한다")
+	void moveTo_changesParentWhenOwnerMatched() {
+		User owner = user(1L);
+		Folder parent = Folder.create(owner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		folder.moveTo(parent);
+
+		assertThat(folder.getParent()).isEqualTo(parent);
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 부모 폴더로는 이동할 수 없다")
+	void moveTo_throwsWhenParentOwnerDoesNotMatch() {
+		User owner = user(1L);
+		User otherOwner = user(2L);
+
+		Folder parent = Folder.create(otherOwner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		assertThatThrownBy(() -> folder.moveTo(parent))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("소유자 ID가 없으면 부모 폴더로 이동할 수 없다")
+	void moveTo_throwsWhenOwnerIdIsNull() {
+		User owner = user(1L);
+		Folder parent = Folder.create(owner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		ReflectionTestUtils.setField(owner, "id", null);
+
+		assertThatThrownBy(() -> folder.moveTo(parent))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+
+	@Test
 	@DisplayName("폴더를 소프트 삭제한다")
 	void softDelete_marksFolderAtDeleted() {
 		User owner = user(1L);

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -22,192 +22,192 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(JpaAuditingConfig.class)
 public class FolderRepositoryTest {
 
-    @Autowired
-    private FolderRepository folderRepository;
+	@Autowired
+	private FolderRepository folderRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+	@Autowired
+	private UserRepository userRepository;
 
-    private User user1;
-    private User user2;
+	private User user1;
+	private User user2;
 
-    @BeforeEach
-    void setUp() {
-        user1 = userRepository.save(User.create("user1@test.com", "유저1"));
-        user2 = userRepository.save(User.create("user2@test.com", "유저2"));
-    }
+	@BeforeEach
+	void setUp() {
+		user1 = userRepository.save(User.create("user1@test.com", "유저1"));
+		user2 = userRepository.save(User.create("user2@test.com", "유저2"));
+	}
 
-    @Nested
-    @DisplayName("FindFolders")
-    class FindFolders {
+	@Nested
+	@DisplayName("FindFolders")
+	class FindFolders {
 
-        @Test
-        @DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")
-        void findRootFolders_ordersByName_and_excludesDeleted() {
-            // given
-            Folder a = folderRepository.save(Folder.create(user1, null, "a"));
-            Folder b = folderRepository.save(Folder.create(user1, null, "b"));
-            Folder other = folderRepository.save(Folder.create(user2, null, "aa"));
+		@Test
+		@DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+		void findRootFolders_ordersByName_and_excludesDeleted() {
+			// given
+			Folder a = folderRepository.save(Folder.create(user1, null, "a"));
+			Folder b = folderRepository.save(Folder.create(user1, null, "b"));
+			Folder other = folderRepository.save(Folder.create(user2, null, "aa"));
 
-            Folder deleted = folderRepository.save(Folder.create(user1, null, "c"));
-            deleted.softDelete();
-            folderRepository.save(deleted);
+			Folder deleted = folderRepository.save(Folder.create(user1, null, "c"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
 
-            // when
-            List<Folder> result = folderRepository.findRootFolders(user1.getId());
+			// when
+			List<Folder> result = folderRepository.findRootFolders(user1.getId());
 
-            // then
-            assertThat(result).extracting(Folder::getName)
-                    .containsExactly("a", "b");
-        }
+			// then
+			assertThat(result).extracting(Folder::getName)
+					.containsExactly("a", "b");
+		}
 
-        @Test
-        @DisplayName("findChildFolders: 특정 parent의 자식 폴더를 name ASC로 조회하고 soft delete는 제외한다")
-        void findChildFolders_ordersByName_and_excludesDeleted() {
-            // given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-            Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
+		@Test
+		@DisplayName("findChildFolders: 특정 parent의 자식 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+		void findChildFolders_ordersByName_and_excludesDeleted() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+			Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
 
-            Folder c1 = folderRepository.save(Folder.create(user1, parent, "backend"));
-            Folder c2 = folderRepository.save(Folder.create(user1, parent, "frontend"));
-            folderRepository.save(Folder.create(user2, otherParent, "zzz"));
+			Folder c1 = folderRepository.save(Folder.create(user1, parent, "backend"));
+			Folder c2 = folderRepository.save(Folder.create(user1, parent, "frontend"));
+			folderRepository.save(Folder.create(user2, otherParent, "zzz"));
 
-            Folder deleted = folderRepository.save(Folder.create(user1, parent, "old"));
-            deleted.softDelete();
-            folderRepository.save(deleted);
+			Folder deleted = folderRepository.save(Folder.create(user1, parent, "old"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
 
-            // when
-            List<Folder> result = folderRepository.findChildFolders(user1.getId(), parent.getId());
+			// when
+			List<Folder> result = folderRepository.findChildFolders(user1.getId(), parent.getId());
 
-            // then
-            assertThat(result).extracting(Folder::getName)
-                    .containsExactly("backend", "frontend");
+			// then
+			assertThat(result).extracting(Folder::getName)
+					.containsExactly("backend", "frontend");
 
-        }
+		}
 
-        @Test
-        @DisplayName("existChildFolder: 내 동일 parent 아래 같은 이름이 있으면 true를 반환한다")
-        void existsChildFolder_works() {
-            //given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-            folderRepository.save(Folder.create(user1, parent, "spring"));
+		@Test
+		@DisplayName("existChildFolder: 내 동일 parent 아래 같은 이름이 있으면 true를 반환한다")
+		void existsChildFolder_works() {
+			//given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+			folderRepository.save(Folder.create(user1, parent, "spring"));
 
-            // expect
-            assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "spring")).isTrue();
-            assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "DB")).isFalse();
-            assertThat(folderRepository.existsChildFolder(user2.getId(), parent.getId(), "spring")).isFalse();
-        }
+			// expect
+			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "spring")).isTrue();
+			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "DB")).isFalse();
+			assertThat(folderRepository.existsChildFolder(user2.getId(), parent.getId(), "spring")).isFalse();
+		}
 
-        @Test
-        @DisplayName("findTreeRows: 루트 포함 + parentId 매핑 + name ASC + soft delete 제외")
-        void findTreeRows_includesRoot_and_mapsParentId_and_ordersByName() {
-            // given
-            Folder rootA = folderRepository.save(Folder.create(user1, null, "A"));
-            Folder rootB = folderRepository.save(Folder.create(user1, null, "B"));
-            Folder child = folderRepository.save(Folder.create(user1, rootA, "AA"));
+		@Test
+		@DisplayName("findTreeRows: 루트 포함 + parentId 매핑 + name ASC + soft delete 제외")
+		void findTreeRows_includesRoot_and_mapsParentId_and_ordersByName() {
+			// given
+			Folder rootA = folderRepository.save(Folder.create(user1, null, "A"));
+			Folder rootB = folderRepository.save(Folder.create(user1, null, "B"));
+			Folder child = folderRepository.save(Folder.create(user1, rootA, "AA"));
 
-            Folder deleted = folderRepository.save(Folder.create(user1, null, "C"));
-            deleted.softDelete();
-            folderRepository.save(deleted);
+			Folder deleted = folderRepository.save(Folder.create(user1, null, "C"));
+			deleted.softDelete();
+			folderRepository.save(deleted);
 
-            folderRepository.save(Folder.create(user2, null, "2"));
+			folderRepository.save(Folder.create(user2, null, "2"));
 
-            // when
-            List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
+			// when
+			List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
 
-            // then
-            assertThat(rows).extracting(FolderTreeRow::name)
-                    .containsExactly("A", "AA", "B");
+			// then
+			assertThat(rows).extracting(FolderTreeRow::name)
+					.containsExactly("A", "AA", "B");
 
-            FolderTreeRow aRow = rows.stream()
-                    .filter(r -> r.folderId()
-                            .equals(rootA.getId()))
-                    .findFirst()
-                    .orElseThrow();
-            assertThat(aRow.parentId()).isNull();
+			FolderTreeRow aRow = rows.stream()
+					.filter(r -> r.folderId()
+							.equals(rootA.getId()))
+					.findFirst()
+					.orElseThrow();
+			assertThat(aRow.parentId()).isNull();
 
-            FolderTreeRow aaRow = rows.stream()
-                    .filter(r -> r.folderId()
-                            .equals(child.getId()))
-                    .findFirst()
-                    .orElseThrow();
-            assertThat(aaRow.parentId()).isEqualTo(rootA.getId());
-        }
-    }
+			FolderTreeRow aaRow = rows.stream()
+					.filter(r -> r.folderId()
+							.equals(child.getId()))
+					.findFirst()
+					.orElseThrow();
+			assertThat(aaRow.parentId()).isEqualTo(rootA.getId());
+		}
+	}
 
-    @Nested
-    @DisplayName("ExistsFolders")
-    class ExistsFolders {
+	@Nested
+	@DisplayName("ExistsFolders")
+	class ExistsFolders {
 
-        @Test
-        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 활성 자식 폴더가 있으면 true를 반환한다.")
-        void existsActiveChildFolder_returnsTrue() {
-            // given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-            folderRepository.save(Folder.create(user1, parent, "child"));
+		@Test
+		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 활성 자식 폴더가 있으면 true를 반환한다.")
+		void existsActiveChildFolder_returnsTrue() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+			folderRepository.save(Folder.create(user1, parent, "child"));
 
-            // when
-            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
-                    user1.getId(),
-                    parent.getId()
-            );
+			// when
+			boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+					user1.getId(),
+					parent.getId()
+			);
 
-            // then
-            assertThat(result).isTrue();
-        }
+			// then
+			assertThat(result).isTrue();
+		}
 
-        @Test
-        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 자식 폴더가 없으면 false를 반환한다")
-        void existActiveChildFolder_returnsFalseWhenNoChildExist() {
-            // given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+		@Test
+		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 자식 폴더가 없으면 false를 반환한다")
+		void existActiveChildFolder_returnsFalseWhenNoChildExist() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
 
-            // when
-            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
-                    user1.getId(),
-                    parent.getId()
-            );
+			// when
+			boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+					user1.getId(),
+					parent.getId()
+			);
 
-            // then
-            assertThat(result).isFalse();
-        }
+			// then
+			assertThat(result).isFalse();
+		}
 
-        @Test
-        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 삭제된 자식 폴더만 있으면 false를 반환한다")
-        void existActiveChildFolder_returnsFalseWhenOnlyDeletedChildExists() {
-            // given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-            Folder deletedChild = folderRepository.save(Folder.create(user1, parent, "child"));
-            deletedChild.softDelete();
-            folderRepository.save(deletedChild);
+		@Test
+		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 삭제된 자식 폴더만 있으면 false를 반환한다")
+		void existActiveChildFolder_returnsFalseWhenOnlyDeletedChildExists() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+			Folder deletedChild = folderRepository.save(Folder.create(user1, parent, "child"));
+			deletedChild.softDelete();
+			folderRepository.save(deletedChild);
 
-            // when
-            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
-                    user1.getId(),
-                    parent.getId()
-            );
+			// when
+			boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+					user1.getId(),
+					parent.getId()
+			);
 
-            // then
-            assertThat(result).isFalse();
-        }
+			// then
+			assertThat(result).isFalse();
+		}
 
-        @Test
-        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 다른 사용자의 자식 폴더는 제외한다")
-        void existsActiveChildFolder_returnsFalseWhenChildBelongsToAnotherUser() {
-            // given
-            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+		@Test
+		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 다른 사용자의 자식 폴더는 제외한다")
+		void existsActiveChildFolder_returnsFalseWhenChildBelongsToAnotherUser() {
+			// given
+			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
 
-            Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
-            folderRepository.save(Folder.create(user2, otherParent, "other-child"));
+			Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
+			folderRepository.save(Folder.create(user2, otherParent, "other-child"));
 
-            // when
-            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
-                    user1.getId(),
-                    parent.getId()
-            );
+			// when
+			boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+					user1.getId(),
+					parent.getId()
+			);
 
-            // then
-            assertThat(result).isFalse();
-        }
-    }
+			// then
+			assertThat(result).isFalse();
+		}
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -1,14 +1,11 @@
 package com.keepgoing.keepgoing.folder.repository;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.global.config.JpaAuditingConfig;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,120 +14,200 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
 public class FolderRepositoryTest {
 
-	@Autowired
-	private FolderRepository folderRepository;
+    @Autowired
+    private FolderRepository folderRepository;
 
-	@Autowired
-	private UserRepository userRepository;
+    @Autowired
+    private UserRepository userRepository;
 
-	private User user1;
-	private User user2;
+    private User user1;
+    private User user2;
 
-	@BeforeEach
-	void setUp() {
-		user1 = userRepository.save(User.create("user1@test.com", "유저1"));
-		user2 = userRepository.save(User.create("user2@test.com", "유저2"));
-	}
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(User.create("user1@test.com", "유저1"));
+        user2 = userRepository.save(User.create("user2@test.com", "유저2"));
+    }
 
-	@Nested
-	@DisplayName("FindFolders")
-	class FindFolders {
+    @Nested
+    @DisplayName("FindFolders")
+    class FindFolders {
 
-		@Test
-		@DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")
-		void findRootFolders_ordersByName_and_excludesDeleted() {
-			// given
-			Folder a = folderRepository.save(Folder.create(user1, null, "a"));
-			Folder b = folderRepository.save(Folder.create(user1, null, "b"));
-			Folder other = folderRepository.save(Folder.create(user2, null, "aa"));
+        @Test
+        @DisplayName("findRootFolders: 내 루트 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+        void findRootFolders_ordersByName_and_excludesDeleted() {
+            // given
+            Folder a = folderRepository.save(Folder.create(user1, null, "a"));
+            Folder b = folderRepository.save(Folder.create(user1, null, "b"));
+            Folder other = folderRepository.save(Folder.create(user2, null, "aa"));
 
-			Folder deleted = folderRepository.save(Folder.create(user1, null, "c"));
-			deleted.softDelete();
-			folderRepository.save(deleted);
+            Folder deleted = folderRepository.save(Folder.create(user1, null, "c"));
+            deleted.softDelete();
+            folderRepository.save(deleted);
 
-			// when
-			List<Folder> result = folderRepository.findRootFolders(user1.getId());
+            // when
+            List<Folder> result = folderRepository.findRootFolders(user1.getId());
 
-			// then
-			assertThat(result).extracting(Folder::getName)
-					.containsExactly("a", "b");
-		}
+            // then
+            assertThat(result).extracting(Folder::getName)
+                    .containsExactly("a", "b");
+        }
 
-		@Test
-		@DisplayName("findChildFolders: 특정 parent의 자식 폴더를 name ASC로 조회하고 soft delete는 제외한다")
-		void findChildFolders_ordersByName_and_excludesDeleted() {
-			// given
-			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-			Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
+        @Test
+        @DisplayName("findChildFolders: 특정 parent의 자식 폴더를 name ASC로 조회하고 soft delete는 제외한다")
+        void findChildFolders_ordersByName_and_excludesDeleted() {
+            // given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+            Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
 
-			Folder c1 = folderRepository.save(Folder.create(user1, parent, "backend"));
-			Folder c2 = folderRepository.save(Folder.create(user1, parent, "frontend"));
-			folderRepository.save(Folder.create(user2, otherParent, "zzz"));
+            Folder c1 = folderRepository.save(Folder.create(user1, parent, "backend"));
+            Folder c2 = folderRepository.save(Folder.create(user1, parent, "frontend"));
+            folderRepository.save(Folder.create(user2, otherParent, "zzz"));
 
-			Folder deleted = folderRepository.save(Folder.create(user1, parent, "old"));
-			deleted.softDelete();
-			folderRepository.save(deleted);
+            Folder deleted = folderRepository.save(Folder.create(user1, parent, "old"));
+            deleted.softDelete();
+            folderRepository.save(deleted);
 
-			// when
-			List<Folder> result = folderRepository.findChildFolders(user1.getId(), parent.getId());
+            // when
+            List<Folder> result = folderRepository.findChildFolders(user1.getId(), parent.getId());
 
-			// then
-			assertThat(result).extracting(Folder::getName)
-					.containsExactly("backend", "frontend");
+            // then
+            assertThat(result).extracting(Folder::getName)
+                    .containsExactly("backend", "frontend");
 
-		}
+        }
 
-		@Test
-		@DisplayName("existChildFolder: 내 동일 parent 아래 같은 이름이 있으면 true를 반환한다")
-		void existsChildFolder_works() {
-			//given
-			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
-			folderRepository.save(Folder.create(user1, parent, "spring"));
+        @Test
+        @DisplayName("existChildFolder: 내 동일 parent 아래 같은 이름이 있으면 true를 반환한다")
+        void existsChildFolder_works() {
+            //given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+            folderRepository.save(Folder.create(user1, parent, "spring"));
 
-			// expect
-			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "spring")).isTrue();
-			assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "DB")).isFalse();
-			assertThat(folderRepository.existsChildFolder(user2.getId(), parent.getId(), "spring")).isFalse();
-		}
+            // expect
+            assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "spring")).isTrue();
+            assertThat(folderRepository.existsChildFolder(user1.getId(), parent.getId(), "DB")).isFalse();
+            assertThat(folderRepository.existsChildFolder(user2.getId(), parent.getId(), "spring")).isFalse();
+        }
 
-		@Test
-		@DisplayName("findTreeRows: 루트 포함 + parentId 매핑 + name ASC + soft delete 제외")
-		void findTreeRows_includesRoot_and_mapsParentId_and_ordersByName() {
-			// given
-			Folder rootA = folderRepository.save(Folder.create(user1, null, "A"));
-			Folder rootB = folderRepository.save(Folder.create(user1, null, "B"));
-			Folder child = folderRepository.save(Folder.create(user1, rootA, "AA"));
+        @Test
+        @DisplayName("findTreeRows: 루트 포함 + parentId 매핑 + name ASC + soft delete 제외")
+        void findTreeRows_includesRoot_and_mapsParentId_and_ordersByName() {
+            // given
+            Folder rootA = folderRepository.save(Folder.create(user1, null, "A"));
+            Folder rootB = folderRepository.save(Folder.create(user1, null, "B"));
+            Folder child = folderRepository.save(Folder.create(user1, rootA, "AA"));
 
-			Folder deleted = folderRepository.save(Folder.create(user1, null, "C"));
-			deleted.softDelete();
-			folderRepository.save(deleted);
+            Folder deleted = folderRepository.save(Folder.create(user1, null, "C"));
+            deleted.softDelete();
+            folderRepository.save(deleted);
 
-			folderRepository.save(Folder.create(user2, null, "2"));
+            folderRepository.save(Folder.create(user2, null, "2"));
 
-			// when
-			List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
+            // when
+            List<FolderTreeRow> rows = folderRepository.findTreeRows(user1.getId());
 
-			// then
-			assertThat(rows).extracting(FolderTreeRow::name)
-					.containsExactly("A", "AA", "B");
+            // then
+            assertThat(rows).extracting(FolderTreeRow::name)
+                    .containsExactly("A", "AA", "B");
 
-			FolderTreeRow aRow = rows.stream()
-					.filter(r -> r.folderId()
-							.equals(rootA.getId()))
-					.findFirst()
-					.orElseThrow();
-			assertThat(aRow.parentId()).isNull();
+            FolderTreeRow aRow = rows.stream()
+                    .filter(r -> r.folderId()
+                            .equals(rootA.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(aRow.parentId()).isNull();
 
-			FolderTreeRow aaRow = rows.stream()
-					.filter(r -> r.folderId()
-							.equals(child.getId()))
-					.findFirst()
-					.orElseThrow();
-			assertThat(aaRow.parentId()).isEqualTo(rootA.getId());
-		}
-	}
+            FolderTreeRow aaRow = rows.stream()
+                    .filter(r -> r.folderId()
+                            .equals(child.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(aaRow.parentId()).isEqualTo(rootA.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("ExistsFolders")
+    class ExistsFolders {
+
+        @Test
+        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 활성 자식 폴더가 있으면 true를 반환한다.")
+        void existsActiveChildFolder_returnsTrue() {
+            // given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+            folderRepository.save(Folder.create(user1, parent, "child"));
+
+            // when
+            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+                    user1.getId(),
+                    parent.getId()
+            );
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 자식 폴더가 없으면 false를 반환한다")
+        void existActiveChildFolder_returnsFalseWhenNoChildExist() {
+            // given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+
+            // when
+            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+                    user1.getId(),
+                    parent.getId()
+            );
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 삭제된 자식 폴더만 있으면 false를 반환한다")
+        void existActiveChildFolder_returnsFalseWhenOnlyDeletedChildExists() {
+            // given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+            Folder deletedChild = folderRepository.save(Folder.create(user1, parent, "child"));
+            deletedChild.softDelete();
+            folderRepository.save(deletedChild);
+
+            // when
+            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+                    user1.getId(),
+                    parent.getId()
+            );
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 다른 사용자의 자식 폴더는 제외한다")
+        void existsActiveChildFolder_returnsFalseWhenChildBelongsToAnotherUser() {
+            // given
+            Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
+
+            Folder otherParent = folderRepository.save(Folder.create(user2, null, "other-root"));
+            folderRepository.save(Folder.create(user2, otherParent, "other-child"));
+
+            // when
+            boolean result = folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(
+                    user1.getId(),
+                    parent.getId()
+            );
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/repository/FolderRepositoryTest.java
@@ -158,7 +158,7 @@ public class FolderRepositoryTest {
 
 		@Test
 		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 자식 폴더가 없으면 false를 반환한다")
-		void existActiveChildFolder_returnsFalseWhenNoChildExist() {
+		void existsActiveChildFolder_returnsFalseWhenNoChildExist() {
 			// given
 			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
 
@@ -174,7 +174,7 @@ public class FolderRepositoryTest {
 
 		@Test
 		@DisplayName("existsByOwner_IdAndParent_IdAndDeletedAtIsNull: 삭제된 자식 폴더만 있으면 false를 반환한다")
-		void existActiveChildFolder_returnsFalseWhenOnlyDeletedChildExists() {
+		void existsActiveChildFolder_returnsFalseWhenOnlyDeletedChildExists() {
 			// given
 			Folder parent = folderRepository.save(Folder.create(user1, null, "root"));
 			Folder deletedChild = folderRepository.save(Folder.create(user1, parent, "child"));

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -17,6 +17,7 @@ import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.ArrayList;
@@ -25,8 +26,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,6 +42,9 @@ class FolderServiceTest {
 
 	@Mock
 	FolderRepository folderRepository;
+
+	@Mock
+	NoteRepository noteRepository;
 
 	@InjectMocks
 	FolderService folderService;
@@ -651,6 +655,127 @@ class FolderServiceTest {
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
 			verify(folderRepository).existsChildFolder(userId, parentId, "test");
 			verifyNoMoreInteractions(folderRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("deleteFolder()")
+	class DeleteFolder {
+
+		@Test
+		@DisplayName("자식 폴더가 없으면 soft delete 처리한다.")
+		void deleteFolder_softDeletesWhenNoChildren() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(false);
+
+			// when
+			folderService.deleteFolder(userId, folderId);
+
+			// then
+			Object deletedAt = ReflectionTestUtils.getField(folder, "deletedAt");
+			assertThat(deletedAt).isNotNull();
+			assertThat(folder.isDeleted()).isTrue();
+			assertThat(folder.getDeletedAt()).isNotNull();
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
+			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void deleteFolder_throwsWhenFolderNotFound() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		void deleteFolder_throwsWhenFolderOwnedByAnotherUser() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+
+			User other = user(99L);
+			Folder folder = Folder.create(other, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+
+		@Test
+		@DisplayName("자식 폴더가 있으면 FOLDER_NOT_EMPTY 예외가 발생한다")
+		void deleteFolder_throwsWhenFolderHasChildren() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_EMPTY);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+
+		@Test
+		@DisplayName("노트가 있으면 FOLDER_NOT_EMPTY 예외가 발생한다")
+		void deleteFolder_throwsWhenFolderHasNotes() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(false);
+			given(noteRepository.existsByFolder_IdAndDeletedAtIsNull(folderId)).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_EMPTY);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
+			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository);
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -6,12 +6,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -776,6 +778,353 @@ class FolderServiceTest {
 			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
 			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
 			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("moveFolder()")
+	class MoveFolder {
+
+		@Test
+		@DisplayName("루트 폴더를 다른 부모 아래로 이동한다")
+		void moveFolder_movesRootFolderToAnotherParent() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, null, "root")
+			));
+			given(folderRepository.existsChildFolder(userId, targetParentId, "backend")).willReturn(false);
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isEqualTo(targetParentId);
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isEqualTo(targetParent);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("하위 폴더를 루트로 이동한다")
+		void moveFolder_movesChildFolderToRoot() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(false);
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isNull();
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isNull();
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsRootFolder(userId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("같은 부모로 이동하면 그대로 반환한다")
+		void moveFolder_returnsCurrentFolderWhenTargetParentIsSame() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, currentParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isEqualTo(currentParentId);
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isEqualTo(currentParent);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void moveFolder_throwsWhenFolderNotFound() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, 20L);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		void moveFolder_throwsWhenFolderOwnedByAnotherUser() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User other = user(99L);
+			Folder folder = Folder.create(other, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, 20L);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("새 부모 폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void moveFolder_throwsWhenTargetParentNotFound() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 부모 폴더로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentOwnedByAnotherUser() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+			User other = user(99L);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(other, null, "other-root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("자기 자신 아래로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentIsSelf() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User user = user(userId);
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("하위 폴더 아래로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentIsDescendant() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, folder, "child");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, folderId, "child")
+			));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("루트로 이동할 때 같은 이름이 있으면 FOLDER_NAME_DUPLICATED 예외가 발생한다")
+		void moveFolder_throwsWhenRootNameDuplicated() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsRootFolder(userId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("대상 부모 아래 같은 이름이 있으면 FOLDER_NAME_DUPLICATED 예외가 발생한다")
+		void moveFolder_throwsWhenChildNameDuplicated() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, null, "root")
+			));
+			given(folderRepository.existsChildFolder(userId, targetParentId, "backend")).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -1126,5 +1126,36 @@ class FolderServiceTest {
 			verifyNoMoreInteractions(folderRepository);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
+
+		@Test
+		@DisplayName("부모 체인에 순환이 있으면 FOLDER_MOVE_INVALID 예외가 발생한다")
+		void moveFolder_throwsWhenTargetParentLineageContaionsCycle() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "target");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "root"),
+					new FolderTreeRow(20L, 30L, "target"),
+					new FolderTreeRow(30L, 20L, "cycle")
+			));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/repository/NoteRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/repository/NoteRepositoryTest.java
@@ -18,6 +18,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -246,6 +247,56 @@ class NoteRepositoryTest {
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Nested
+	@DisplayName("ExistsNotes")
+	class ExistsNotes {
+
+		@Test
+		@DisplayName("existsByFolder_IdAndDeletedAtIsNull: 활성 노트가 있으면 true를 반환한다")
+		void existsActiveNoteInFolder_returnsTrue() {
+			// given
+			Folder folder = folderRepository.save(Folder.create(user1, null, "업무"));
+			noteRepository.save(Note.create(user1, folder, "title", "content",
+					NoteVisibility.PRIVATE, false));
+
+			// when
+			boolean result = noteRepository.existsByFolder_IdAndDeletedAtIsNull(folder.getId());
+
+			// then
+			assertThat(result).isTrue();
+		}
+
+		@Test
+		@DisplayName("existsByFolder_IdAndDeletedAtIsNull: 노트가 없으면 false를 반환한다")
+		void existsActiveNoteInFolder_returnsFalseWhenNoNoteExists() {
+			// given
+			Folder folder = folderRepository.save(Folder.create(user1, null, "업무"));
+
+			// when
+			boolean result = noteRepository.existsByFolder_IdAndDeletedAtIsNull(folder.getId());
+
+			// then
+			assertThat(result).isFalse();
+		}
+
+		@Test
+		@DisplayName("existsByFolder_IdAndDeletedAtIsNull: 삭제된 노트만 있으면 false를 반환한다")
+		void existsActiveNoteInFolder_returnsFalseWhenOnlyDeletedNoteExists() {
+			// given
+			Folder folder = folderRepository.save(Folder.create(user1, null, "업무"));
+			Note note = noteRepository.save(
+					Note.create(user1, folder, "title", "content", NoteVisibility.PRIVATE, false)
+			);
+			note.softDelete();
+
+			// when
+			boolean result = noteRepository.existsByFolder_IdAndDeletedAtIsNull(folder.getId());
+
+			// then
+			assertThat(result).isFalse();
+		}
 	}
 
 	private Statistics statistics() {


### PR DESCRIPTION
  ### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - 기능 추가

  ### 📌 관련 이슈
  - #52-folder-delete

  ### ✨ 반영 브랜치
  feat/52-folder-delete -> develop

  ### 📝 변경 사항
  - [x] 폴더 삭제 API 추가: `DELETE /api/folders/{folderId}`
  - [x] 폴더 삭제 서비스 로직 추가
  - [x] 삭제 가능 여부 검증 로직 추가
    - 하위 폴더가 있으면 삭제 불가
    - 노트가 남아 있으면 삭제 불가
  - [x] 삭제 불가 상황용 에러 코드 추가: `FOLDER_NOT_EMPTY`
  - [x] 삭제 검증용 repository exists 메서드 추가
    - `FolderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(...)`
    - `NoteRepository.existsByFolder_IdAndDeletedAtIsNull(...)`
  - [x] 컨트롤러 / 서비스 / 리포지토리 테스트 추가

  ### ➕ 추가 메모
  - 삭제는 hard delete가 아니라 soft delete로 처리했습니다.
  - 삭제 성공 시 응답은 `204 No Content`입니다.
  - 이미 삭제된 폴더는 `findByIdAndDeletedAtIsNull(...)` 기준으로 조회되지 않으므로 `FOLDER_NOT_FOUND`로 처리됩니다.
  - v1 정책상 폴더가 비어 있을 때만 삭제 가능하도록 했습니다.

  ### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
  - `./gradlew test --tests '*FolderServiceTest' --tests '*FolderControllerTest' --tests '*FolderRepositoryTest' --tests '*NoteRepositoryTest'` 통과
  - `./gradlew check` 통과
  - 주요 검증 케이스
    - 삭제 성공 시 204 반환
    - 존재하지 않는 폴더 404
    - 다른 사용자의 폴더 403
    - 하위 폴더 또는 노트가 남아 있는 경우 409
    - repository exists 쿼리 정상 동작