### PR TITLE
[Folder/Note] #78 폴더 삭제 invariant 동시성 제어 보강

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/repository/FolderRepository.java
@@ -2,9 +2,12 @@ package com.keepgoing.keepgoing.folder.repository;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.dto.FolderTreeRow;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -67,4 +70,23 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 			order by f.name asc
 			""")
 	List<FolderTreeRow> findTreeRows(@Param("ownerId") Long ownerId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+			select f
+			from Folder f
+			where f.id = :targetFolderId
+			  and f.deletedAt is null 
+			""")
+	Optional<Folder> findForUpdate(@Param("targetFolderId") Long targetFolderId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+			select f
+			from Folder f
+			where f.id in :targetFolderIds
+			  and f.deletedAt is null
+			order by f.id asc
+			""")
+	List<Folder> findAllForUpdate(@Param("targetFolderIds") Collection<Long> targetFolderIds);
 }

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderLockService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderLockService.java
@@ -1,0 +1,51 @@
+package com.keepgoing.keepgoing.folder.service;
+
+import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.global.common.error.BusinessException;
+import com.keepgoing.keepgoing.global.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class FolderLockService {
+
+	private final FolderRepository folderRepository;
+
+	@Transactional(propagation = Propagation.MANDATORY)
+	public Folder lockActiveFolder(Long folderId) {
+		return folderRepository.findForUpdate(folderId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+	}
+
+	@Transactional(propagation = Propagation.MANDATORY)
+	public Map<Long, Folder> lockActiveFolders(Collection<Long> folderIds) {
+		List<Long> ids = folderIds.stream()
+				.filter(id -> id != null)
+				.distinct()
+				.sorted(Comparator.naturalOrder())
+				.toList();
+		if (ids.isEmpty()) {
+			return Map.of();
+		}
+
+		List<Folder> folders = folderRepository.findAllForUpdate(ids);
+		if (folders.size() != ids.size()) {
+			throw new BusinessException(ErrorCode.FOLDER_NOT_FOUND);
+		}
+
+		Map<Long, Folder> result = new LinkedHashMap<>();
+		for (Folder folder : folders) {
+			result.put(folder.getId(), folder);
+		}
+		return result;
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/FolderService.java
@@ -14,6 +14,7 @@ import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -35,6 +36,7 @@ public class FolderService {
 	private final UserRepository userRepository;
 	private final FolderRepository folderRepository;
 	private final NoteRepository noteRepository;
+	private final FolderLockService folderLockService;
 	private static final int MAX_TREE_DEPTH = 200;
 
 	@Transactional
@@ -52,8 +54,7 @@ public class FolderService {
 
 		Folder parent = null;
 		if (parentId != null) {
-			parent = folderRepository.findByIdAndDeletedAtIsNull(parentId)
-					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+			parent = folderLockService.lockActiveFolder(parentId);
 		}
 
 		Folder newFolder = Folder.create(user, parent, folderName);
@@ -95,7 +96,7 @@ public class FolderService {
 			nodes.put(r.folderId(), new Node(r.folderId(), r.parentId(), r.name()));
 		}
 
-		// 2) parentId 기반으로 children 연결
+		// 2) targetParentId 기반으로 children 연결
 		List<Node> roots = new ArrayList<>();
 		for (Node node : nodes.values()) {
 			Long parentId = node.parentId;
@@ -167,7 +168,7 @@ public class FolderService {
 
 		Long userId = command.userId();
 		Long folderId = command.folderId();
-		Long targetParentId = command.parentId();
+		Long targetParentId = command.targetParentId();
 		Long currentParentId = folder.getParent() != null ? folder.getParent().getId() : null;
 
 		folder.validateOwner(userId);
@@ -180,13 +181,11 @@ public class FolderService {
 			return FolderSummaryResult.from(folder);
 		}
 
-		Folder targetParent = null;
-		if (targetParentId != null) {
-			targetParent = folderRepository.findByIdAndDeletedAtIsNull(targetParentId)
-					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
-			targetParent.validateOwner(userId);
-			validateMoveTarget(userId, folderId, targetParentId);
-		}
+		Map<Long, Folder> lockedFolders = folderLockService.lockActiveFolders(
+				Arrays.asList(currentParentId, targetParentId)
+		);
+
+		Folder targetParent = resolveTargetParent(lockedFolders, folderId, targetParentId, userId);
 
 		if (isDuplicatedFolderName(userId, targetParent, folder.getName())) {
 			throw new BusinessException(ErrorCode.FOLDER_NAME_DUPLICATED);
@@ -198,8 +197,7 @@ public class FolderService {
 
 	@Transactional
 	public void deleteFolder(Long userId, Long folderId) {
-		Folder folder = folderRepository.findByIdAndDeletedAtIsNull(folderId)
-				.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+		Folder folder = folderLockService.lockActiveFolder(folderId);
 
 		folder.validateOwner(userId);
 
@@ -214,6 +212,33 @@ public class FolderService {
 		}
 
 		folder.softDelete();
+	}
+
+	private String normalizeName(String raw) {
+		return raw == null ? "" : raw.trim();
+	}
+
+	private boolean isDuplicatedFolderName(Long userId, Folder parent, String folderName) {
+		return (parent == null)
+				? folderRepository.existsRootFolder(userId, folderName)
+				: folderRepository.existsChildFolder(userId, parent.getId(), folderName);
+	}
+
+	private Folder resolveTargetParent(
+			Map<Long, Folder> lockedFolders,
+			Long folderId,
+			Long targetParentId,
+			Long userId
+	) {
+		if (targetParentId == null) {
+			return null;
+		}
+
+		Folder targetParent = lockedFolders.get(targetParentId);
+		targetParent.validateOwner(userId);
+		validateMoveTarget(userId, folderId, targetParentId);
+
+		return targetParent;
 	}
 
 	private void validateMoveTarget(Long userId, Long folderId, Long targetParentId) {
@@ -234,16 +259,6 @@ public class FolderService {
 			}
 			currentId = parentMap.get(currentId);
 		}
-	}
-
-	private String normalizeName(String raw) {
-		return raw == null ? "" : raw.trim();
-	}
-
-	private boolean isDuplicatedFolderName(Long userId, Folder parent, String folderName) {
-		return (parent == null)
-				? folderRepository.existsRootFolder(userId, folderName)
-				: folderRepository.existsChildFolder(userId, parent.getId(), folderName);
 	}
 
 	private static class Node {

--- a/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/folder/service/dto/FolderMoveCommand.java
@@ -3,6 +3,6 @@ package com.keepgoing.keepgoing.folder.service.dto;
 public record FolderMoveCommand(
 		Long userId,
 		Long folderId,
-		Long parentId
+		Long targetParentId
 ) {
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepgoing.note.service;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.folder.service.FolderLockService;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.Note;
@@ -15,6 +16,9 @@ import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +32,7 @@ public class NoteService {
 	private final NoteRepository noteRepository;
 	private final UserRepository userRepository;
 	private final FolderRepository folderRepository;
+	private final FolderLockService folderLockService;
 
 	/**
 	 * 노트 생성
@@ -39,8 +44,7 @@ public class NoteService {
 
 		Folder folder = null;
 		if (command.folderId() != null) {
-			folder = folderRepository.findByIdAndDeletedAtIsNull(command.folderId())
-					.orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+			folder = folderLockService.lockActiveFolder(command.folderId());
 		}
 
 		Note note = Note.create(
@@ -141,11 +145,14 @@ public class NoteService {
 		Note note = noteRepository.findById(command.noteId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
 
-		Long targetFolderId = command.folderId();
-		Folder targetFolder = (targetFolderId == null)
-				? null
-				: folderRepository.findByIdAndDeletedAtIsNull(targetFolderId)
-				  .orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
+		Long sourceFolderId = note.getFolder() != null ? note.getFolder().getId() : null;
+		Long targetFolderId = command.targetFolderId();
+
+		Map<Long, Folder> lockedFolders = folderLockService.lockActiveFolders(
+				Arrays.asList(sourceFolderId, targetFolderId)
+		);
+
+		Folder targetFolder = (targetFolderId == null) ? null : lockedFolders.get(targetFolderId);
 
 		note.changeFolder(command.userId(), targetFolder);
 		return NoteDetailResult.from(note);

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteMoveCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteMoveCommand.java
@@ -3,6 +3,6 @@ package com.keepgoing.keepgoing.note.service.dto;
 public record NoteMoveCommand(
 		Long noteId,
 		Long userId,
-		Long folderId
+		Long targetFolderId
 ) {
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/controller/FolderControllerTest.java
@@ -172,7 +172,7 @@ class FolderControllerTest {
 	}
 
 	@Nested
-	@DisplayName("PATCH /api/folders/{folderId}")
+	@DisplayName("PATCH /api/folders/{targetFolderId}")
 	class PatchFolders {
 
 		@Test
@@ -288,7 +288,7 @@ class FolderControllerTest {
 	}
 
 	@Nested
-	@DisplayName("PATCH /api/folders/{folderId}/parent")
+	@DisplayName("PATCH /api/folders/{targetFolderId}/parent")
 	class PatchFolderParent {
 
 		@Test
@@ -319,7 +319,7 @@ class FolderControllerTest {
 			verify(folderService).moveFolder(argThat(command ->
 					command.userId().equals(userId)
 							&& command.folderId().equals(folderId)
-							&& command.parentId().equals(parentId)
+							&& command.targetParentId().equals(parentId)
 			));
 		}
 
@@ -350,7 +350,7 @@ class FolderControllerTest {
 			verify(folderService).moveFolder(argThat(command ->
 					command.userId().equals(userId)
 							&& command.folderId().equals(folderId)
-							&& command.parentId() == null
+							&& command.targetParentId() == null
 			));
 		}
 
@@ -577,7 +577,7 @@ class FolderControllerTest {
 	}
 
 	@Nested
-	@DisplayName("DELETE /api/folders/{folderId}")
+	@DisplayName("DELETE /api/folders/{targetFolderId}")
 	class DeleteFolder {
 
 		@Test

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderMutationConcurrencyTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderMutationConcurrencyTest.java
@@ -1,0 +1,417 @@
+package com.keepgoing.keepgoing.folder.service;
+
+import com.keepgoing.keepgoing.folder.domain.Folder;
+import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.folder.service.dto.FolderCreateCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderMoveCommand;
+import com.keepgoing.keepgoing.folder.service.dto.FolderSummaryResult;
+import com.keepgoing.keepgoing.note.domain.NoteVisibility;
+import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.note.service.NoteService;
+import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
+import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
+import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+public class FolderMutationConcurrencyTest {
+
+	@Autowired
+	FolderService folderService;
+
+	@Autowired
+	NoteService noteService;
+
+	@Autowired
+	FolderRepository folderRepository;
+
+	@Autowired
+	NoteRepository noteRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	private User user;
+	private Long userId;
+
+	@BeforeEach
+	void setUp() {
+		noteRepository.deleteAll();
+		folderRepository.deleteAll();
+		userRepository.deleteAll();
+
+		user = userRepository.save(User.create("test@test.com", "tester"));
+		userId = user.getId();
+	}
+
+	@Test
+	@DisplayName("deleteFolder와 createNote가 동시에 실행되면 둘 다 성공하지 않는다")
+	void deleteFolder_and_createNote_areSerialized() throws Exception {
+		Folder folder = folderRepository.save(Folder.create(user, null, "target"));
+		Long folderId = folder.getId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger createSuccess = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, folderId);
+
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				noteService.createNote(NoteCreateCommand.builder()
+						.userId(userId)
+						.folderId(folderId)
+						.title("title")
+						.content("content")
+						.visibility(NoteVisibility.PRIVATE)
+						.aiCollectable(false)
+						.build());
+				createSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		assertThat(deleteSuccess.get() + createSuccess.get()).isEqualTo(1);
+		assertThat(failureCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("deleteFolder와 createFolder가 동시에 실행되면 둘 다 성공하지 않는다")
+	void deleteFolder_and_createFolder_areSerialized() throws Exception {
+		Folder folder = folderRepository.save(Folder.create(user, null, "target"));
+		Long folderId = folder.getId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger createSuccess = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, folderId);
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.createFolder(new FolderCreateCommand(userId, folderId, "child"));
+				createSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		assertThat(deleteSuccess.get() + createSuccess.get()).isEqualTo(1);
+		assertThat(failureCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("deleteFolder와 moveNote(target folder)가 동시에 실행되면 둘 다 성공하지 않는다")
+	void deleteFolder_and_moveNoteToTargetFolder_areSerialized() throws Exception {
+		Folder sourceFolder = folderRepository.save(Folder.create(user, null, "source"));
+		Folder targetFolder = folderRepository.save(Folder.create(user, null, "target"));
+
+		Long sourceFolderId = sourceFolder.getId();
+		Long targetFolderId = targetFolder.getId();
+		Long noteId = noteService.createNote(NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(sourceFolderId)
+				.title("title")
+				.content("content")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(false)
+				.build())
+				.noteId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger moveSuccess = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, targetFolderId);
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				noteService.moveNote(new NoteMoveCommand(noteId, userId, targetFolderId));
+				moveSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		assertThat(deleteSuccess.get() + moveSuccess.get()).isEqualTo(1);
+		assertThat(failureCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("deleteFolder와 moveFolder(target parent)가 동시에 실행되면 둘 다 성공하지 않는다")
+	void deleteFolder_and_moveFolderToTargetParent_areSerialized() throws Exception {
+		Folder movingFolder = folderRepository.save(Folder.create(user, null, "moving"));
+		Folder targetParent = folderRepository.save(Folder.create(user, null, "target"));
+
+		Long movingFolderId = movingFolder.getId();
+		Long targetParentId = targetParent.getId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger moveSuccess = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, targetParentId);
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.moveFolder(new FolderMoveCommand(userId, movingFolderId, targetParentId));
+				moveSuccess.incrementAndGet();
+			} catch (Exception e) {
+				failureCount.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		assertThat(deleteSuccess.get() + moveSuccess.get()).isEqualTo(1);
+		assertThat(failureCount.get()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("source 폴더에서 note를 빼는 move와 delete가 함께 와도 source invariant를 유지한다")
+	void moveNoteOutOfSourceFolder_and_deleteSourceFolder_preserveInvariant() throws Exception {
+		Folder sourceFolder = folderRepository.save(Folder.create(user, null, "source"));
+		Long sourceFolderId = sourceFolder.getId();
+
+		Long noteId = noteService.createNote(NoteCreateCommand.builder()
+				.userId(userId)
+				.folderId(sourceFolderId)
+				.title("title")
+				.content("content")
+				.visibility(NoteVisibility.PRIVATE)
+				.aiCollectable(false)
+				.build())
+				.noteId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger deleteFailure = new AtomicInteger();
+		AtomicInteger moveSuccess = new AtomicInteger();
+		AtomicInteger moveFailure = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, sourceFolderId);
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				deleteFailure.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				noteService.moveNote(new NoteMoveCommand(noteId, userId, null));
+				moveSuccess.incrementAndGet();
+			} catch (Exception e) {
+				moveFailure.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		NoteDetailResult note = noteService.getNote(userId, noteId);
+		boolean sourceDeleted = folderRepository.findById(sourceFolderId)
+				.orElseThrow()
+				.isDeleted();
+
+		assertThat(moveSuccess.get()).isEqualTo(1);
+		assertThat(moveFailure.get()).isZero();
+		assertThat(deleteSuccess.get() + deleteFailure.get()).isEqualTo(1);
+		assertThat(note.folderId()).isNull();
+		assertThat(sourceDeleted).isEqualTo(deleteSuccess.get() == 1);
+	}
+
+	@Test
+	@DisplayName("source 부모에서 child를 빼는 move와 delete가 함께 와도 source invariant를 유지한다")
+	void moveFolderOutOfSourceParent_and_deleteSourceParent_preserveInvariant() throws Exception {
+		Folder sourceParent = folderRepository.save(Folder.create(user, null, "source-parent"));
+		Long sourceParentId = sourceParent.getId();
+
+		Folder child = folderRepository.save(Folder.create(user, sourceParent, "child"));
+		Long childFolderId = child.getId();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch readyLatch = new CountDownLatch(2);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(2);
+
+		AtomicInteger deleteSuccess = new AtomicInteger();
+		AtomicInteger deleteFailure = new AtomicInteger();
+		AtomicInteger moveSuccess = new AtomicInteger();
+		AtomicInteger moveFailure = new AtomicInteger();
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.deleteFolder(userId, sourceParentId);
+				deleteSuccess.incrementAndGet();
+			} catch (Exception e) {
+				deleteFailure.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		executor.submit(() -> {
+			try {
+				readyLatch.countDown();
+				startLatch.await();
+				folderService.moveFolder(new FolderMoveCommand(userId, childFolderId, null));
+				moveSuccess.incrementAndGet();
+			} catch (Exception e) {
+				moveFailure.incrementAndGet();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await(10, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		List<FolderSummaryResult> rootFolders = folderService.getFolders(userId, null);
+		boolean sourceDeleted = folderRepository.findById(sourceParentId)
+				.orElseThrow()
+				.isDeleted();
+
+		assertThat(moveSuccess.get()).isEqualTo(1);
+		assertThat(moveFailure.get()).isZero();
+		assertThat(deleteSuccess.get() + deleteFailure.get()).isEqualTo(1);
+		assertThat(rootFolders).anySatisfy(folder ->
+				assertThat(folder.folderId()).isEqualTo(childFolderId)
+		);
+		assertThat(sourceDeleted).isEqualTo(deleteSuccess.get() == 1);
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderMutationConcurrencyTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderMutationConcurrencyTest.java
@@ -48,6 +48,9 @@ public class FolderMutationConcurrencyTest {
 
 	private User user;
 	private Long userId;
+	private static final long READY_TIMEOUT_SECONDS = 5L;
+	private static final long DONE_TIMEOUT_SECONDS = 10L;
+	private static final long TERMINATION_TIMEOUT_SECONDS = 5L;
 
 	@BeforeEach
 	void setUp() {
@@ -108,10 +111,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		assertThat(deleteSuccess.get() + createSuccess.get()).isEqualTo(1);
 		assertThat(failureCount.get()).isEqualTo(1);
@@ -158,10 +158,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		assertThat(deleteSuccess.get() + createSuccess.get()).isEqualTo(1);
 		assertThat(failureCount.get()).isEqualTo(1);
@@ -220,10 +217,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		assertThat(deleteSuccess.get() + moveSuccess.get()).isEqualTo(1);
 		assertThat(failureCount.get()).isEqualTo(1);
@@ -273,10 +267,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		assertThat(deleteSuccess.get() + moveSuccess.get()).isEqualTo(1);
 		assertThat(failureCount.get()).isEqualTo(1);
@@ -334,10 +325,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		NoteDetailResult note = noteService.getNote(userId, noteId);
 		boolean sourceDeleted = folderRepository.findById(sourceFolderId)
@@ -396,10 +384,7 @@ public class FolderMutationConcurrencyTest {
 			}
 		});
 
-		readyLatch.await();
-		startLatch.countDown();
-		doneLatch.await(10, TimeUnit.SECONDS);
-		executor.shutdown();
+		awaitConcurrentTasks(readyLatch, startLatch, doneLatch, executor);
 
 		List<FolderSummaryResult> rootFolders = folderService.getFolders(userId, null);
 		boolean sourceDeleted = folderRepository.findById(sourceParentId)
@@ -413,5 +398,29 @@ public class FolderMutationConcurrencyTest {
 				assertThat(folder.folderId()).isEqualTo(childFolderId)
 		);
 		assertThat(sourceDeleted).isEqualTo(deleteSuccess.get() == 1);
+	}
+
+	private void awaitConcurrentTasks(
+			CountDownLatch readyLatch,
+			CountDownLatch startLatch,
+			CountDownLatch doneLatch,
+			ExecutorService executor
+	) throws InterruptedException {
+		try {
+			assertThat(readyLatch.await(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+					.as("worker threads did not become ready in time")
+					.isTrue();
+
+			startLatch.countDown();
+
+			assertThat(doneLatch.await(DONE_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+					.as("concurrent tasks did not finish in time")
+					.isTrue();
+		} finally {
+			executor.shutdownNow();
+			assertThat(executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+					.as("executor did not terminate in time")
+					.isTrue();
+		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/folder/service/FolderServiceTest.java
@@ -23,7 +23,9 @@ import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,6 +49,9 @@ class FolderServiceTest {
 
 	@Mock
 	NoteRepository noteRepository;
+
+	@Mock
+	FolderLockService folderLockService;
 
 	@InjectMocks
 	FolderService folderService;
@@ -132,7 +137,7 @@ class FolderServiceTest {
 			FolderCreateCommand command = new FolderCreateCommand(userId, parentId, DIRECTORY_NAME);
 
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
-			given(folderRepository.findByIdAndDeletedAtIsNull(parentId)).willReturn(Optional.of(parent));
+			given(folderLockService.lockActiveFolder(parentId)).willReturn(parent);
 			given(folderRepository.existsChildFolder(userId, parentId, DIRECTORY_NAME)).willReturn(false);
 
 			Folder saved = Folder.create(user, parent, DIRECTORY_NAME);
@@ -148,10 +153,10 @@ class FolderServiceTest {
 			assertThat(result.name()).isEqualTo(DIRECTORY_NAME);
 
 			verify(userRepository).findById(userId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
+			verify(folderLockService).lockActiveFolder(parentId);
 			verify(folderRepository).existsChildFolder(userId, parentId, DIRECTORY_NAME);
 			verify(folderRepository).save(any(Folder.class));
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 		}
 
 		@Test
@@ -183,15 +188,16 @@ class FolderServiceTest {
 			FolderCreateCommand command = new FolderCreateCommand(userId, parentId, DIRECTORY_NAME);
 
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
-			given(folderRepository.findByIdAndDeletedAtIsNull(parentId)).willReturn(Optional.empty());
+			given(folderLockService.lockActiveFolder(parentId))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 			// when & then
 			assertThatThrownBy(() -> folderService.createFolder(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
 			verify(userRepository).findById(userId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verify(folderLockService).lockActiveFolder(parentId);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 		}
 
 		@Test
@@ -210,7 +216,7 @@ class FolderServiceTest {
 			FolderCreateCommand command = new FolderCreateCommand(userId, parentId, DIRECTORY_NAME);
 
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
-			given(folderRepository.findByIdAndDeletedAtIsNull(parentId)).willReturn(Optional.of(parent));
+			given(folderLockService.lockActiveFolder(parentId)).willReturn(parent);
 
 			// when & then
 			assertThatThrownBy(() -> folderService.createFolder(command))
@@ -218,8 +224,8 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
 
 			verify(userRepository).findById(userId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verify(folderLockService).lockActiveFolder(parentId);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 		}
 
 		@Test
@@ -278,7 +284,7 @@ class FolderServiceTest {
 			FolderCreateCommand command = new FolderCreateCommand(userId, parentId, DIRECTORY_NAME);
 
 			given(userRepository.findById(userId)).willReturn(Optional.of(user));
-			given(folderRepository.findByIdAndDeletedAtIsNull(parentId)).willReturn(Optional.of(parent));
+			given(folderLockService.lockActiveFolder(parentId)).willReturn(parent);
 			given(folderRepository.existsChildFolder(userId, parentId, DIRECTORY_NAME)).willReturn(true);
 
 			// when & then
@@ -287,9 +293,9 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
 
 			verify(userRepository).findById(userId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(parentId);
+			verify(folderLockService).lockActiveFolder(parentId);
 			verify(folderRepository).existsChildFolder(userId, parentId, DIRECTORY_NAME);
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 		}
 	}
 
@@ -405,7 +411,7 @@ class FolderServiceTest {
 	class GetFolderTree {
 
 		@Test
-		@DisplayName("전체 폴더를 1번 조회해서 parentId 기반 트리 구조로 조립한다.")
+		@DisplayName("전체 폴더를 1번 조회해서 targetParentId 기반 트리 구조로 조립한다.")
 		void getFolderTree_buildsTreeFromRows() {
 			// given
 			Long userId = 1L;
@@ -466,7 +472,7 @@ class FolderServiceTest {
 		void getFolderTree_treatsOrphanAsRootWhenParentMissing() {
 			// given
 			Long userId = 1L;
-			// parentId=999는 rows에 없음
+			// targetParentId=999는 rows에 없음
 			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
 					new FolderTreeRow(1L, null, "A"),
 					new FolderTreeRow(2L, 999L, "Orphan")
@@ -675,7 +681,7 @@ class FolderServiceTest {
 			Folder folder = Folder.create(user, null, "root");
 			ReflectionTestUtils.setField(folder, "id", folderId);
 
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(folderId)).willReturn(folder);
 			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(false);
 
 			// when
@@ -687,10 +693,10 @@ class FolderServiceTest {
 			assertThat(folder.isDeleted()).isTrue();
 			assertThat(folder.getDeletedAt()).isNotNull();
 
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolder(folderId);
 			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
 			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(folderRepository, noteRepository);
+			verifyNoMoreInteractions(folderRepository, noteRepository, folderLockService);
 		}
 
 		@Test
@@ -700,15 +706,16 @@ class FolderServiceTest {
 			Long userId = 1L;
 			Long folderId = 10L;
 
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+			given(folderLockService.lockActiveFolder(folderId))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 			// when & then
 			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
 
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(folderRepository, noteRepository);
+			verify(folderLockService).lockActiveFolder(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository, folderLockService);
 		}
 
 		@Test
@@ -722,14 +729,14 @@ class FolderServiceTest {
 			Folder folder = Folder.create(other, null, "root");
 			ReflectionTestUtils.setField(folder, "id", folderId);
 
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(folderId)).willReturn(folder);
 
 			// when & then
 			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(folderRepository, noteRepository);
+			verify(folderLockService).lockActiveFolder(folderId);
+			verifyNoMoreInteractions(folderRepository, noteRepository, folderLockService);
 		}
 
 		@Test
@@ -743,16 +750,16 @@ class FolderServiceTest {
 			Folder folder = Folder.create(user, null, "root");
 			ReflectionTestUtils.setField(folder, "id", folderId);
 
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(folderId)).willReturn(folder);
 			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(true);
 
 			// when & then
 			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_EMPTY);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolder(folderId);
 			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
-			verifyNoMoreInteractions(folderRepository, noteRepository);
+			verifyNoMoreInteractions(folderRepository, noteRepository, folderLockService);
 		}
 
 		@Test
@@ -766,7 +773,7 @@ class FolderServiceTest {
 			Folder folder = Folder.create(user, null, "root");
 			ReflectionTestUtils.setField(folder, "id", folderId);
 
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(folderId)).willReturn(folder);
 			given(folderRepository.existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId)).willReturn(false);
 			given(noteRepository.existsByFolder_IdAndDeletedAtIsNull(folderId)).willReturn(true);
 
@@ -774,10 +781,10 @@ class FolderServiceTest {
 			assertThatThrownBy(() -> folderService.deleteFolder(userId, folderId))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_EMPTY);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolder(folderId);
 			verify(folderRepository).existsByOwner_IdAndParent_IdAndDeletedAtIsNull(userId, folderId);
 			verify(noteRepository).existsByFolder_IdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(folderRepository, noteRepository);
+			verifyNoMoreInteractions(folderRepository, noteRepository, folderLockService);
 		}
 	}
 
@@ -803,7 +810,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willReturn(Map.of(targetParentId, targetParent));
 			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
 					new FolderTreeRow(folderId, null, "backend"),
 					new FolderTreeRow(targetParentId, null, "root")
@@ -820,10 +828,56 @@ class FolderServiceTest {
 			assertThat(folder.getParent()).isEqualTo(targetParent);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
 			verify(folderRepository).findTreeRows(userId);
 			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
-			verifyNoMoreInteractions(folderRepository);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
+			verifyNoInteractions(noteRepository, userRepository);
+		}
+
+		@Test
+		@DisplayName("하위 폴더를 다른 부모 아래로 이동할 때 현재 부모와 대상 부모를 함께 잠근다")
+		void moveFolder_locksCurrentParentAndTargetParentTogether() {
+			// given
+			Long userId = 1L;
+			Long folderId = 10L;
+			Long currentParentId = 20L;
+			Long targetParentId = 30L;
+			User user = user(userId);
+
+			Folder currentParent = Folder.create(user, null, "current");
+			ReflectionTestUtils.setField(currentParent, "id", currentParentId);
+
+			Folder targetParent = Folder.create(user, null, "target");
+			ReflectionTestUtils.setField(targetParent, "id", targetParentId);
+
+			Folder folder = Folder.create(user, currentParent, "backend");
+			ReflectionTestUtils.setField(folder, "id", folderId);
+
+			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
+
+			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolders(Arrays.asList(currentParentId, targetParentId)))
+					.willReturn(Map.of(currentParentId, currentParent, targetParentId, targetParent));
+			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
+					new FolderTreeRow(folderId, currentParentId, "backend"),
+					new FolderTreeRow(currentParentId, null, "current"),
+					new FolderTreeRow(targetParentId, null, "target")
+			));
+			given(folderRepository.existsChildFolder(userId, targetParentId, "backend")).willReturn(false);
+
+			// when
+			FolderSummaryResult result = folderService.moveFolder(command);
+
+			// then
+			assertThat(result.parentId()).isEqualTo(targetParentId);
+			assertThat(folder.getParent()).isEqualTo(targetParent);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(currentParentId, targetParentId));
+			verify(folderRepository).findTreeRows(userId);
+			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -845,6 +899,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolders(Arrays.asList(currentParentId, null)))
+					.willReturn(Map.of(currentParentId, currentParent));
 			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(false);
 
 			// when
@@ -857,8 +913,9 @@ class FolderServiceTest {
 			assertThat(folder.getParent()).isNull();
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(currentParentId, null));
 			verify(folderRepository).existsRootFolder(userId, "backend");
-			verifyNoMoreInteractions(folderRepository);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -953,7 +1010,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.empty());
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 			// when & then
 			assertThatThrownBy(() -> folderService.moveFolder(command))
@@ -961,8 +1019,8 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
-			verifyNoMoreInteractions(folderRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -985,7 +1043,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willReturn(Map.of(targetParentId, targetParent));
 
 			// when & then
 			assertThatThrownBy(() -> folderService.moveFolder(command))
@@ -993,8 +1052,8 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
-			verifyNoMoreInteractions(folderRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -1040,7 +1099,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willReturn(Map.of(targetParentId, targetParent));
 			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
 					new FolderTreeRow(folderId, null, "backend"),
 					new FolderTreeRow(targetParentId, folderId, "child")
@@ -1052,9 +1112,9 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
 			verify(folderRepository).findTreeRows(userId);
-			verifyNoMoreInteractions(folderRepository);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -1076,6 +1136,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, null);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolders(Arrays.asList(currentParentId, null)))
+					.willReturn(Map.of(currentParentId, currentParent));
 			given(folderRepository.existsRootFolder(userId, "backend")).willReturn(true);
 
 			// when & then
@@ -1084,8 +1146,9 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(currentParentId, null));
 			verify(folderRepository).existsRootFolder(userId, "backend");
-			verifyNoMoreInteractions(folderRepository);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -1107,7 +1170,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willReturn(Map.of(targetParentId, targetParent));
 			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
 					new FolderTreeRow(folderId, null, "backend"),
 					new FolderTreeRow(targetParentId, null, "root")
@@ -1120,10 +1184,10 @@ class FolderServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NAME_DUPLICATED);
 
 			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(targetParentId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
 			verify(folderRepository).findTreeRows(userId);
 			verify(folderRepository).existsChildFolder(userId, targetParentId, "backend");
-			verifyNoMoreInteractions(folderRepository);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository, userRepository);
 		}
 
@@ -1145,7 +1209,8 @@ class FolderServiceTest {
 			FolderMoveCommand command = new FolderMoveCommand(userId, folderId, targetParentId);
 
 			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
-			given(folderRepository.findByIdAndDeletedAtIsNull(targetParentId)).willReturn(Optional.of(targetParent));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, targetParentId)))
+					.willReturn(Map.of(targetParentId, targetParent));
 			given(folderRepository.findTreeRows(userId)).willReturn(List.of(
 					new FolderTreeRow(folderId, null, "root"),
 					new FolderTreeRow(20L, 30L, "target"),
@@ -1156,6 +1221,12 @@ class FolderServiceTest {
 			assertThatThrownBy(() -> folderService.moveFolder(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_MOVE_INVALID);
+
+			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, targetParentId));
+			verify(folderRepository).findTreeRows(userId);
+			verifyNoMoreInteractions(folderRepository, folderLockService);
+			verifyNoInteractions(noteRepository, userRepository);
 		}
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -676,7 +676,7 @@ public class NoteControllerTest {
 			verify(noteService).moveNote(captor.capture());
 			assertThat(captor.getValue().noteId()).isEqualTo(noteId);
 			assertThat(captor.getValue().userId()).isEqualTo(userId);
-			assertThat(captor.getValue().folderId()).isEqualTo(folderId);
+			assertThat(captor.getValue().targetFolderId()).isEqualTo(folderId);
 		}
 
 		@Test
@@ -716,7 +716,7 @@ public class NoteControllerTest {
 
 			ArgumentCaptor<NoteMoveCommand> captor = ArgumentCaptor.forClass(NoteMoveCommand.class);
 			verify(noteService).moveNote(captor.capture());
-			assertThat(captor.getValue().folderId()).isNull();
+			assertThat(captor.getValue().targetFolderId()).isNull();
 		}
 
 		@Test

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.keepgoing.keepgoing.folder.domain.Folder;
 import com.keepgoing.keepgoing.folder.repository.FolderRepository;
+import com.keepgoing.keepgoing.folder.service.FolderLockService;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.Note;
@@ -25,7 +26,9 @@ import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,6 +58,9 @@ class NoteServiceTest {
 
 	@Mock
 	FolderRepository folderRepository;
+
+	@Mock
+	FolderLockService folderLockService;
 
 	@InjectMocks
 	NoteService noteService;
@@ -144,8 +150,7 @@ class NoteServiceTest {
 					.build();
 
 			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
-			given(folderRepository.findByIdAndDeletedAtIsNull(command.folderId()))
-					.willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(command.folderId())).willReturn(folder);
 			given(noteRepository.save(any(Note.class)))
 					.willAnswer(invocation -> invocation.getArgument(0));
 
@@ -170,9 +175,9 @@ class NoteServiceTest {
 			assertThat(result.visibility()).isEqualTo(command.visibility());
 			assertThat(result.aiCollectable()).isEqualTo(command.aiCollectable());
 			verify(userRepository).findById(userId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folder.getId());
+			verify(folderLockService).lockActiveFolder(folder.getId());
 			verify(noteRepository).save(any(Note.class));
-			verifyNoMoreInteractions(userRepository, noteRepository, folderRepository);
+			verifyNoMoreInteractions(userRepository, noteRepository, folderRepository, folderLockService);
 		}
 
 		@Test
@@ -190,14 +195,15 @@ class NoteServiceTest {
 					.build();
 
 			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
-			given(folderRepository.findByIdAndDeletedAtIsNull(2L)).willReturn(Optional.empty());
+			given(folderLockService.lockActiveFolder(2L))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 			assertThatThrownBy(() -> noteService.createNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
 			verify(userRepository).findById(command.userId());
-			verify(folderRepository).findByIdAndDeletedAtIsNull(2L);
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verify(folderLockService).lockActiveFolder(2L);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository);
 		}
 
@@ -220,14 +226,14 @@ class NoteServiceTest {
 					.build();
 
 			given(userRepository.findById(command.userId())).willReturn(Optional.of(author));
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolder(folderId)).willReturn(folder);
 
 			assertThatThrownBy(() -> noteService.createNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
 			verify(userRepository).findById(command.userId());
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(userRepository, folderRepository);
+			verify(folderLockService).lockActiveFolder(folderId);
+			verifyNoMoreInteractions(userRepository, folderRepository, folderLockService);
 			verifyNoInteractions(noteRepository);
 		}
 	}
@@ -539,15 +545,43 @@ class NoteServiceTest {
 			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
 
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(folder));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, folderId)))
+					.willReturn(Map.of(folderId, folder));
 
 			NoteDetailResult result = noteService.moveNote(command);
 
 			assertThat(note.getFolder()).isEqualTo(folder);
 			assertThat(result.folderId()).isEqualTo(folderId);
 			verify(noteRepository).findById(noteId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, folderId));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
+			verifyNoInteractions(userRepository);
+		}
+
+		@Test
+		@DisplayName("폴더 간 이동 시 source 와 target 폴더를 함께 잠근다")
+		void moveNote_locksSourceAndTargetFoldersTogether() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			Long sourceFolderId = 20L;
+			Long targetFolderId = 30L;
+			User author = user(userId);
+			Folder sourceFolder = folder(author, sourceFolderId);
+			Folder targetFolder = folder(author, targetFolderId);
+			Note note = Note.create(author, sourceFolder, "title", "content", NoteVisibility.PRIVATE, true);
+			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, targetFolderId);
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderLockService.lockActiveFolders(Arrays.asList(sourceFolderId, targetFolderId)))
+					.willReturn(Map.of(sourceFolderId, sourceFolder, targetFolderId, targetFolder));
+
+			NoteDetailResult result = noteService.moveNote(command);
+
+			assertThat(note.getFolder()).isEqualTo(targetFolder);
+			assertThat(result.folderId()).isEqualTo(targetFolderId);
+			verify(noteRepository).findById(noteId);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(sourceFolderId, targetFolderId));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
 			verifyNoInteractions(userRepository);
 		}
 
@@ -563,14 +597,17 @@ class NoteServiceTest {
 			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, null);
 
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderLockService.lockActiveFolders(Arrays.asList(existingFolderId, null)))
+					.willReturn(Map.of(existingFolderId, existingFolder));
 
 			NoteDetailResult result = noteService.moveNote(command);
 
 			assertThat(note.getFolder()).isNull();
 			assertThat(result.folderId()).isNull();
 			verify(noteRepository).findById(noteId);
-			verifyNoMoreInteractions(noteRepository);
-			verifyNoInteractions(folderRepository, userRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(existingFolderId, null));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
+			verifyNoInteractions(userRepository);
 		}
 
 		@Test
@@ -602,14 +639,15 @@ class NoteServiceTest {
 			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
 
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.empty());
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, folderId)))
+					.willThrow(new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 			assertThatThrownBy(() -> noteService.moveNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_NOT_FOUND);
 			verify(noteRepository).findById(noteId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, folderId));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
 			verifyNoInteractions(userRepository);
 		}
 
@@ -624,13 +662,16 @@ class NoteServiceTest {
 			NoteMoveCommand command = new NoteMoveCommand(noteId, requesterId, null);
 
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, null)))
+					.willReturn(Map.of());
 
 			assertThatThrownBy(() -> noteService.moveNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
 			verify(noteRepository).findById(noteId);
-			verifyNoMoreInteractions(noteRepository);
-			verifyNoInteractions(folderRepository, userRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, null));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
+			verifyNoInteractions(userRepository);
 		}
 
 		@Test
@@ -647,14 +688,15 @@ class NoteServiceTest {
 			NoteMoveCommand command = new NoteMoveCommand(noteId, userId, folderId);
 
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
-			given(folderRepository.findByIdAndDeletedAtIsNull(folderId)).willReturn(Optional.of(otherFolder));
+			given(folderLockService.lockActiveFolders(Arrays.asList(null, folderId)))
+					.willReturn(Map.of(folderId, otherFolder));
 
 			assertThatThrownBy(() -> noteService.moveNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
 			verify(noteRepository).findById(noteId);
-			verify(folderRepository).findByIdAndDeletedAtIsNull(folderId);
-			verifyNoMoreInteractions(noteRepository, folderRepository);
+			verify(folderLockService).lockActiveFolders(Arrays.asList(null, folderId));
+			verifyNoMoreInteractions(noteRepository, folderRepository, folderLockService);
 			verifyNoInteractions(userRepository);
 		}
 	}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - 버그 수정

  ### 📌 관련 이슈
  -close #78

  ### ✨ 반영 브랜치
  feat/78 -> develop

  ### 📝 변경 사항
  - [x] 폴더 삭제 invariant에 영향을 주는 mutation(`deleteFolder`,
  `createFolder`, `moveFolder`, `createNote`, `moveNote`)에 동일한 락 기준을 적용했습니다.
  - [x] `FolderRepository`에 `PESSIMISTIC_WRITE` 기반 row lock 조회를 추가했습니다.
  - [x] `FolderLockService`를 추가해 단일/다중 폴더 lock을 공통화했습니다.
  - [x] 여러 폴더를 함께 잠글 때 `null 제거 -> 중복 제거 -> id 오름차순` 순서로 lock하도록 해 deadlock 가능성을 줄였습니다.
  - [x] `moveFolder`, `moveNote`는 target뿐 아니라 source의 empty 상태도 바꾸므로 source/target을 함께 lock하도록 반영했습니다.
  - [x] 서비스 테스트와 병행 통합 테스트를 추가해 target-side 직렬화와 source-side invariant 유지 여부를 검증했습니다.

  ### ➕ 추가 메모
  - target 쪽 경쟁(`delete vs create/move to target`)은 둘 다 성공하지 않음을 검증했습니다.
  - source 쪽 경쟁(`move out of source vs delete source`)은 둘 다 성공할 수도 있으므로, 최종 상태가 invariant를 만족하는지 기준으로 검증했습니다.

  ### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
  - `./gradlew test --tests '*FolderServiceTest' --tests '*NoteServiceTest'
  --tests '*FolderMutationConcurrencyTest'` 통과
  - `./gradlew check` 통과