### PR TITLE
feat(note): #83 노트 제목 변경 API 추가

### DIFF
--- a/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/NoteController.java
@@ -5,12 +5,14 @@ import com.keepgoing.keepgoing.global.api.response.PagedResponse;
 import com.keepgoing.keepgoing.note.controller.dto.NoteCreateRequest;
 import com.keepgoing.keepgoing.note.controller.dto.NoteDetailResponse;
 import com.keepgoing.keepgoing.note.controller.dto.NoteMoveRequest;
+import com.keepgoing.keepgoing.note.controller.dto.NoteRenameRequest;
 import com.keepgoing.keepgoing.note.controller.dto.NoteSummaryResponse;
 import com.keepgoing.keepgoing.note.controller.dto.NoteUpdateRequest;
 import com.keepgoing.keepgoing.note.service.NoteService;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.note.service.dto.NoteRenameCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
@@ -183,6 +185,23 @@ public class NoteController {
 		NoteDetailResult noteDetailResult = noteService.moveNote(command);
 
 		NoteDetailResponse response = NoteDetailResponse.from(noteDetailResult);
+
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 노트 제목 변경
+	 */
+	@PatchMapping("/{noteId}/title")
+	public ResponseEntity<ApiResponse<NoteDetailResponse>> renameNote(
+			@PathVariable Long noteId,
+			@Valid @RequestBody NoteRenameRequest request,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteRenameCommand command = request.toCommand(noteId, userId);
+
+		NoteDetailResult result = noteService.renameNote(command);
+		NoteDetailResponse response = NoteDetailResponse.from(result);
 
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}

--- a/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteRenameRequest.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/controller/dto/NoteRenameRequest.java
@@ -1,0 +1,20 @@
+package com.keepgoing.keepgoing.note.controller.dto;
+
+import com.keepgoing.keepgoing.note.service.dto.NoteRenameCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoteRenameRequest(
+		@NotBlank
+		@Size(max = 200)
+		String title
+) {
+
+	public NoteRenameCommand toCommand(Long noteId, Long userId) {
+		return new NoteRenameCommand(
+				noteId,
+				userId,
+				this.title
+		);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/domain/Note.java
@@ -175,4 +175,15 @@ public class Note extends BaseEntity {
 		}
 		this.folder = targetFolder;
 	}
+
+	/**
+	 * 제목 변경
+	 */
+	public void renameTitle(Long requesterId, String newTitle) {
+		validateAuthor(requesterId);
+
+		if (newTitle == null || newTitle.isBlank() || newTitle.length() > 200)
+			throw new BusinessException(ErrorCode.INVALID_INPUT);
+		this.title = newTitle;
+	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/NoteService.java
@@ -10,6 +10,7 @@ import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.note.service.dto.NoteRenameCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
@@ -148,6 +149,18 @@ public class NoteService {
 				  .orElseThrow(() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 
 		note.changeFolder(command.userId(), targetFolder);
+		return NoteDetailResult.from(note);
+	}
+
+	/**
+	 * 노트 이름 변경
+	 */
+	@Transactional
+	public NoteDetailResult renameNote(NoteRenameCommand command) {
+		Note note = noteRepository.findById(command.noteId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_NOT_FOUND));
+
+		note.renameTitle(command.userId(), command.title());
 		return NoteDetailResult.from(note);
 	}
 

--- a/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteRenameCommand.java
+++ b/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteRenameCommand.java
@@ -1,0 +1,9 @@
+package com.keepgoing.keepgoing.note.service.dto;
+
+public record NoteRenameCommand(
+	Long noteId,
+	Long userId,
+	String title
+) {
+}
+

--- a/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/global/config/SecurityConfigTest.java
@@ -248,6 +248,9 @@ class SecurityConfigTest {
 			assertUnauthorized(patch("/api/notes/{noteId}/folder", 1L)
 					.contentType(JSON)
 					.content(EMPTY_JSON));
+			assertUnauthorized(patch("/api/notes/{noteId}/title", 1L)
+					.contentType(JSON)
+					.content(EMPTY_JSON));
 			assertUnauthorized(delete("/api/notes/{noteId}", 1L));
 		}
 

--- a/src/test/java/com/keepgoing/keepgoing/note/NoteIntegrationTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/NoteIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.keepgoing.keepgoing.note;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keepgoing.keepgoing.note.controller.dto.NoteRenameRequest;
+import com.keepgoing.keepgoing.note.domain.Note;
+import com.keepgoing.keepgoing.note.domain.NoteVisibility;
+import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.domain.UserRole;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class NoteIntegrationTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	NoteRepository noteRepository;
+
+	@Autowired
+	EntityManager entityManager;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Nested
+	@DisplayName("PATCH /api/notes/{noteId}/title")
+	class RenameTitle {
+
+		@Test
+		@DisplayName("작성자가 제목 변경을 요청하면 응답과 DB에 변경 내용이 반영된다")
+		void renamesTitleAndPersistsChange() throws Exception {
+			User author = saveUser("author@test.com", "작성자");
+			Note note = saveNote(author, "기존 제목");
+			mockLoginUser(author.getId());
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", note.getId())
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new NoteRenameRequest("변경된 제목"))))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.noteId").value(note.getId()))
+					.andExpect(jsonPath("$.data.userId").value(author.getId()))
+					.andExpect(jsonPath("$.data.title").value("변경된 제목"));
+
+			entityManager.flush();
+			entityManager.clear();
+
+			Note renamed = noteRepository.findById(note.getId()).orElseThrow();
+			assertThat(renamed.getTitle()).isEqualTo("변경된 제목");
+		}
+
+		@Test
+		@DisplayName("제목을 공백으로 보내면 입력값 검증 오류를 응답하고 기존 제목을 유지한다")
+		void returnsBadRequestWhenTitleIsBlank() throws Exception {
+			User author = saveUser("author@test.com", "작성자");
+			Note note = saveNote(author, "기존 제목");
+			mockLoginUser(author.getId());
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", note.getId())
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new NoteRenameRequest(" "))))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("title"));
+
+			entityManager.flush();
+			entityManager.clear();
+
+			Note unchanged = noteRepository.findById(note.getId()).orElseThrow();
+			assertThat(unchanged.getTitle()).isEqualTo("기존 제목");
+		}
+
+		@Test
+		@DisplayName("다른 사용자가 제목 변경을 요청하면 권한 오류를 응답하고 기존 제목을 유지한다")
+		void returnsForbiddenWhenRequesterIsNotAuthor() throws Exception {
+			User author = saveUser("author@test.com", "작성자");
+			User requester = saveUser("other@test.com", "다른 사용자");
+			Note note = saveNote(author, "기존 제목");
+			mockLoginUser(requester.getId());
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", note.getId())
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new NoteRenameRequest("변경 시도"))))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_ACCESS_DENIED"));
+
+			entityManager.flush();
+			entityManager.clear();
+
+			Note unchanged = noteRepository.findById(note.getId()).orElseThrow();
+			assertThat(unchanged.getTitle()).isEqualTo("기존 제목");
+		}
+
+		@Test
+		@DisplayName("없는 노트의 제목 변경을 요청하면 찾을 수 없음을 응답한다")
+		void returnsNotFoundWhenNoteDoesNotExist() throws Exception {
+			User author = saveUser("author@test.com", "작성자");
+			mockLoginUser(author.getId());
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", 999999L)
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new NoteRenameRequest("새 제목"))))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_NOT_FOUND"));
+		}
+	}
+
+	private User saveUser(String email, String name) {
+		return userRepository.saveAndFlush(User.create(email, name));
+	}
+
+	private Note saveNote(User author, String title) {
+		Note note = Note.create(author, null, title, "본문", NoteVisibility.PRIVATE, false);
+		return noteRepository.saveAndFlush(note);
+	}
+
+	private String requestJson(Object request) throws Exception {
+		return objectMapper.writeValueAsString(request);
+	}
+
+	private void mockLoginUser(Long userId) {
+		Authentication authenticated = UsernamePasswordAuthenticationToken.authenticated(
+				userId,
+				null,
+				List.of(new SimpleGrantedAuthority(UserRole.USER.toAuthority()))
+		);
+		SecurityContextHolder.getContext().setAuthentication(authenticated);
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -25,12 +25,14 @@ import com.keepgoing.keepgoing.global.config.JacksonConfig;
 import com.keepgoing.keepgoing.global.security.cookie.CookieConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.note.controller.dto.NoteCreateRequest;
-import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.note.controller.dto.NoteRenameRequest;
 import com.keepgoing.keepgoing.note.controller.dto.NoteUpdateRequest;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.service.NoteService;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
+import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.note.service.dto.NoteRenameCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
@@ -849,6 +851,134 @@ public class NoteControllerTest {
 					.andExpect(status().isForbidden())
 					.andExpect(jsonPath("$.success").value(false))
 					.andExpect(jsonPath("$.error.code").value("FOLDER_ACCESS_DENIED"));
+		}
+	}
+
+	@Nested
+	@DisplayName("PATCH /api/notes/{noteId}/title")
+	class Rename {
+
+		@Test
+		@DisplayName("노트 제목 변경 성공")
+		void success() throws Exception {
+			Long userId = 1L;
+			Long noteId = 10L;
+			NoteRenameRequest request = new NoteRenameRequest("새 제목");
+
+			NoteDetailResult result = new NoteDetailResult(
+					noteId,
+					null,
+					userId,
+					"새 제목",
+					"기존 내용",
+					NoteVisibility.PRIVATE,
+					false,
+					null,
+					null
+			);
+
+			given(noteService.renameNote(any(NoteRenameCommand.class)))
+					.willReturn(result);
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", noteId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.noteId").value(noteId))
+					.andExpect(jsonPath("$.data.userId").value(userId))
+					.andExpect(jsonPath("$.data.title").value("새 제목"));
+
+			ArgumentCaptor<NoteRenameCommand> captor = ArgumentCaptor.forClass(NoteRenameCommand.class);
+			verify(noteService).renameNote(captor.capture());
+			assertThat(captor.getValue().noteId()).isEqualTo(noteId);
+			assertThat(captor.getValue().userId()).isEqualTo(userId);
+			assertThat(captor.getValue().title()).isEqualTo("새 제목");
+		}
+
+		@Test
+		@DisplayName("제목을 공백으로 보내면 입력값 검증 오류를 응답한다")
+		void returnsBadRequestWhenTitleIsBlank() throws Exception {
+			Long userId = 1L;
+			Long noteId = 10L;
+			NoteRenameRequest request = new NoteRenameRequest(" ");
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", noteId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("title"));
+		}
+
+		@Test
+		@DisplayName("제목이 길이 제한을 넘으면 입력값 검증 오류를 응답한다")
+		void returnsBadRequestWhenTitleIsTooLong() throws Exception {
+			Long userId = 1L;
+			Long noteId = 10L;
+			NoteRenameRequest request = new NoteRenameRequest("a".repeat(201));
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", noteId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+					.andExpect(jsonPath("$.error.fieldErrors[0].field").value("title"));
+		}
+
+		@Test
+		@DisplayName("다른 사용자가 제목 변경을 요청하면 권한 오류를 응답한다")
+		void returnsForbiddenWhenRequesterIsNotAuthor() throws Exception {
+			Long userId = 1L;
+			Long noteId = 10L;
+
+			given(noteService.renameNote(any(NoteRenameCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_ACCESS_DENIED));
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", noteId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"title":"남의 제목"}
+									"""))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_ACCESS_DENIED"));
+		}
+
+		@Test
+		@DisplayName("없는 노트의 제목 변경을 요청하면 찾을 수 없음을 응답한다")
+		void returnsNotFoundWhenNoteDoesNotExist() throws Exception {
+			Long userId = 1L;
+			Long noteId = 10L;
+
+			given(noteService.renameNote(any(NoteRenameCommand.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_NOT_FOUND));
+
+			SecurityContextHolder.getContext()
+					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+
+			mockMvc.perform(patch("/api/notes/{noteId}/title", noteId)
+							.contentType(MediaType.APPLICATION_JSON)
+							.content("""
+									{"title":"새 제목"}
+									"""))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_NOT_FOUND"));
 		}
 	}
 

--- a/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/controller/NoteControllerTest.java
@@ -407,7 +407,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("없는 게시글이면 NOTE_NOT_FOUND 에러 응답")
+		@DisplayName("없는 노트를 조회하면 찾을 수 없음을 응답한다")
 		void returnsNotFoundWhenNoteDoesNotExist() throws Exception {
 			Long noteId = 999L;
 
@@ -547,7 +547,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 에러 반환")
+		@DisplayName("다른 사용자가 노트 수정을 요청하면 권한 오류를 응답한다")
 		void accessDenied() throws Exception {
 			// given
 			Long noteId = 1L;
@@ -605,7 +605,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 에러 반환")
+		@DisplayName("다른 사용자가 노트 삭제를 요청하면 권한 오류를 응답한다")
 		void accessDenied() throws Exception {
 			// given
 			Long noteId = 1L;
@@ -760,7 +760,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("노트가 없으면 NOTE_NOT_FOUND 에러를 반환한다")
+		@DisplayName("없는 노트의 이동을 요청하면 찾을 수 없음을 응답한다")
 		void returnsNotFoundWhenNoteDoesNotExist() throws Exception {
 			// given
 			Long userId = 1L;
@@ -783,7 +783,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 에러를 반환한다")
+		@DisplayName("다른 사용자가 노트 이동을 요청하면 권한 오류를 응답한다")
 		void returnsForbiddenWhenRequesterIsNotAuthor() throws Exception {
 			// given
 			Long userId = 1L;
@@ -806,7 +806,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("대상 폴더가 없으면 FOLDER_NOT_FOUND 에러를 반환한다")
+		@DisplayName("없는 폴더로 이동을 요청하면 찾을 수 없음을 응답한다")
 		void returnsNotFoundWhenFolderDoesNotExist() throws Exception {
 			// given
 			Long userId = 1L;
@@ -829,7 +829,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 에러를 반환한다")
+		@DisplayName("다른 사용자의 폴더로 이동을 요청하면 권한 오류를 응답한다")
 		void returnsForbiddenWhenFolderOwnedByAnotherUser() throws Exception {
 			// given
 			Long userId = 1L;
@@ -911,7 +911,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("keyword가 공백이면 400 + NOTE_SEARCH_KEYWORD_REQUIRED 반환")
+		@DisplayName("검색어가 공백이면 공개 노트 검색 요청을 거절한다")
 		void blankKeywordReturns400() throws Exception {
 			given(noteService.searchPublicNotes(any(NoteSearchQuery.class)))
 					.willThrow(new BusinessException(ErrorCode.NOTE_SEARCH_KEYWORD_REQUIRED));
@@ -1002,7 +1002,7 @@ public class NoteControllerTest {
 		}
 
 		@Test
-		@DisplayName("keyword가 공백이면 400 + NOTE_SEARCH_KEYWORD_REQUIRED 반환")
+		@DisplayName("검색어가 공백이면 내 노트 검색 요청을 거절한다")
 		void blankKeywordReturns400() throws Exception {
 			// given
 			Long userId = 1L;

--- a/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
@@ -379,4 +379,76 @@ class NoteTest {
 				.isInstanceOf(BusinessException.class)
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FOLDER_ACCESS_DENIED);
 	}
+
+	@Nested
+	@DisplayName("renameTitle")
+	class RenameTitle {
+
+		@Test
+		@DisplayName("작성자가 요청하면 제목이 변경된다")
+		void changesTitleWhenRequesterIsAuthor() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+
+			note.renameTitle(author.getId(), "새 제목");
+
+			assertThat(note.getTitle()).isEqualTo("새 제목");
+		}
+
+		@Test
+		@DisplayName("다른 사용자가 제목 변경을 시도하면 예외가 발생한다")
+		void throwsWhenRequesterIsNotAuthor() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+
+			assertThatThrownBy(() -> note.renameTitle(2L, "새 제목"))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+		}
+
+		@Test
+		@DisplayName("제목을 공백으로 바꾸려고 하면 예외가 발생한다")
+		void throwsWhenTitleIsBlank() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+
+			assertThatThrownBy(() -> note.renameTitle(author.getId(), " "))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+		}
+
+		@Test
+		@DisplayName("제목이 길이 제한을 넘으면 예외가 발생한다")
+		void throwsWhenTitleIsTooLong() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+
+			assertThatThrownBy(() -> note.renameTitle(author.getId(), "a".repeat(201)))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+		}
+
+		@Test
+		@DisplayName("제목을 null로 바꾸려고 하면 예외가 발생한다")
+		void throwsWhenTitleIsNull() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+
+			assertThatThrownBy(() -> note.renameTitle(author.getId(), null))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+		}
+
+		@Test
+		@DisplayName("제목 길이가 200자면 변경할 수 있다")
+		void changesTitleWhenLengthIsExactly200() {
+			User author = user(1L, "author@test.com", "author");
+			Note note = Note.create(author, null, TITLE, CONTENT, NoteVisibility.PRIVATE, false);
+			String newTitle = "a".repeat(200);
+
+			note.renameTitle(author.getId(), newTitle);
+
+			assertThat(note.getTitle()).isEqualTo(newTitle);
+		}
+	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/domain/NoteTest.java
@@ -122,7 +122,7 @@ class NoteTest {
 		}
 
 		@Test
-		@DisplayName("폴더 owner와 작성자가 다르면 FOLDER_ACCESS_DENIED 예외가 발생한다.")
+		@DisplayName("폴더 소유자와 작성자가 다르면 해당 폴더로 노트를 만들 수 없다.")
 		void create_throwsWhenFolderOwnerDoesNotMatchAuthor() {
 			// given
 			Long authorId = 1L;
@@ -165,7 +165,7 @@ class NoteTest {
 		}
 
 		@Test
-		@DisplayName("제목이 비어있으면 INVALID_INPUT 예외가 발생한다.")
+		@DisplayName("제목이 비어 있으면 노트를 만들 수 없다.")
 		void create_throwsWhenTitleIsBlank() {
 			// given
 			User author = user(1L, "test@test.com", "test");
@@ -184,7 +184,7 @@ class NoteTest {
 		}
 
 		@Test
-		@DisplayName("본문이 비어있으면 INVALID_INPUT 예외가 발생한다.")
+		@DisplayName("본문이 비어 있으면 노트를 만들 수 없다.")
 		void create_throwsWhenContentIsBlank() {
 			// given
 			User author = user(1L, "test@test.com", "test");
@@ -352,7 +352,7 @@ class NoteTest {
 	}
 
 	@Test
-	@DisplayName("changeFolder: 작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+	@DisplayName("changeFolder: 다른 사용자가 이동을 시도하면 예외가 발생한다")
 	void changeFolder_throwsWhenRequesterIsNotAuthor() {
 		// given
 		User author = user(1L, "author@test.com", "author");
@@ -366,7 +366,7 @@ class NoteTest {
 	}
 
 	@Test
-	@DisplayName("changeFolder: 다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+	@DisplayName("changeFolder: 다른 사용자의 폴더로는 이동할 수 없다")
 	void changeFolder_throwsWhenTargetFolderOwnedByAnotherUser() {
 		// given
 		User author = user(1L, "author@test.com", "author");

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -549,7 +549,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("없는 노트의 제목 변경을 요청하면 예외가 발생한다")
+		@DisplayName("없는 노트의 이동을 요청하면 예외가 발생한다")
 		void throwsWhenNoteNotFound() {
 			Long userId = 1L;
 			Long noteId = 10L;

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -107,7 +107,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("유저가 없으면 USER_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 사용자가 노트 생성을 요청하면 예외가 발생한다")
 		void throwsWhenUserNotFound() {
 			Long userId = 1L;
 			NoteCreateCommand command = new NoteCreateCommand(
@@ -176,7 +176,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("존재하지 않는 폴더면 FOLDER_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 폴더로 노트를 만들려고 하면 예외가 발생한다")
 		void throwsWhenFolderNotFound() {
 			Long userId = 1L;
 			User author = user(userId);
@@ -202,7 +202,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자의 폴더로 노트를 만들려고 하면 예외가 발생한다")
 		void throwsWhenFolderOwnedByAnotherUser() {
 			Long userId = 1L;
 			Long otherUserId = 2L;
@@ -275,7 +275,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("익명 사용자가 비공개 노트를 조회하면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("익명 사용자가 비공개 노트를 조회하려고 하면 예외가 발생한다")
 		void throwsWhenAnonymousViewerRequestsPrivateNote() {
 			Long noteId = 1L;
 			User author = user(2L);
@@ -311,7 +311,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("다른 사용자가 비공개 노트를 조회하면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자가 비공개 노트를 조회하려고 하면 예외가 발생한다")
 		void throwsWhenDifferentViewerRequestsPrivateNote() {
 			Long noteId = 1L;
 			Long viewerId = 1L;
@@ -329,7 +329,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 노트를 조회하려고 하면 예외가 발생한다")
 		void throwsWhenNotFound() {
 			Long viewerId = 1L;
 			Long noteId = 1L;
@@ -414,7 +414,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 노트를 수정하려고 하면 예외가 발생한다")
 		void throwsWhenNoteNotFound() {
 			Long userId = 1L;
 			Long noteId = 10L;
@@ -438,7 +438,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자가 노트 수정을 요청하면 예외가 발생한다")
 		void throwsWhenNotAuthor() {
 			Long requesterId = 1L;
 			Long authorId = 2L;
@@ -488,7 +488,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("게시글이 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 노트를 삭제하려고 하면 예외가 발생한다")
 		void throwsWhenNoteNotFound() {
 			Long userId = 1L;
 			Long noteId = 10L;
@@ -504,7 +504,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자가 노트 삭제를 요청하면 예외가 발생한다")
 		void throwsWhenNotAuthor() {
 			Long requesterId = 1L;
 			Long authorId = 2L;
@@ -574,7 +574,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("노트가 없으면 NOTE_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 노트의 제목 변경을 요청하면 예외가 발생한다")
 		void throwsWhenNoteNotFound() {
 			Long noteId = 10L;
 			Long userId = 1L;
@@ -592,7 +592,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("대상 폴더가 없으면 FOLDER_NOT_FOUND 예외가 발생한다")
+		@DisplayName("없는 폴더로 노트를 이동하려고 하면 예외가 발생한다")
 		void throwsWhenFolderNotFound() {
 			Long userId = 1L;
 			Long noteId = 10L;
@@ -614,7 +614,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("작성자가 아니면 NOTE_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자가 노트 이동을 요청하면 예외가 발생한다")
 		void throwsWhenRequesterIsNotAuthor() {
 			Long requesterId = 1L;
 			Long authorId = 2L;
@@ -634,7 +634,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("다른 사용자의 폴더면 FOLDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("다른 사용자의 폴더로 노트를 이동하려고 하면 예외가 발생한다")
 		void throwsWhenTargetFolderOwnedByAnotherUser() {
 			Long userId = 1L;
 			Long otherUserId = 2L;
@@ -690,7 +690,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외가 발생한다")
+		@DisplayName("검색어가 비어 있으면 내 노트 검색을 진행할 수 없다")
 		void throwsWhenKeywordBlank() {
 			Long userId = 1L;
 			Pageable pageable = PageRequest.of(0, 10);
@@ -759,7 +759,7 @@ class NoteServiceTest {
 		}
 
 		@Test
-		@DisplayName("keyword가 비어있으면 NOTE_SEARCH_KEYWORD_REQUIRED 예외가 발생한다")
+		@DisplayName("검색어가 비어 있으면 공개 노트 검색을 진행할 수 없다")
 		void throwsWhenKeywordBlank() {
 			Pageable pageable = PageRequest.of(0, 10);
 			NoteSearchQuery query = new NoteSearchQuery("   ", pageable);

--- a/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/note/service/NoteServiceTest.java
@@ -20,6 +20,7 @@ import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.note.service.dto.NoteCreateCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteMoveCommand;
+import com.keepgoing.keepgoing.note.service.dto.NoteRenameCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteSearchQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteSummaryResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteUpdateCommand;
@@ -515,6 +516,68 @@ class NoteServiceTest {
 			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
 
 			assertThatThrownBy(() -> noteService.deleteNote(requesterId, noteId))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+	}
+
+	@Nested
+	@DisplayName("노트 제목 변경")
+	class RenameNote {
+
+		@Test
+		@DisplayName("작성자가 맞으면 제목이 변경된다")
+		void renamesWhenAuthorMatches() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			User author = user(userId);
+			Note note = Note.create(author, null, "기존 제목", "내용", NoteVisibility.PRIVATE, true);
+			NoteRenameCommand command = new NoteRenameCommand(noteId, userId, "새 제목");
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			NoteDetailResult result = noteService.renameNote(command);
+
+			assertThat(note.getTitle()).isEqualTo("새 제목");
+			assertThat(result.title()).isEqualTo("새 제목");
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("없는 노트의 제목 변경을 요청하면 예외가 발생한다")
+		void throwsWhenNoteNotFound() {
+			Long userId = 1L;
+			Long noteId = 10L;
+			NoteRenameCommand command = new NoteRenameCommand(noteId, userId, "새 제목");
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> noteService.renameNote(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_NOT_FOUND);
+			verify(noteRepository).findById(noteId);
+			verifyNoMoreInteractions(noteRepository);
+			verifyNoInteractions(userRepository, folderRepository);
+		}
+
+		@Test
+		@DisplayName("다른 사용자가 제목 변경을 요청하면 예외가 발생한다")
+		void throwsWhenRequesterIsNotAuthor() {
+			Long requesterId = 1L;
+			Long authorId = 2L;
+			Long noteId = 10L;
+			User author = user(authorId);
+			Note note = Note.create(author, null, "기존 제목", "내용", NoteVisibility.PRIVATE, true);
+			NoteRenameCommand command = new NoteRenameCommand(noteId, requesterId, "새 제목");
+
+			given(noteRepository.findById(noteId)).willReturn(Optional.of(note));
+
+			assertThatThrownBy(() -> noteService.renameNote(command))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_ACCESS_DENIED);
 			verify(noteRepository).findById(noteId);


### PR DESCRIPTION
## 관련 이슈
- closes #83

## 변경 사항
- 노트 제목 변경 API 추가 (`PATCH /api/notes/{noteId}/title`)
- 제목 변경 request/command 및 domain/service 로직 추가
- controller/service/domain/integration/security 테스트 추가

## 테스트
- `./gradlew test --tests 'com.keepgoing.keepgoing.note.NoteIntegrationTest' --tests 'com.keepgoing.keepgoing.note.domain.NoteTest' --tests 'com.keepgoing.keepgoing.note.service.NoteServiceTest' --tests 'com.keepgoing.keepgoing.note.controller.NoteControllerTest' --tests 'com.keepgoing.keepgoing.global.config.SecurityConfigTest'`
