### PR TITLE
[Folder] #52-folder-move 폴더 이동 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ bin/
 .factorypath
 out/
 AGENTS.md
+GEMINI.md
+conductor/

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/FolderController.java
@@ -1,11 +1,13 @@
 package com.keepgoing.keepgoing.folder.controller;
 
 import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
+import com.keepgoing.keepgoing.folder.controller.dto.FolderMoveRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderRenameRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderSummaryResponse;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderTreeNodeResponse;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -81,6 +83,19 @@ public class FolderController {
 	) {
 		FolderRenameCommand command = request.toCommand(userId, folderId);
 		FolderSummaryResult result = folderService.renameFolder(command);
+		FolderSummaryResponse response = FolderSummaryResponse.from(result);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PatchMapping("/{folderId}/parent")
+	public ResponseEntity<ApiResponse<FolderSummaryResponse>> moveFolder(
+			@PathVariable Long folderId,
+			@AuthenticationPrincipal Long userId,
+			@Valid @RequestBody FolderMoveRequest request
+	) {
+		FolderMoveCommand command = request.toCommand(userId, folderId);
+		FolderSummaryResult result = folderService.moveFolder(command);
 		FolderSummaryResponse response = FolderSummaryResponse.from(result);
 
 		return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderMoveRequest.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/controller/dto/FolderMoveRequest.java
@@ -1,0 +1,22 @@
+package com.keepgoing.keepgoing.folder.controller.dto;
+
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
+import com.keepgoing.keepgoing.global.validation.PositiveIfPresent;
+import com.keepgoing.keepgoing.global.validation.PresentJsonNullable;
+import jakarta.validation.valueextraction.Unwrapping;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+public record FolderMoveRequest(
+		@PresentJsonNullable(payload = {Unwrapping.Skip.class})
+		@PositiveIfPresent(payload = {Unwrapping.Skip.class})
+		JsonNullable<Long> parentId
+) {
+
+	public FolderMoveCommand toCommand(Long userId, Long folderId) {
+		return new FolderMoveCommand(
+				userId,
+				folderId,
+				parentId.orElse(null)
+		);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
@@ -76,6 +76,10 @@ public class Folder extends BaseEntity {
 		this.name = name;
 	}
 
+	public void moveTo(Folder parent) {
+		this.parent = parent;
+	}
+
 	public void softDelete() {
 		if (this.deletedAt == null) {
 			this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/domain/Folder.java
@@ -76,8 +76,14 @@ public class Folder extends BaseEntity {
 		this.name = name;
 	}
 
-	public void moveTo(Folder parent) {
-		this.parent = parent;
+	public void moveTo(Folder targetParent) {
+		if (targetParent != null) {
+			if (this.owner == null || this.owner.getId() == null) {
+				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+			}
+			targetParent.validateOwner(this.owner.getId());
+		}
+		this.parent = targetParent;
 	}
 
 	public void softDelete() {

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -4,6 +4,7 @@ import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
@@ -159,6 +161,42 @@ public class FolderService {
 	}
 
 	@Transactional
+	public FolderSummaryResult moveFolder(FolderMoveCommand command) {
+		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(command.folderId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+		Long userId = command.userId();
+		Long folderId = command.folderId();
+		Long targetParentId = command.parentId();
+		Long currentParentId = folder.getParent() != null ? folder.getParent().getId() : null;
+
+		folder.validateOwner(userId);
+
+		if (Objects.equals(folderId, targetParentId)) {
+			throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+		}
+
+		if (Objects.equals(currentParentId, targetParentId)) {
+			return FolderSummaryResult.from(folder);
+		}
+
+		Folder targetParent = null;
+		if (targetParentId != null) {
+			targetParent = folderRepository.findByIdAndDeletedAtIsNull(targetParentId)
+					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+			targetParent.validateOwner(userId);
+			validateMoveTarget(userId, folderId, targetParentId);
+		}
+
+		if (isDuplicatedFolderName(userId, targetParent, folder.getName())) {
+			throw new BusinessException(ErrorCode.FOLDER_NAME_DUPLICATED);
+		}
+
+		folder.moveTo(targetParent);
+		return FolderSummaryResult.from(folder);
+	}
+
+	@Transactional
 	public void deleteFolder(Long userId, Long folderId) {
 		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(folderId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
@@ -176,6 +214,21 @@ public class FolderService {
 		}
 
 		folder.softDelete();
+	}
+
+	private void validateMoveTarget(Long userId, Long folderId, Long targetParentId) {
+		Map<Long, Long> parentMap = new LinkedHashMap<>();
+		for (FolderTreeRow row : folderRepository.findTreeRows(userId)) {
+			parentMap.put(row.folderId(), row.parentId());
+		}
+
+		Long currentId = targetParentId;
+		while (currentId != null) {
+			if (currentId.equals(folderId)) {
+				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+			}
+			currentId = parentMap.get(currentId);
+		}
 	}
 
 	private String normalizeName(String raw) {

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -222,8 +222,13 @@ public class FolderService {
 			parentMap.put(row.folderId(), row.parentId());
 		}
 
+		Set<Long> visited = new HashSet<>();
 		Long currentId = targetParentId;
+
 		while (currentId != null) {
+			if (!visited.add(currentId)) {
+				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
+			}
 			if (currentId.equals(folderId)) {
 				throw new BusinessException(ErrorCode.FOLDER_MOVE_INVALID);
 			}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
@@ -1,0 +1,8 @@
+package com.keepgoing.keepgoing.folder.service.dto;
+
+public record FolderMoveCommand(
+		Long userId,
+		Long folderId,
+		Long parentId
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -192,8 +192,7 @@ public enum ErrorCode {
 			HttpStatus.BAD_REQUEST,
 			"FOLDER_005",
 			"허용되지 않는 폴더 이동입니다."
-			)
-	,
+	),
 	FOLDER_NOT_EMPTY(
 			HttpStatus.CONFLICT,
 			"FOLDER_006",

--- a/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
+++ b/src/main/java/com/keepgoing/keepgoing/global/common/error/ErrorCode.java
@@ -188,9 +188,15 @@ public enum ErrorCode {
 			"FOLDER_004",
 			"허용되지 않는 폴더 이름입니다."
 	),
+	FOLDER_MOVE_INVALID(
+			HttpStatus.BAD_REQUEST,
+			"FOLDER_005",
+			"허용되지 않는 폴더 이동입니다."
+			)
+	,
 	FOLDER_NOT_EMPTY(
 			HttpStatus.CONFLICT,
-			"FOLDER_005",
+			"FOLDER_006",
 			"하위 폴더 또는 노트가 남아 있어 삭제할 수 없습니다."
 	)
 	;

--- a/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
@@ -19,11 +19,14 @@ import com.keepgoing.keepgoing.folder.controller.dto.FolderCreateRequest;
 import com.keepgoing.keepgoing.folder.controller.dto.FolderRenameRequest;
 import com.keepgoing.keepgoing.folder.service.FolderService;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
+import com.keepgoing.keepgoing.global.api.exception.GlobalExceptionHandler;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import com.keepgoing.keepgoing.global.config.JacksonConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtAuthenticationFilter;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import java.util.List;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -44,6 +48,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FolderController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, JacksonConfig.class})
 class FolderControllerTest {
 
 	public static final String DIRECTORY_NAME = "backend";
@@ -276,6 +281,204 @@ class FolderControllerTest {
 			mockMvc.perform(patch("/api/folders/{folderId}", folderId)
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isConflict())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NAME_DUPLICATED.toString()));
+		}
+	}
+
+	@Nested
+	@DisplayName("PATCH /api/folders/{folderId}/parent")
+	class PatchFolderParent {
+
+		@Test
+		@DisplayName("유효한 요청이면 폴더를 다른 부모 아래로 이동한다.")
+		void moveFolder_returnsOk() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long parentId = 20L;
+			var result = new FolderSummaryResult(folderId, parentId, DIRECTORY_NAME);
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willReturn(result);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.folderId").value(folderId))
+					.andExpect(jsonPath("$.data.parentId").value(parentId))
+					.andExpect(jsonPath("$.data.name").value(DIRECTORY_NAME));
+
+			verify(folderService).moveFolder(argThat(command ->
+					command.userId().equals(userId)
+							&& command.folderId().equals(folderId)
+							&& command.parentId().equals(parentId)
+			));
+		}
+
+		@Test
+		@DisplayName("parentId가 null이면 루트로 이동한다.")
+		void moveFolder_returnsOkWhenMovingToRoot() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			var result = new FolderSummaryResult(folderId, null, DIRECTORY_NAME);
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willReturn(result);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": null}
+									"""))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.folderId").value(folderId))
+					.andExpect(jsonPath("$.data.parentId").value(nullValue()))
+					.andExpect(jsonPath("$.data.name").value(DIRECTORY_NAME));
+
+			verify(folderService).moveFolder(argThat(command ->
+					command.userId().equals(userId)
+							&& command.folderId().equals(folderId)
+							&& command.parentId() == null
+			));
+		}
+
+		@Test
+		@DisplayName("parentId 필드가 없으면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenParentIdIsMissing() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("{}"))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("parentId"));
+
+			verifyNoInteractions(folderService);
+		}
+
+		@Test
+		@DisplayName("parentId가 0 이하면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenParentIdIsNotPositive() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 0}
+									"""))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("parentId"));
+
+			verifyNoInteractions(folderService);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 404 Not Found를 반환한다.")
+		void moveFolder_returnsNotFoundWhenFolderDoesNotExist() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NOT_FOUND.toString()));
+		}
+
+		@Test
+		@DisplayName("접근 권한이 없으면 403 Forbidden을 반환한다.")
+		void moveFolder_returnsForbiddenWhenAccessDenied() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_ACCESS_DENIED));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_ACCESS_DENIED.toString()));
+		}
+
+		@Test
+		@DisplayName("허용되지 않는 이동이면 400 Bad Request를 반환한다.")
+		void moveFolder_returnsBadRequestWhenMoveIsInvalid() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_MOVE_INVALID));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_MOVE_INVALID.toString()));
+		}
+
+		@Test
+		@DisplayName("같은 이름의 폴더가 이미 있으면 409 Conflict를 반환한다.")
+		void moveFolder_returnsConflictWhenFolderNameDuplicated() throws Exception {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			mockLoginUser(userId);
+
+			given(folderService.moveFolder(any(FolderMoveCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NAME_DUPLICATED));
+
+			// when & then
+			mockMvc.perform(patch("/api/folders/{folderId}/parent", folderId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"parentId": 20}
+									"""))
 					.andExpect(status().isConflict())
 					.andExpect(jsonPath("$.success").value(false))
 					.andExpect(jsonPath("$.error.code").value(ErrorCode.FOLDER_NAME_DUPLICATED.toString()));

--- a/src/test/java/com/keepgoing/keepgoing/folder/domain/FolderTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/domain/FolderTest.java
@@ -166,6 +166,46 @@ class FolderTest {
 	}
 
 	@Test
+	@DisplayName("같은 사용자의 부모 폴더로 이동한다")
+	void moveTo_changesParentWhenOwnerMatched() {
+		User owner = user(1L);
+		Folder parent = Folder.create(owner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		folder.moveTo(parent);
+
+		assertThat(folder.getParent()).isEqualTo(parent);
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 부모 폴더로는 이동할 수 없다")
+	void moveTo_throwsWhenParentOwnerDoesNotMatch() {
+		User owner = user(1L);
+		User otherOwner = user(2L);
+
+		Folder parent = Folder.create(otherOwner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		assertThatThrownBy(() -> folder.moveTo(parent))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("소유자 ID가 없으면 부모 폴더로 이동할 수 없다")
+	void moveTo_throwsWhenOwnerIdIsNull() {
+		User owner = user(1L);
+		Folder parent = Folder.create(owner, null, "root");
+		Folder folder = Folder.create(owner, null, "move");
+
+		ReflectionTestUtils.setField(owner, "id", null);
+
+		assertThatThrownBy(() -> folder.moveTo(parent))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+
+	@Test
 	@DisplayName("폴더를 소프트 삭제한다")
 	void softDelete_marksFolderAtDeleted() {
 		User owner = user(1L);

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -6,12 +6,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
 import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderRenameCommand;
 import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
 import com.keepgoing.keepgoing.folder.service.dto.FolderTreeNodeResult;
@@ -776,6 +778,353 @@ class FolderServiceTest {
 			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
 			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
 			verifyNoMoreInteractions(folderRepository, noteRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("moveFolder()")
+	class MoveFolder {
+
+		@Test
+		@DisplayName("루트 폴더를 다른 부모 아래로 이동한다")
+		void moveFolder_movesRootFolderToAnotherParent() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, null, "root")
+			));
+			given(folderRepository.existsChildFolder(userId, targetParentId, "backend")).willReturn(false);
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isEqualTo(targetParentId);
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isEqualTo(targetParent);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("하위 폴더를 루트로 이동한다")
+		void moveFolder_movesChildFolderToRoot() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(false);
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isNull();
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isNull();
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsRootFolder(userId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("같은 부모로 이동하면 그대로 반환한다")
+		void moveFolder_returnsCurrentFolderWhenTargetParentIsSame() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, currentParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.folderId()).isEqualTo(folderId);
+			assertThat(result.parentId()).isEqualTo(currentParentId);
+			assertThat(result.name()).isEqualTo("backend");
+			assertThat(folder.getParent()).isEqualTo(currentParent);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void moveFolder_throwsWhenFolderNotFound() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, 20L);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		void moveFolder_throwsWhenFolderOwnedByAnotherUser() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User other = user(99L);
+			Folder folder = Folder.create(other, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, 20L);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("새 부모 폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		void moveFolder_throwsWhenTargetParentNotFound() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 부모 폴더로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentOwnedByAnotherUser() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+			User other = user(99L);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(other, null, "other-root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("자기 자신 아래로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentIsSelf() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			User user = user(userId);
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, folderId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("하위 폴더 아래로는 이동할 수 없다")
+		void moveFolder_throwsWhenTargetParentIsDescendant() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, folder, "child");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, folderId, "child")
+			));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("루트로 이동할 때 같은 이름이 있으면 FOLDER_NAME_DUPLICATED 예외가 발생한다")
+		void moveFolder_throwsWhenRootNameDuplicated() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).existsRootFolder(userId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("대상 부모 아래 같은 이름이 있으면 FOLDER_NAME_DUPLICATED 예외가 발생한다")
+		void moveFolder_throwsWhenChildNameDuplicated() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "backend"),
+					new FolderTreeRow(targetParentId, null, "root")
+			));
+			given(folderRepository.existsChildFolder(userId, targetParentId, "backend")).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderRepository).findTreeRows(userId);
+			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
+			verifyNoMoreInteractions(folderRepository);
+			verifyNoInteractions(noteRepository, userRepository);
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -1126,5 +1126,36 @@ class FolderServiceTest {
 			verifyNoMoreInteractions(folderRepository);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
+
+		@Test
+		@DisplayName("부모 체인에 순환이 있으면 FOLDER_MOVE_INVALID 예외가 발생한다")
+		void moveFolder_throwsWhenTargetParentLineageContaionsCycle() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long targetParentId = 20L;
+			User user = user(userId);
+
+			Folder folder = Folder.create(user, null, "root");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			Folder targetParent = Folder.create(user, null, "target");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, null, "root"),
+					new FolderTreeRow(20L, 30L, "target"),
+					new FolderTreeRow(30L, 20L, "cycle")
+			));
+
+			// when & then
+			assertThatThrownBy(() -> folderService.moveFolder(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+		}
 	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - 기능 추가

  ### 📌 관련 이슈
  - #52-folder-move

  ### ✨ 반영 브랜치
  feat/52-folder-move -> feat/52-folder-delete

  ### 📝 변경 사항
  - [x] 폴더 이동 API 추가: `PATCH /api/folders/{folderId}/parent`
  - [x] `parentId: null` 요청을 루트 이동으로 처리하도록 구현
  - [x] 폴더 이동 서비스 로직 추가
  - [x] 폴더 이동 검증 추가
    - 자기 자신 아래로 이동 금지
    - 하위 폴더 아래로 이동 금지
    - 같은 부모로 이동 요청은 no-op 처리
    - 대상 위치에 동일 이름이 있으면 이동 불가
  - [x] 폴더 이동 관련 에러 코드 추가
    - `FOLDER_MOVE_INVALID`
  - [x] 컨트롤러 / 서비스 / 리포지토리 테스트 보강

  ### ➕ 추가 메모
  - 폴더 이동은 기존 트리 조회 결과(`findTreeRows`)를 이용해 descendant 여부를 검증합니다.
  - 루트 이동은 `parentId: null`로 처리합니다.
  - 같은 부모로 이동 요청은 에러가 아니라 현재 상태를 그대로 반환하는 no-op으로 처리했습니다.

  ### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
  - [x] `./gradlew test --tests '*FolderServiceTest' --tests '*FolderControllerTest'`
  - [x] `./gradlew check`
