### PR TITLE
feat(AI): #103 AI 패널 retrieval 및 citation 응답 구조 추가

### DIFF
--- a/docs/ai/rag-flow.md
+++ b/docs/ai/rag-flow.md
@@ -13,109 +13,110 @@ AI 패널은 사용자의 메시지에 답변할 때 단순히 선택된 note �
 - AI 응답에 참고한 note 정보를 citation으로 함께 반환한다.
 - 근거가 부족할 때 모델이 과장된 답변을 하지 않도록 prompt 규칙을 둔다.
 
-  ---
+---
 
 ## 전체 흐름
 
-  ```text
-  Note 생성/수정/삭제/이름 변경
-          ↓
-  AiNoteIndexingRequestService
-          ↓
-  AiNoteIndexRequestedEvent 발행
-          ↓
-  @TransactionalEventListener(AFTER_COMMIT)
-  @Async("aiIndexingExecutor")
-          ↓
-  AiNoteIndexingService
-          ↓
-  AiNoteIndexingProcessor
-          ↓
-  ai_note_indexes / ai_note_chunks 저장
-          ↓
-  사용자 AI 패널 메시지 요청
-          ↓
-  AiPanelService
-          ↓
-  AiNoteRetrievalService
-          ↓
-  AiNoteChunkRepository.searchRelevantChunks(...)
-          ↓
-  Prompt assembly
-          ↓
-  ChatClient 호출
-          ↓
-  assistantMessage + citations[] 응답
-  ```
+```text
+Note 생성/수정/삭제/이름 변경
+        ↓
+AiNoteIndexingRequestService
+        ↓
+AiNoteIndexRequestedEvent 발행
+        ↓
+@TransactionalEventListener(AFTER_COMMIT)
+@Async("aiIndexingExecutor")
+        ↓
+AiNoteIndexingService
+        ↓
+AiNoteIndexingProcessor
+        ↓
+ai_note_indexes / ai_note_chunks 저장
+        ↓
+사용자 AI 패널 메시지 요청
+        ↓
+AiPanelService
+        ↓
+AiNoteRetrievalService
+        ↓
+AiNoteChunkRepository.searchRelevantChunks(...)
+        ↓
+Prompt assembly
+        ↓
+ChatClient 호출
+        ↓
+assistantMessage + citations[] 응답
+```
 ---
 
 
-  ## 1. 인덱싱 요청
+## 1. 인덱싱 요청
 
-  note가 생성, 수정, 삭제, 이름 변경되면 AiNoteIndexingRequestService가 재색인을 요청한다.
+note가 생성, 수정, 삭제, 이름 변경되면 AiNoteIndexingRequestService가 재색인을 요청한다.
 
-  AiNoteIndexingRequestService.requestReindex(noteId, authorId)
+AiNoteIndexingRequestService.requestReindex(noteId, authorId)
 
-  역할:
+역할:
 
-  - ai_note_indexes에 note 단위 indexing 상태를 생성하거나 갱신한다.
-  - 상태를 PENDING으로 변경한다.
-  - AiNoteIndexRequestedEvent를 발행한다.
-
----
-
-  ## 2. 비동기 인덱싱 처리
-
-  인덱싱 이벤트는 트랜잭션 commit 이후 비동기로 처리된다.
-
-  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-  @Async("aiIndexingExecutor")
-
-  ```
-  처리 흐름:
-
-  AiNoteIndexingService
-          ↓
-  AiNoteIndexingProcessor
-  ```
-  AiNoteIndexingService는 wrapper 역할을 한다.
-
-  - processor 호출
-  - 예외 발생 시 실패 상태 기록
-  - 실패 로그 기록
-  - 예외 재전파
-
-  AiNoteIndexingProcessor는 실제 인덱싱 트랜잭션을 담당한다.
-
-  - ai_note_indexes row를 pessimistic lock으로 조회한다.
-  - source note를 조회한다.
-  - 삭제된 note 또는 aiCollectable=false note면 chunk를 제거하고 REMOVED로 마킹한다.
-  - 수집 가능한 note면 chunk를 재생성하고 COMPLETED로 마킹한다.
+- ai_note_indexes에 note 단위 indexing 상태를 생성하거나 갱신한다.
+- 상태를 PENDING으로 변경한다.
+- AiNoteIndexRequestedEvent를 발행한다.
 
 ---
 
-  ## 3. 실패 상태 기록
+## 2. 비동기 인덱싱 처리
 
-  인덱싱 중 예외가 발생하면 실패 상태는 별도 트랜잭션으로 기록한다.
+인덱싱 이벤트는 트랜잭션 commit 이후 비동기로 처리된다.
 
-  AiNoteIndexFailureRecorder.markFailed(...)
+@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+@Async("aiIndexingExecutor")
 
-  이 recorder는 REQUIRES_NEW 트랜잭션으로 동작한다.
 
-  목적:
+처리 흐름:
 
-  - 인덱싱 트랜잭션이 rollback되어도 FAILED 상태가 남도록 한다.
-  - last_error, last_processed_at, attempt_count를 기록한다.
+```text
+AiNoteIndexingService
+        ↓
+AiNoteIndexingProcessor
+```
+AiNoteIndexingService는 wrapper 역할을 한다.
+
+- processor 호출
+- 예외 발생 시 실패 상태 기록
+- 실패 로그 기록
+- 예외 재전파
+
+AiNoteIndexingProcessor는 실제 인덱싱 트랜잭션을 담당한다.
+
+- ai_note_indexes row를 pessimistic lock으로 조회한다.
+- source note를 조회한다.
+- 삭제된 note 또는 aiCollectable=false note면 chunk를 제거하고 REMOVED로 마킹한다.
+- 수집 가능한 note면 chunk를 재생성하고 COMPLETED로 마킹한다.
 
 ---
 
-  ## 4. 저장 구조
+## 3. 실패 상태 기록
 
-  ### ai_note_indexes
+인덱싱 중 예외가 발생하면 실패 상태는 별도 트랜잭션으로 기록한다.
 
-  note 단위의 인덱싱 상태를 관리한다.
+AiNoteIndexFailureRecorder.markFailed(...)
 
-  주요 컬럼:
+이 recorder는 REQUIRES_NEW 트랜잭션으로 동작한다.
+
+목적:
+
+- 인덱싱 트랜잭션이 rollback되어도 FAILED 상태가 남도록 한다.
+- last_error, last_processed_at, attempt_count를 기록한다.
+
+---
+
+## 4. 저장 구조
+
+### ai_note_indexes
+
+note 단위의 인덱싱 상태를 관리한다.
+
+주요 컬럼:
 
   | 컬럼 | 설명 |
   | --- | --- |
@@ -128,11 +129,11 @@ AI 패널은 사용자의 메시지에 답변할 때 단순히 선택된 note �
   | indexed_at | 인덱싱 완료 시각 |
   | last_error | 실패 메시지 |
 
-  ### ai_note_chunks
+### ai_note_chunks
 
-  retrieval에 사용할 note chunk를 저장한다.
+retrieval에 사용할 note chunk를 저장한다.
 
-  주요 컬럼:
+주요 컬럼:
 
   | 컬럼 | 설명 |
   | --- | --- |
@@ -147,115 +148,116 @@ AI 패널은 사용자의 메시지에 답변할 때 단순히 선택된 note �
 
 ---
 
-  ## 5. Retrieval 조건
+## 5. Retrieval 조건
 
-  AI 패널 메시지가 들어오면 AiNoteRetrievalService가 사용자 메시지를 기준으로 관련 note chunk를 조회한다.
+AI 패널 메시지가 들어오면 AiNoteRetrievalService가 사용자 메시지를 기준으로 관련 note chunk를 조회한다.
 
-  AiNoteRetrievalService.retrieve(userId, message, contextNoteId)
+AiNoteRetrievalService.retrieve(userId, message, contextNoteId)
 
-  실제 DB 조회는 AiNoteChunkRepository.searchRelevantChunks(...)가 담당한다.
+실제 DB 조회는 AiNoteChunkRepository.searchRelevantChunks(...)가 담당한다.
 
-  ``` 
-  retrieval 대상 조건:
 
-  c.author_id = userId
-  i.author_id = userId
-  n.author_id = userId
-  i.status = COMPLETED
-  n.deleted_at IS NULL
-  n.ai_collectable = true
-  contextNoteId는 제외
-  title 또는 content_chunk가 keyword와 match
-  ```
-  이 조건을 통해 다음을 보장한다.
-  
-  - 다른 사용자의 note는 retrieval되지 않는다.
-  - 삭제된 note는 retrieval되지 않는다.
-  - AI 수집이 허용되지 않은 note는 retrieval되지 않는다.
-  - 인덱싱이 완료되지 않은 note는 retrieval되지 않는다.
-  - 사용자가 직접 선택한 context note는 retrieved note와 중복되지 않는다.
+retrieval 대상 조건:
 
----
+```text
+c.author_id = userId
+i.author_id = userId
+n.author_id = userId
+i.status = COMPLETED
+n.deleted_at IS NULL
+n.ai_collectable = true
+contextNoteId는 제외
+title 또는 content_chunk가 keyword와 match
+```
+이 조건을 통해 다음을 보장한다.
 
-  ## 6. 중복 제거
-
-  DB query는 chunk 단위로 후보를 반환한다.
-  같은 note의 여러 chunk가 검색될 수 있으므로 service 레벨에서 noteId 기준으로 중복 제거한다.
-
-  ```
-  AiNoteRetrievalService
-    - candidate chunk 최대 20개 조회
-    - noteId 기준 중복 제거
-    - 최종 retrieved note 최대 5개 반환
-  ```
-
-  중복 제거는 조회 순서를 유지한다.
-  즉, query 정렬상 더 관련 있다고 판단된 chunk가 해당 note의 대표 excerpt가 된다.
+- 다른 사용자의 note는 retrieval되지 않는다.
+- 삭제된 note는 retrieval되지 않는다.
+- AI 수집이 허용되지 않은 note는 retrieval되지 않는다.
+- 인덱싱이 완료되지 않은 note는 retrieval되지 않는다.
+- 사용자가 직접 선택한 context note는 retrieved note와 중복되지 않는다.
 
 ---
 
-  ## 7. Prompt assembly
+## 6. 중복 제거
 
-  AiPanelService는 다음 정보를 조합해 user prompt를 만든다.
+DB query는 chunk 단위로 후보를 반환한다.
+같은 note의 여러 chunk가 검색될 수 있으므로 service 레벨에서 noteId 기준으로 중복 제거한다.
 
-  1. 현재 선택된 note context
-  2. retrieval된 관련 note
-  3. 답변 규칙
-  4. 사용자 메시지
+```text
+AiNoteRetrievalService
+  - candidate chunk 최대 20개 조회
+  - noteId 기준 중복 제거
+  - 최종 retrieved note 최대 5개 반환
+```
 
+중복 제거는 조회 순서를 유지한다.
+즉, query 정렬상 더 관련 있다고 판단된 chunk가 해당 note의 대표 excerpt가 된다.
 
-  prompt 구조:
-  ```
-  [현재 노트 문맥]
-  - noteId: ...
-  - title: ...
-  - content:
-  ...
-
-  [검색된 관련 노트]
-  1. noteId: ...
-     title: ...
-     excerpt:
-     ...
-
-  [답변 규칙]
-  - 제공된 현재 노트 문맥과 검색된 관련 노트 문맥만 근거로 답변한다.
-  - 근거가 부족하면 추측하지 말고 "노트에서 확인되지 않습니다"라고 말한다.
-  - 실제 저장/수정/삭제가 완료된 것처럼 말하지 않는다.
-  - 참고한 노트가 있다면 답변 내용이 해당 노트 문맥과 연결되도록 답한다.
-
-  [사용자 메시지]
-  ...
-  ```
 ---
 
-  ## 8. Citation 응답
+## 7. Prompt assembly
 
-  AI 패널 응답은 assistant message와 함께 citation 정보를 반환한다.
+AiPanelService는 다음 정보를 조합해 user prompt를 만든다.
 
-  응답 예시:
-  ```
-  {
-    "assistantMessage": "배포 일정은 금요일로 보입니다.",
-    "contextNoteId": 10,
-    "contextAttached": true,
-    "citations": [
-      {
-        "noteId": 10,
-        "title": "현재 회의록",
-        "excerpt": "오늘 논의한 내용...",
-        "sourceType": "CONTEXT_NOTE"
-      },
-      {
-        "noteId": 20,
-        "title": "배포 회의",
-        "excerpt": "금요일 배포 결정",
-        "sourceType": "RETRIEVED_NOTE"
-      }
-    ]
-  }
-  ```
-  citation 필드:
+1. 현재 선택된 note context
+2. retrieval된 관련 note
+3. 답변 규칙
+4. 사용자 메시지
+
+
+prompt 구조:
+```text
+[현재 노트 문맥]
+- noteId: ...
+- title: ...
+- content:
+...
+
+[검색된 관련 노트]
+1. noteId: ...
+   title: ...
+   excerpt:
+   ...
+
+[답변 규칙]
+- 제공된 현재 노트 문맥과 검색된 관련 노트 문맥만 근거로 답변한다.
+- 근거가 부족하면 추측하지 말고 "노트에서 확인되지 않습니다"라고 말한다.
+- 실제 저장/수정/삭제가 완료된 것처럼 말하지 않는다.
+- 참고한 노트가 있다면 답변 내용이 해당 노트 문맥과 연결되도록 답한다.
+
+[사용자 메시지]
+...
+```
+---
+
+## 8. Citation 응답
+
+AI 패널 응답은 assistant message와 함께 citation 정보를 반환한다.
+
+응답 예시:
+```json
+{
+  "assistantMessage": "배포 일정은 금요일로 보입니다.",
+  "contextNoteId": 10,
+  "contextAttached": true,
+  "citations": [
+    {
+      "noteId": 10,
+      "title": "현재 회의록",
+      "excerpt": "오늘 논의한 내용...",
+      "sourceType": "CONTEXT_NOTE"
+    },
+    {
+      "noteId": 20,
+      "title": "배포 회의",
+      "excerpt": "금요일 배포 결정",
+      "sourceType": "RETRIEVED_NOTE"
+    }
+  ]
+}
+```
+citation 필드:
 
   | 필드 | 설명 |
   | --- | --- |

--- a/docs/ai/rag-flow.md
+++ b/docs/ai/rag-flow.md
@@ -1,0 +1,365 @@
+# AI RAG MVP 흐름
+
+## 목적
+
+AI 패널은 사용자의 메시지에 답변할 때 단순히 선택된 note 하나만 참고하지 않고,
+사용자의 메시지와 관련 있는 indexed note를 검색해 함께 참고한다.
+
+이 문서의 목적은 KeepGoing의 AI RAG MVP가 다음을 어떻게 보장하는지 설명하는 것이다.
+
+- 사용자가 접근 가능한 note만 retrieval 대상에 포함한다.
+- AI 수집이 허용된 note만 retrieval 대상에 포함한다.
+- 인덱싱이 완료된 note chunk만 검색한다.
+- AI 응답에 참고한 note 정보를 citation으로 함께 반환한다.
+- 근거가 부족할 때 모델이 과장된 답변을 하지 않도록 prompt 규칙을 둔다.
+
+  ---
+
+## 전체 흐름
+
+  ```text
+  Note 생성/수정/삭제/이름 변경
+          ↓
+  AiNoteIndexingRequestService
+          ↓
+  AiNoteIndexRequestedEvent 발행
+          ↓
+  @TransactionalEventListener(AFTER_COMMIT)
+  @Async("aiIndexingExecutor")
+          ↓
+  AiNoteIndexingService
+          ↓
+  AiNoteIndexingProcessor
+          ↓
+  ai_note_indexes / ai_note_chunks 저장
+          ↓
+  사용자 AI 패널 메시지 요청
+          ↓
+  AiPanelService
+          ↓
+  AiNoteRetrievalService
+          ↓
+  AiNoteChunkRepository.searchRelevantChunks(...)
+          ↓
+  Prompt assembly
+          ↓
+  ChatClient 호출
+          ↓
+  assistantMessage + citations[] 응답
+  ```
+---
+
+
+  ## 1. 인덱싱 요청
+
+  note가 생성, 수정, 삭제, 이름 변경되면 AiNoteIndexingRequestService가 재색인을 요청한다.
+
+  AiNoteIndexingRequestService.requestReindex(noteId, authorId)
+
+  역할:
+
+  - ai_note_indexes에 note 단위 indexing 상태를 생성하거나 갱신한다.
+  - 상태를 PENDING으로 변경한다.
+  - AiNoteIndexRequestedEvent를 발행한다.
+
+---
+
+  ## 2. 비동기 인덱싱 처리
+
+  인덱싱 이벤트는 트랜잭션 commit 이후 비동기로 처리된다.
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Async("aiIndexingExecutor")
+
+  ```
+  처리 흐름:
+
+  AiNoteIndexingService
+          ↓
+  AiNoteIndexingProcessor
+  ```
+  AiNoteIndexingService는 wrapper 역할을 한다.
+
+  - processor 호출
+  - 예외 발생 시 실패 상태 기록
+  - 실패 로그 기록
+  - 예외 재전파
+
+  AiNoteIndexingProcessor는 실제 인덱싱 트랜잭션을 담당한다.
+
+  - ai_note_indexes row를 pessimistic lock으로 조회한다.
+  - source note를 조회한다.
+  - 삭제된 note 또는 aiCollectable=false note면 chunk를 제거하고 REMOVED로 마킹한다.
+  - 수집 가능한 note면 chunk를 재생성하고 COMPLETED로 마킹한다.
+
+---
+
+  ## 3. 실패 상태 기록
+
+  인덱싱 중 예외가 발생하면 실패 상태는 별도 트랜잭션으로 기록한다.
+
+  AiNoteIndexFailureRecorder.markFailed(...)
+
+  이 recorder는 REQUIRES_NEW 트랜잭션으로 동작한다.
+
+  목적:
+
+  - 인덱싱 트랜잭션이 rollback되어도 FAILED 상태가 남도록 한다.
+  - last_error, last_processed_at, attempt_count를 기록한다.
+
+---
+
+  ## 4. 저장 구조
+
+  ### ai_note_indexes
+
+  note 단위의 인덱싱 상태를 관리한다.
+
+  주요 컬럼:
+
+  | 컬럼 | 설명 |
+  | --- | --- |
+  | note_id | 인덱싱 대상 note id |
+  | author_id | note 작성자 id |
+  | status | PENDING, COMPLETED, FAILED, REMOVED |
+  | attempt_count | 처리 시도 횟수 |
+  | last_requested_at | 마지막 인덱싱 요청 시각 |
+  | last_processed_at | 마지막 처리 시각 |
+  | indexed_at | 인덱싱 완료 시각 |
+  | last_error | 실패 메시지 |
+
+  ### ai_note_chunks
+
+  retrieval에 사용할 note chunk를 저장한다.
+
+  주요 컬럼:
+
+  | 컬럼 | 설명 |
+  | --- | --- |
+  | id | chunk id |
+  | note_id | 원본 note id |
+  | author_id | note 작성자 id |
+  | chunk_order | note 내 chunk 순서 |
+  | title | note 제목 |
+  | content_chunk | 검색 및 prompt에 사용할 본문 일부 |
+  | source_updated_at | 원본 note 수정 시각 |
+  | indexed_at | chunk 인덱싱 시각 |
+
+---
+
+  ## 5. Retrieval 조건
+
+  AI 패널 메시지가 들어오면 AiNoteRetrievalService가 사용자 메시지를 기준으로 관련 note chunk를 조회한다.
+
+  AiNoteRetrievalService.retrieve(userId, message, contextNoteId)
+
+  실제 DB 조회는 AiNoteChunkRepository.searchRelevantChunks(...)가 담당한다.
+
+  ``` 
+  retrieval 대상 조건:
+
+  c.author_id = userId
+  i.author_id = userId
+  n.author_id = userId
+  i.status = COMPLETED
+  n.deleted_at IS NULL
+  n.ai_collectable = true
+  contextNoteId는 제외
+  title 또는 content_chunk가 keyword와 match
+  ```
+  이 조건을 통해 다음을 보장한다.
+  
+  - 다른 사용자의 note는 retrieval되지 않는다.
+  - 삭제된 note는 retrieval되지 않는다.
+  - AI 수집이 허용되지 않은 note는 retrieval되지 않는다.
+  - 인덱싱이 완료되지 않은 note는 retrieval되지 않는다.
+  - 사용자가 직접 선택한 context note는 retrieved note와 중복되지 않는다.
+
+---
+
+  ## 6. 중복 제거
+
+  DB query는 chunk 단위로 후보를 반환한다.
+  같은 note의 여러 chunk가 검색될 수 있으므로 service 레벨에서 noteId 기준으로 중복 제거한다.
+
+  ```
+  AiNoteRetrievalService
+    - candidate chunk 최대 20개 조회
+    - noteId 기준 중복 제거
+    - 최종 retrieved note 최대 5개 반환
+  ```
+
+  중복 제거는 조회 순서를 유지한다.
+  즉, query 정렬상 더 관련 있다고 판단된 chunk가 해당 note의 대표 excerpt가 된다.
+
+---
+
+  ## 7. Prompt assembly
+
+  AiPanelService는 다음 정보를 조합해 user prompt를 만든다.
+
+  1. 현재 선택된 note context
+  2. retrieval된 관련 note
+  3. 답변 규칙
+  4. 사용자 메시지
+
+
+  prompt 구조:
+  ```
+  [현재 노트 문맥]
+  - noteId: ...
+  - title: ...
+  - content:
+  ...
+
+  [검색된 관련 노트]
+  1. noteId: ...
+     title: ...
+     excerpt:
+     ...
+
+  [답변 규칙]
+  - 제공된 현재 노트 문맥과 검색된 관련 노트 문맥만 근거로 답변한다.
+  - 근거가 부족하면 추측하지 말고 "노트에서 확인되지 않습니다"라고 말한다.
+  - 실제 저장/수정/삭제가 완료된 것처럼 말하지 않는다.
+  - 참고한 노트가 있다면 답변 내용이 해당 노트 문맥과 연결되도록 답한다.
+
+  [사용자 메시지]
+  ...
+  ```
+---
+
+  ## 8. Citation 응답
+
+  AI 패널 응답은 assistant message와 함께 citation 정보를 반환한다.
+
+  응답 예시:
+  ```
+  {
+    "assistantMessage": "배포 일정은 금요일로 보입니다.",
+    "contextNoteId": 10,
+    "contextAttached": true,
+    "citations": [
+      {
+        "noteId": 10,
+        "title": "현재 회의록",
+        "excerpt": "오늘 논의한 내용...",
+        "sourceType": "CONTEXT_NOTE"
+      },
+      {
+        "noteId": 20,
+        "title": "배포 회의",
+        "excerpt": "금요일 배포 결정",
+        "sourceType": "RETRIEVED_NOTE"
+      }
+    ]
+  }
+  ```
+  citation 필드:
+
+  | 필드 | 설명 |
+  | --- | --- |
+  | noteId | 참고한 note id |
+  | title | 참고한 note 제목 |
+  | excerpt | 참고한 note 본문 일부 |
+  | sourceType | CONTEXT_NOTE 또는 RETRIEVED_NOTE |
+
+---
+
+  ## 9. Source type
+
+  ### CONTEXT_NOTE
+
+  사용자가 명시적으로 선택한 현재 note 문맥이다.
+
+  특징:
+
+  - contextNoteId로 전달된다.
+  - 기존 NoteService.getNote(...) 권한 검사를 통과해야 한다.
+  - citation 목록에서 retrieved note보다 먼저 반환된다.
+
+  ### RETRIEVED_NOTE
+
+  사용자 메시지를 기준으로 검색된 관련 note다.
+
+  특징:
+
+  - indexed chunk 기반으로 검색된다.
+  - 작성자, 삭제 여부, AI 수집 허용 여부, 인덱싱 완료 상태를 모두 만족해야 한다.
+  - context note와 중복되지 않는다.
+
+---
+
+  ## 10. 검증 범위
+
+  현재 테스트는 다음 흐름을 검증한다.
+
+  ### 인덱싱
+
+  - AiNoteIndexingServiceTest
+      - processor 성공 시 실패 상태를 기록하지 않음
+      - processor 실패 시 실패 상태 기록 후 예외 재전파
+  - AiNoteIndexingProcessorTest
+      - 수집 가능한 note는 chunk 저장 후 COMPLETED
+      - 삭제된 note는 chunk 제거 후 REMOVED
+      - aiCollectable=false note는 chunk 제거 후 REMOVED
+      - index가 없으면 예외 발생
+      - processor는 실패 상태를 직접 마킹하지 않고 예외 전파
+  - AiNoteIndexFailureRecorderTest
+      - 실패 발생 시 FAILED, last_error, attempt_count 기록
+
+  ### Retrieval
+
+  - AiNoteChunkRepositoryTest
+      - 내 note + COMPLETED + aiCollectable=true + not deleted note 검색
+      - 다른 사용자 note 제외
+      - aiCollectable=false note 제외
+      - COMPLETED가 아닌 index 제외
+      - 삭제된 note 제외
+      - excludeNoteId 제외
+      - title match가 content match보다 우선 정렬
+  - AiNoteRetrievalServiceTest
+      - blank message면 검색하지 않음
+      - 후보 chunk를 noteId 기준으로 중복 제거
+      - 최종 결과 최대 5개 제한
+      - 긴 excerpt truncate
+
+  ### AI Panel
+
+  - AiPanelServiceTest
+      - context note prompt 포함
+      - retrieved note prompt 포함
+      - 답변 규칙 prompt 포함
+      - context/retrieved citation 생성
+      - 접근 불가능한 context note면 모델 호출 전 예외
+  - AiPanelControllerTest
+      - citation 응답 JSON 형식 검증
+      - validation 오류 검증
+      - AI 예외 응답 검증
+  - AiPanelIntegrationTest
+      - context note citation 응답 검증
+      - retrieved note prompt/citation 반영 검증
+      - 다른 사용자 note가 retrieval prompt/citation에 포함되지 않음
+
+---
+
+  ## 11. MVP 한계
+
+  현재 retrieval은 MVP 범위로 keyword LIKE 검색 기반이다.
+
+  현재 방식의 한계:
+
+  - embedding/vector search가 아니다.
+  - 의미 기반 검색 품질은 제한적이다.
+  - 한국어 형태소 분석을 수행하지 않는다.
+  - LOWER(...) LIKE '%keyword%' 형태라 데이터가 커지면 성능 한계가 생길 수 있다.
+  - 같은 note의 여러 chunk 중 대표 chunk 선택은 query 정렬과 service 중복 제거에 의존한다.
+
+  향후 개선 방향:
+
+  - PostgreSQL pg_trgm 기반 유사도 검색
+  - PostgreSQL full-text search
+  - embedding 생성 및 vector search
+  - 사용자 메시지 keyword extraction
+  - retrieved context score 반환
+  - citation과 실제 모델 답변의 source alignment 강화

--- a/src/main/java/com/keepgoing/keepgoing/ai/controller/dto/AiPanelCitationResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/controller/dto/AiPanelCitationResponse.java
@@ -1,0 +1,19 @@
+package com.keepgoing.keepgoing.ai.controller.dto;
+
+import com.keepgoing.keepgoing.ai.service.dto.AiPanelCitationResult;
+
+public record AiPanelCitationResponse(
+		Long noteId,
+		String title,
+		String excerpt,
+		String sourceType
+) {
+	public static AiPanelCitationResponse from(AiPanelCitationResult result) {
+		return new AiPanelCitationResponse(
+				result.noteId(),
+				result.title(),
+				result.excerpt(),
+				result.sourceType().name()
+		);
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/ai/controller/dto/AiPanelMessageResponse.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/controller/dto/AiPanelMessageResponse.java
@@ -3,18 +3,27 @@ package com.keepgoing.keepgoing.ai.controller.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageResult;
+import java.util.List;
 
 @JsonInclude(Include.NON_NULL)
 public record AiPanelMessageResponse(
 		String assistantMessage,
 		Long contextNoteId,
-		boolean contextAttached
+		boolean contextAttached,
+		List<AiPanelCitationResponse> citations
 ) {
 	public static AiPanelMessageResponse from(AiPanelMessageResult result) {
+		List<AiPanelCitationResponse> citations = result.citations() == null
+				? List.of()
+				: result.citations().stream()
+						.map(AiPanelCitationResponse::from)
+						.toList();
+
 		return new AiPanelMessageResponse(
 				result.assistantMessage(),
 				result.contextNoteId(),
-				result.contextAttached()
+				result.contextAttached(),
+				citations
 		);
 	}
 }

--- a/src/main/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepository.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepository.java
@@ -1,9 +1,48 @@
 package com.keepgoing.keepgoing.ai.repository;
 
 import com.keepgoing.keepgoing.ai.domain.AiNoteChunk;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AiNoteChunkRepository extends JpaRepository<AiNoteChunk, Long> {
 
 	void deleteByNoteId(Long noteId);
+
+	@Query(value = """
+  		SELECT
+  			c.note_id AS noteId,
+  			c.title AS title,
+  			c.content_chunk AS excerpt
+  		FROM ai_note_chunks c
+  		JOIN ai_note_indexes i ON i.note_id = c.note_id
+  		JOIN notes n ON n.id = c.note_id
+  		WHERE c.author_id = :authorId
+  		  AND i.author_id = :authorId
+  		  AND n.author_id = :authorId
+  		  AND i.status = 'COMPLETED'
+  		  AND n.deleted_at IS NULL
+  		  AND n.ai_collectable = true
+  		  AND (:excludeNoteId IS NULL OR c.note_id <> :excludeNoteId)
+  		  AND (
+  			LOWER(c.title) LIKE CONCAT('%', LOWER(:keyword), '%')
+  			OR LOWER(c.content_chunk) LIKE CONCAT('%', LOWER(:keyword), '%')
+  		  )
+  		ORDER BY
+  			CASE
+  				WHEN LOWER(c.title) LIKE CONCAT('%', LOWER(:keyword), '%') THEN 0
+  				ELSE 1
+  			END,
+  			c.indexed_at DESC,
+  			c.note_id DESC,
+  			c.chunk_order ASC
+  		LIMIT :limit
+  		""", nativeQuery = true)
+	List<AiNoteRetrievalView> searchRelevantChunks(
+			@Param("authorId") Long authorId,
+			@Param("keyword") String keyword,
+			@Param("excludeNoteId") Long excludeNoteId,
+			@Param("limit") int limit
+	);
 }

--- a/src/main/java/com/keepgoing/keepgoing/ai/repository/AiNoteRetrievalView.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/repository/AiNoteRetrievalView.java
@@ -1,0 +1,9 @@
+package com.keepgoing.keepgoing.ai.repository;
+
+public interface AiNoteRetrievalView {
+	Long getNoteId();
+
+	String getTitle();
+
+	String getExcerpt();
+}

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/AiNoteRetrievalService.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/AiNoteRetrievalService.java
@@ -1,0 +1,82 @@
+package com.keepgoing.keepgoing.ai.service;
+
+import com.keepgoing.keepgoing.ai.repository.AiNoteChunkRepository;
+import com.keepgoing.keepgoing.ai.repository.AiNoteRetrievalView;
+import com.keepgoing.keepgoing.ai.service.dto.AiNoteRetrievalResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiNoteRetrievalService {
+
+	private static final int MAX_RETRIEVED_NOTES = 5;
+	private static final int CANDIDATE_CHUNK_LIMIT = 20;
+	private static final int MAX_EXCERPT_LENGTH = 500;
+
+	private final AiNoteChunkRepository aiNoteChunkRepository;
+
+	public List<AiNoteRetrievalResult> retrieve(
+			Long userId,
+			String message,
+			Long contextNoteId
+	) {
+		String keyword = normalizeKeyword(message);
+
+		if (keyword.isBlank()) {
+			return List.of();
+		}
+
+		List<AiNoteRetrievalView> candidates = aiNoteChunkRepository.searchRelevantChunks(
+				userId,
+				keyword,
+				contextNoteId,
+				CANDIDATE_CHUNK_LIMIT
+		);
+
+		return deduplicateByNoteId(candidates);
+	}
+
+	private List<AiNoteRetrievalResult> deduplicateByNoteId(List<AiNoteRetrievalView> candidates) {
+		Map<Long, AiNoteRetrievalResult> resultsByNoteId = new LinkedHashMap<>();
+
+		for (AiNoteRetrievalView candidate : candidates) {
+			resultsByNoteId.putIfAbsent(
+					candidate.getNoteId(),
+					new AiNoteRetrievalResult(
+							candidate.getNoteId(),
+							candidate.getTitle(),
+							truncateExcerpt(candidate.getExcerpt())
+					)
+			);
+
+			if (resultsByNoteId.size() >= MAX_RETRIEVED_NOTES) {
+				break;
+			}
+		}
+		return List.copyOf(resultsByNoteId.values());
+	}
+
+	private String normalizeKeyword(String message) {
+		if (message == null) {
+			return "";
+		}
+
+		return message.trim();
+	}
+
+	private String truncateExcerpt(String excerpt) {
+		if (excerpt == null || excerpt.isBlank()) {
+			return "";
+		}
+
+		if (excerpt.length() <= MAX_EXCERPT_LENGTH) {
+			return excerpt;
+		}
+
+		return excerpt.substring(0, MAX_EXCERPT_LENGTH) + "\n...(truncated)";
+	}
+}

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/AiPanelService.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/AiPanelService.java
@@ -1,5 +1,8 @@
 package com.keepgoing.keepgoing.ai.service;
 
+import com.keepgoing.keepgoing.ai.service.dto.AiCitationSourceType;
+import com.keepgoing.keepgoing.ai.service.dto.AiNoteRetrievalResult;
+import com.keepgoing.keepgoing.ai.service.dto.AiPanelCitationResult;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageCommand;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageResult;
 import com.keepgoing.keepgoing.note.service.NoteService;
@@ -7,16 +10,17 @@ import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * 초기 AI 패널 메시지 채널 서비스.
- *
+ * <p>
  * 현재 구현은 사용자의 메시지를 받아 GLM 응답을 반환하는 최소 채널에 집중한다.
- *
- * note context가 주어지면 기존 NoteService의 읽기 권한 규칙을 재사용해
- * 현재 노트 문맥을 프롬프트에 포함한다.
- *
+ * <p>
+ * note context가 주어지면 기존 NoteService의 읽기 권한 규칙을 재사용해 현재 노트 문맥을 프롬프트에 포함한다.
+ * <p>
  * 현재 책임은 패널 메시지 orchestration + 모델 호출에 한정한다.
  */
 @Service
@@ -27,26 +31,36 @@ public class AiPanelService {
 	private final ChatClient aiPanelChatClient;
 
 	private final NoteService noteService;
+	private final AiNoteRetrievalService aiNoteRetrievalService;
 
 	public AiPanelMessageResult sendMessage(Long userId, AiPanelMessageCommand command) {
 		// note context 조회
-		AiNoteContext context = loadNoteContextIfPresent(userId, command);
+		AiPanelContextNote context = loadNoteContextIfPresent(userId, command);
 
-		String userPrompt = buildUserPrompt(command.message(), context);
+		List<AiNoteRetrievalResult> retrievedNotes = aiNoteRetrievalService.retrieve(
+				userId,
+				command.message(),
+				context != null ? context.noteId() : null
+		);
+
+		String userPrompt = buildUserPrompt(command.message(), context, retrievedNotes);
 
 		String assistantMessage = aiPanelChatClient.prompt()
 				.user(userPrompt)
 				.call()
 				.content();
 
+		List<AiPanelCitationResult> citations = buildCitations(context, retrievedNotes);
+
 		return new AiPanelMessageResult(
-			assistantMessage,
-			context != null ? context.noteId : null,
-			context != null
+				assistantMessage,
+				context != null ? context.noteId() : null,
+				context != null,
+				citations
 		);
 	}
 
-	private AiNoteContext loadNoteContextIfPresent(Long userId, AiPanelMessageCommand command) {
+	private AiPanelContextNote loadNoteContextIfPresent(Long userId, AiPanelMessageCommand command) {
 		if (command.contextNoteId() == null) {
 			return null;
 		}
@@ -54,38 +68,95 @@ public class AiPanelService {
 		// 현재 note에 대한 직접 상호작용은 허용한다.
 		// aiCollectable은 이후 retrieval/RAG 계열 기능의 gate로 해석한다.
 		NoteDetailResult note = noteService.getNote(userId, command.contextNoteId());
-		return AiNoteContext.from(note);
+		return AiPanelContextNote.from(note);
 	}
 
 	// TODO:
 	// AiActionType별 프롬프트 포맷 분기가 생기면 buildUserPrompt 책임을
 	// AiPromptBuilder / AiPromptAssembler로 분리한다.
 	// 현재는 단일 메시지 흐름이라 AiPanelService 내부에 유지한다.
-	private String buildUserPrompt(String message, AiNoteContext context) {
-		if (context == null) {
-			return """
-					[사용자 메시지]
+	private String buildUserPrompt(
+			String message,
+			AiPanelContextNote context,
+			List<AiNoteRetrievalResult> retrievedNotes
+	) {
+		StringBuilder prompt = new StringBuilder();
+
+		if (context != null) {
+			prompt.append("""
+					[현재 노트 문맥]
+					- noteId: %s
+					- title: %s
+					- content:
 					%s
-					"""
-					.formatted(message);
+					
+					""".formatted(
+					context.noteId(),
+					context.title(),
+					truncate(context.content())
+			));
 		}
 
-		return """
-				[현재 노트 문맥]
-				- noteId: %s
-				- title: %s
-				- content:
-				%s
+		if (!retrievedNotes.isEmpty()) {
+			prompt.append("[검색된 관련 노트]\n");
+
+			for (int i = 0; i < retrievedNotes.size(); i++) {
+				AiNoteRetrievalResult note = retrievedNotes.get(i);
+
+				prompt.append("""
+						%d. noteId: %s
+						   title: %s
+						   excerpt:
+						   %s
+						
+						""".formatted(
+						i + 1,
+						note.noteId(),
+						note.title(),
+						note.excerpt()
+				));
+			}
+		}
+
+		prompt.append("""
+				[답변 규칙]
+				- 제공된 현재 노트 문맥과 검색된 관련 노트 문맥만 근거로 답변한다.
+				- 근거가 부족하면 추측하지 말고 "노트에서 확인되지 않습니다"라고 말한다.
+				- 실제 저장/수정/삭제가 완료된 것처럼 말하지 않는다.
+				- 참고한 노트가 있다면 답변 내용이 해당 노트 문맥과 연결되도록 답한다.
 				
 				[사용자 메시지]
 				%s
-				"""
-				.formatted(
-						context.noteId(),
-						context.title(),
-						truncate(context.content()),
-						message
-				);
+				""".formatted(message));
+
+		return prompt.toString();
+	}
+
+	private List<AiPanelCitationResult> buildCitations(
+			AiPanelContextNote context,
+			List<AiNoteRetrievalResult> retrievedNotes
+	) {
+		List<AiPanelCitationResult> citations = new ArrayList<>();
+
+		if (context != null) {
+			citations.add(new AiPanelCitationResult(
+					context.noteId(),
+					context.title(),
+					truncate(context.content()),
+					AiCitationSourceType.CONTEXT_NOTE
+			));
+		}
+
+		for (AiNoteRetrievalResult note : retrievedNotes) {
+			citations.add(new AiPanelCitationResult(
+					note.noteId(),
+					note.title(),
+					note.excerpt(),
+					AiCitationSourceType.RETRIEVED_NOTE
+			));
+		}
+
+		return citations;
 	}
 
 	private String truncate(String content) {
@@ -99,18 +170,17 @@ public class AiPanelService {
 		return content.substring(0, MAX_LENGTH) + "\n...(truncated)";
 	}
 
-
 	// AI가 실제로 사용하는 현재 노트 문맥의 최소 표현.
 	// NoteDetailResult 전체를 AI 로직에 퍼뜨리지 않기 위해
 	// noteId/title/content만 남긴 최소 모델로 좁혀서 사용한다.
 	// 임시로 사용
-	private record AiNoteContext(
+	private record AiPanelContextNote(
 			Long noteId,
 			String title,
 			String content
 	) {
-		public static AiNoteContext from(NoteDetailResult result) {
-			return new AiNoteContext(
+		public static AiPanelContextNote from(NoteDetailResult result) {
+			return new AiPanelContextNote(
 					result.noteId(),
 					result.title(),
 					result.content()

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiCitationSourceType.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiCitationSourceType.java
@@ -1,0 +1,6 @@
+package com.keepgoing.keepgoing.ai.service.dto;
+
+public enum AiCitationSourceType {
+	CONTEXT_NOTE,
+	RETRIEVED_NOTE
+}

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiNoteRetrievalResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiNoteRetrievalResult.java
@@ -1,0 +1,9 @@
+package com.keepgoing.keepgoing.ai.service.dto;
+
+public record AiNoteRetrievalResult(
+		Long noteId,
+		String title,
+		String excerpt
+) {
+}
+

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiPanelCitationResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiPanelCitationResult.java
@@ -1,0 +1,9 @@
+package com.keepgoing.keepgoing.ai.service.dto;
+
+public record AiPanelCitationResult(
+		Long noteId,
+		String title,
+		String excerpt,
+		AiCitationSourceType sourceType
+) {
+}

--- a/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiPanelMessageResult.java
+++ b/src/main/java/com/keepgoing/keepgoing/ai/service/dto/AiPanelMessageResult.java
@@ -1,8 +1,11 @@
 package com.keepgoing.keepgoing.ai.service.dto;
 
+import java.util.List;
+
 public record AiPanelMessageResult(
 		String assistantMessage,
 		Long contextNoteId,
-		boolean contextAttached
+		boolean contextAttached,
+		List<AiPanelCitationResult> citations
 ) {
 }

--- a/src/test/java/com/keepgoing/keepgoing/ai/AiPanelIntegrationTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/AiPanelIntegrationTest.java
@@ -295,7 +295,7 @@ class AiPanelIntegrationTest {
 				0,
 				title,
 				contentChunk,
-				requestedAt,
+				note.getUpdatedAt(),
 				indexedAt
 		));
 

--- a/src/test/java/com/keepgoing/keepgoing/ai/AiPanelIntegrationTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/AiPanelIntegrationTest.java
@@ -14,6 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keepgoing.keepgoing.ai.controller.dto.AiPanelMessageRequest;
+import com.keepgoing.keepgoing.ai.domain.AiNoteChunk;
+import com.keepgoing.keepgoing.ai.domain.AiNoteIndex;
+import com.keepgoing.keepgoing.ai.repository.AiNoteChunkRepository;
+import com.keepgoing.keepgoing.ai.repository.AiNoteIndexRepository;
 import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
@@ -21,6 +25,7 @@ import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +61,12 @@ class AiPanelIntegrationTest {
 
 	@Autowired
 	NoteRepository noteRepository;
+
+	@Autowired
+	AiNoteIndexRepository aiNoteIndexRepository;
+
+	@Autowired
+	AiNoteChunkRepository aiNoteChunkRepository;
 
 	@Autowired
 	EntityManager entityManager;
@@ -100,7 +111,11 @@ class AiPanelIntegrationTest {
 					.andExpect(jsonPath("$.success").value(true))
 					.andExpect(jsonPath("$.data.assistantMessage").value("AI 응답"))
 					.andExpect(jsonPath("$.data.contextNoteId").value(note.getId()))
-					.andExpect(jsonPath("$.data.contextAttached").value(true));
+					.andExpect(jsonPath("$.data.contextAttached").value(true))
+					.andExpect(jsonPath("$.data.citations[0].noteId").value(note.getId()))
+					.andExpect(jsonPath("$.data.citations[0].title").value("회의록"))
+					.andExpect(jsonPath("$.data.citations[0].excerpt").value("오늘 논의한 내용"))
+					.andExpect(jsonPath("$.data.citations[0].sourceType").value("CONTEXT_NOTE"));
 
 			ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
 			verify(chatClientRequestSpec).user(promptCaptor.capture());
@@ -150,6 +165,85 @@ class AiPanelIntegrationTest {
 
 			verifyNoInteractions(aiPanelChatClient);
 		}
+
+		@Test
+		@DisplayName("retrieval 대상 note가 있으면 prompt와 citation 응답에 RETRIEVED_NOTE로 포함한다")
+		void returnsRetrievedNoteCitation() throws Exception {
+			// given
+			User author = saveUser("author-retrieval@test.com", "작성자");
+			Note note = saveCollectableNote(author, "배포 회의", "금요일 배포 결정");
+
+			saveCompletedAiIndexAndChunk(
+					note,
+					"배포 회의",
+					"금요일 배포 결정"
+			);
+
+			mockLoginUser(author.getId());
+			given(callResponseSpec.content()).willReturn("배포 일정 응답");
+
+			// when & then
+			mockMvc.perform(post("/api/ai/panel/messages")
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new AiPanelMessageRequest(null, "배포"))))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.assistantMessage").value("배포 일정 응답"))
+					.andExpect(jsonPath("$.data.contextNoteId").doesNotHaveJsonPath())
+					.andExpect(jsonPath("$.data.contextAttached").value(false))
+					.andExpect(jsonPath("$.data.citations[0].noteId").value(note.getId()))
+					.andExpect(jsonPath("$.data.citations[0].title").value("배포 회의"))
+					.andExpect(jsonPath("$.data.citations[0].excerpt").value("금요일 배포 결정"))
+					.andExpect(jsonPath("$.data.citations[0].sourceType").value("RETRIEVED_NOTE"));
+
+			ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+			verify(chatClientRequestSpec).user(promptCaptor.capture());
+
+			assertThat(promptCaptor.getValue())
+					.contains("[검색된 관련 노트]")
+					.contains("배포 회의")
+					.contains("금요일 배포 결정")
+					.contains("[답변 규칙]")
+					.contains("노트에서 확인되지 않습니다")
+					.contains("배포");
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 indexed note는 retrieval prompt와 citation에 포함하지 않는다")
+		void doesNotRetrieveOtherUsersNote() throws Exception {
+			// given
+			User author = saveUser("author-private@test.com", "작성자");
+			User requester = saveUser("requester@test.com", "요청자");
+
+			Note otherUserNote = saveCollectableNote(author, "배포 회의", "다른 사용자의 배포 내용");
+
+			saveCompletedAiIndexAndChunk(
+					otherUserNote,
+					"배포 회의",
+					"다른 사용자의 배포 내용"
+			);
+
+			mockLoginUser(requester.getId());
+			given(callResponseSpec.content()).willReturn("근거 없음 응답");
+
+			// when & then
+			mockMvc.perform(post("/api/ai/panel/messages")
+							.contentType(APPLICATION_JSON)
+							.content(requestJson(new AiPanelMessageRequest(null, "배포"))))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.assistantMessage").value("근거 없음 응답"))
+					.andExpect(jsonPath("$.data.contextAttached").value(false))
+					.andExpect(jsonPath("$.data.citations").isEmpty());
+
+			ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+			verify(chatClientRequestSpec).user(promptCaptor.capture());
+
+			assertThat(promptCaptor.getValue())
+					.doesNotContain("다른 사용자의 배포 내용")
+					.doesNotContain("[검색된 관련 노트]")
+					.contains("[답변 규칙]");
+		}
 	}
 
 	private User saveUser(String email, String name) {
@@ -172,5 +266,40 @@ class AiPanelIntegrationTest {
 				List.of(new SimpleGrantedAuthority(UserRole.USER.toAuthority()))
 		);
 		SecurityContextHolder.getContext().setAuthentication(authenticated);
+	}
+
+	private Note saveCollectableNote(User author, String title, String content) {
+		Note note = Note.create(author, null, title, content, NoteVisibility.PRIVATE, true);
+		return noteRepository.saveAndFlush(note);
+	}
+
+	private void saveCompletedAiIndexAndChunk(
+			Note note,
+			String title,
+			String contentChunk
+	) {
+		LocalDateTime requestedAt = LocalDateTime.of(2026, 5, 28, 10, 0);
+		LocalDateTime indexedAt = requestedAt.plusMinutes(1);
+
+		AiNoteIndex index = AiNoteIndex.pending(
+				note.getId(),
+				note.getAuthor().getId(),
+				requestedAt
+		);
+		index.markCompleted(indexedAt);
+		aiNoteIndexRepository.save(index);
+
+		aiNoteChunkRepository.save(AiNoteChunk.create(
+				note.getId(),
+				note.getAuthor().getId(),
+				0,
+				title,
+				contentChunk,
+				requestedAt,
+				indexedAt
+		));
+
+		entityManager.flush();
+		entityManager.clear();
 	}
 }

--- a/src/test/java/com/keepgoing/keepgoing/ai/controller/AiPanelControllerTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/controller/AiPanelControllerTest.java
@@ -13,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keepgoing.keepgoing.ai.controller.dto.AiPanelMessageRequest;
 import com.keepgoing.keepgoing.ai.service.AiPanelService;
+import com.keepgoing.keepgoing.ai.service.dto.AiCitationSourceType;
+import com.keepgoing.keepgoing.ai.service.dto.AiPanelCitationResult;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageCommand;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageResult;
 import com.keepgoing.keepgoing.global.api.exception.GlobalExceptionHandler;
@@ -72,7 +74,17 @@ class AiPanelControllerTest {
 		void success() throws Exception {
 			Long userId = 1L;
 			AiPanelMessageRequest request = new AiPanelMessageRequest(10L, "요약해줘");
-			AiPanelMessageResult result = new AiPanelMessageResult("정리된 응답", 10L, true);
+			AiPanelMessageResult result = new AiPanelMessageResult(
+					"정리된 응답",
+					10L,
+					true,
+					List.of(new AiPanelCitationResult(
+							10L,
+							"회의록",
+							"회의 내용",
+							AiCitationSourceType.CONTEXT_NOTE
+					))
+			);
 
 			SecurityContextHolder.getContext()
 					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
@@ -87,7 +99,11 @@ class AiPanelControllerTest {
 					.andExpect(jsonPath("$.success").value(true))
 					.andExpect(jsonPath("$.data.assistantMessage").value("정리된 응답"))
 					.andExpect(jsonPath("$.data.contextNoteId").value(10L))
-					.andExpect(jsonPath("$.data.contextAttached").value(true));
+					.andExpect(jsonPath("$.data.contextAttached").value(true))
+					.andExpect(jsonPath("$.data.citations[0].noteId").value(10L))
+					.andExpect(jsonPath("$.data.citations[0].title").value("회의록"))
+					.andExpect(jsonPath("$.data.citations[0].excerpt").value("회의 내용"))
+					.andExpect(jsonPath("$.data.citations[0].sourceType").value("CONTEXT_NOTE"));
 
 			ArgumentCaptor<AiPanelMessageCommand> captor = ArgumentCaptor.forClass(AiPanelMessageCommand.class);
 			verify(aiPanelService).sendMessage(eq(userId), captor.capture());
@@ -100,7 +116,7 @@ class AiPanelControllerTest {
 		void successWithoutContextNoteId() throws Exception {
 			Long userId = 1L;
 			AiPanelMessageRequest request = new AiPanelMessageRequest(null, "그냥 답해줘");
-			AiPanelMessageResult result = new AiPanelMessageResult("일반 응답", null, false);
+			AiPanelMessageResult result = new AiPanelMessageResult("일반 응답", null, false, List.of());
 
 			SecurityContextHolder.getContext()
 					.setAuthentication(new UsernamePasswordAuthenticationToken(userId, null, List.of()));
@@ -115,7 +131,8 @@ class AiPanelControllerTest {
 					.andExpect(jsonPath("$.success").value(true))
 					.andExpect(jsonPath("$.data.assistantMessage").value("일반 응답"))
 					.andExpect(jsonPath("$.data.contextNoteId").doesNotHaveJsonPath())
-					.andExpect(jsonPath("$.data.contextAttached").value(false));
+					.andExpect(jsonPath("$.data.contextAttached").value(false))
+					.andExpect(jsonPath("$.data.citations").isEmpty());
 
 			ArgumentCaptor<AiPanelMessageCommand> captor = ArgumentCaptor.forClass(AiPanelMessageCommand.class);
 			verify(aiPanelService).sendMessage(eq(userId), captor.capture());

--- a/src/test/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepositoryTest.java
@@ -1,0 +1,341 @@
+package com.keepgoing.keepgoing.ai.repository;
+
+import com.keepgoing.keepgoing.ai.domain.AiNoteChunk;
+import com.keepgoing.keepgoing.ai.domain.AiNoteIndex;
+import com.keepgoing.keepgoing.ai.domain.AiNoteIndexStatus;
+import com.keepgoing.keepgoing.global.config.JpaAuditingConfig;
+import com.keepgoing.keepgoing.note.domain.Note;
+import com.keepgoing.keepgoing.note.domain.NoteVisibility;
+import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.user.domain.User;
+import com.keepgoing.keepgoing.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class AiNoteChunkRepositoryTest {
+
+	private static final LocalDateTime REQUESTED_AT = LocalDateTime.of(2026, 5, 28, 10, 0);
+	private static final LocalDateTime INDEXED_AT = LocalDateTime.of(2026, 5, 28, 10, 5);
+	private static final int DEFAULT_LIMIT = 20;
+
+	@Autowired
+	AiNoteChunkRepository aiNoteChunkRepository;
+
+	@Autowired
+	AiNoteIndexRepository aiNoteIndexRepository;
+
+	@Autowired
+	NoteRepository noteRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	EntityManager entityManager;
+
+	User user;
+	User otherUser;
+
+	@BeforeEach
+	void setUp() {
+		user = userRepository.save(User.create("user@test.com", "사용자"));
+		otherUser = userRepository.save(User.create("other@test.com", "다른 사용자"));
+	}
+
+	@Test
+	@DisplayName("내 note + COMPLETED + aiCollectable=true + not deleted면 검색된다")
+	void searchRelevantChunksReturnsCollectableCompletedOwnNote() {
+		// given
+		Note note = saveIndexedNote(
+				user,
+				"배포 회의",
+				"금요일 배포 결정",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results)
+				.extracting(AiNoteRetrievalView::getNoteId)
+				.containsExactly(note.getId());
+		assertThat(results.get(0).getTitle()).isEqualTo("배포 회의");
+		assertThat(results.get(0).getExcerpt()).contains("금요일 배포 결정");
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 note는 검색 결과에서 제외된다")
+	void excludesOtherUsersNote() {
+		// given
+		saveIndexedNote(
+				otherUser,
+				"배포 회의",
+				"다른 사용자 배포 내용",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	@DisplayName("aiCollectable=false note는 검색 결과에서 제외된다")
+	void excludesNotCollectableNote() {
+		// given
+		saveIndexedNote(
+				user,
+				"배포 회의",
+				"비수집 배포 내용",
+				false,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	@DisplayName("COMPLETED 상태가 아닌 index는 검색 결과에서 제외된다")
+	void excludesNonCompletedIndex() {
+		// given
+		saveIndexedNote(
+				user,
+				"배포 회의",
+				"PENDING 상태 배포 내용",
+				true,
+				AiNoteIndexStatus.PENDING,
+				false,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	@DisplayName("삭제된 note는 검색 결과에서 제외된다")
+	void excludesDeletedNote() {
+		// given
+		saveIndexedNote(
+				user,
+				"배포 회의",
+				"삭제된 배포 내용",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				true,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	@DisplayName("excludeNoteId로 전달한 note는 검색 결과에서 제외된다")
+	void excludesContextNoteId() {
+		// given
+		Note contextNote = saveIndexedNote(
+				user,
+				"배포 회의",
+				"context note 배포 내용",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT
+		);
+		Note anotherNote = saveIndexedNote(
+				user,
+				"배포 체크리스트",
+				"다른 note 배포 내용",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT.minusMinutes(1)
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				contextNote.getId(),
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results)
+				.extracting(AiNoteRetrievalView::getNoteId)
+				.containsExactly(anotherNote.getId());
+	}
+
+	@Test
+	@DisplayName("title match가 content match보다 먼저 정렬된다")
+	void sortsTitleMatchBeforeContentMatch() {
+		// given
+		Note contentMatchNote = saveIndexedNote(
+				user,
+				"회의록",
+				"본문에 배포 키워드가 있는 노트",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT.plusMinutes(10)
+		);
+		Note titleMatchNote = saveIndexedNote(
+				user,
+				"배포 계획",
+				"본문에는 다른 내용",
+				true,
+				AiNoteIndexStatus.COMPLETED,
+				false,
+				INDEXED_AT
+		);
+
+		flushAndClear();
+
+		// when
+		List<AiNoteRetrievalView> results = aiNoteChunkRepository.searchRelevantChunks(
+				user.getId(),
+				"배포",
+				null,
+				DEFAULT_LIMIT
+		);
+
+		// then
+		assertThat(results)
+				.extracting(AiNoteRetrievalView::getNoteId)
+				.containsExactly(titleMatchNote.getId(), contentMatchNote.getId());
+	}
+
+	private Note saveIndexedNote(
+			User author,
+			String title,
+			String contentChunk,
+			boolean aiCollectable,
+			AiNoteIndexStatus status,
+			boolean deleted,
+			LocalDateTime indexedAt
+	) {
+		Note note = noteRepository.save(Note.create(
+				author,
+				null,
+				title,
+				contentChunk,
+				NoteVisibility.PRIVATE,
+				aiCollectable
+		));
+
+		if (deleted) {
+			note.softDelete();
+		}
+
+		AiNoteIndex index = AiNoteIndex.pending(note.getId(), author.getId(), REQUESTED_AT);
+		applyStatus(index, status, indexedAt);
+		aiNoteIndexRepository.save(index);
+
+		aiNoteChunkRepository.save(AiNoteChunk.create(
+				note.getId(),
+				author.getId(),
+				0,
+				title,
+				contentChunk,
+				REQUESTED_AT,
+				indexedAt
+		));
+
+		return note;
+	}
+
+	private void applyStatus(
+			AiNoteIndex index,
+			AiNoteIndexStatus status,
+			LocalDateTime processedAt
+	) {
+		if (status == AiNoteIndexStatus.COMPLETED) {
+			index.markCompleted(processedAt);
+			return;
+		}
+
+		if (status == AiNoteIndexStatus.FAILED) {
+			index.markFailed(processedAt, "indexing failed");
+			return;
+		}
+
+		if (status == AiNoteIndexStatus.REMOVED) {
+			index.markRemoved(processedAt);
+		}
+	}
+
+	private void flushAndClear() {
+		entityManager.flush();
+		entityManager.clear();
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepositoryTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/repository/AiNoteChunkRepositoryTest.java
@@ -307,7 +307,7 @@ class AiNoteChunkRepositoryTest {
 				0,
 				title,
 				contentChunk,
-				REQUESTED_AT,
+				note.getUpdatedAt(),
 				indexedAt
 		));
 

--- a/src/test/java/com/keepgoing/keepgoing/ai/service/AiNoteRetrievalServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/service/AiNoteRetrievalServiceTest.java
@@ -1,0 +1,122 @@
+package com.keepgoing.keepgoing.ai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.keepgoing.keepgoing.ai.repository.AiNoteChunkRepository;
+import com.keepgoing.keepgoing.ai.repository.AiNoteRetrievalView;
+import com.keepgoing.keepgoing.ai.service.dto.AiNoteRetrievalResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiNoteRetrievalServiceTest {
+
+	@Mock
+	AiNoteChunkRepository aiNoteChunkRepository;
+
+	@InjectMocks
+	AiNoteRetrievalService aiNoteRetrievalService;
+
+	@Test
+	@DisplayName("메시지가 null 또는 blank면 검색하지 않고 빈 결과를 반환한다")
+	void returnsEmptyWhenMessageIsBlank() {
+		assertThat(aiNoteRetrievalService.retrieve(1L, null, null)).isEmpty();
+		assertThat(aiNoteRetrievalService.retrieve(1L, "   ", null)).isEmpty();
+
+		verify(aiNoteChunkRepository, never()).searchRelevantChunks(any(), any(), any(), any(Integer.class));
+	}
+
+	@Test
+	@DisplayName("후보 chunk를 noteId 기준으로 중복 제거하고 정렬 순서를 유지한다")
+	void deduplicatesCandidatesByNoteId() {
+		// given
+		Long userId = 1L;
+		Long contextNoteId = 10L;
+		given(aiNoteChunkRepository.searchRelevantChunks(userId, "배포", contextNoteId, 20))
+				.willReturn(List.of(
+						view(1L, "첫 번째 노트", "첫 번째 chunk"),
+						view(1L, "첫 번째 노트", "같은 노트의 두 번째 chunk"),
+						view(2L, "두 번째 노트", "두 번째 노트 chunk")
+				));
+
+		// when
+		List<AiNoteRetrievalResult> results = aiNoteRetrievalService.retrieve(userId, "  배포  ", contextNoteId);
+
+		// then
+		assertThat(results)
+				.extracting(AiNoteRetrievalResult::noteId)
+				.containsExactly(1L, 2L);
+		assertThat(results.get(0).excerpt()).isEqualTo("첫 번째 chunk");
+		verify(aiNoteChunkRepository).searchRelevantChunks(userId, "배포", contextNoteId, 20);
+	}
+
+	@Test
+	@DisplayName("최종 retrieval 결과는 최대 5개까지만 반환한다")
+	void limitsFinalResultsToFiveNotes() {
+		// given
+		Long userId = 1L;
+		List<AiNoteRetrievalView> candidates = new ArrayList<>();
+		for (long noteId = 1; noteId <= 7; noteId++) {
+			candidates.add(view(noteId, "노트 " + noteId, "내용 " + noteId));
+		}
+
+		given(aiNoteChunkRepository.searchRelevantChunks(userId, "검색어", null, 20))
+				.willReturn(candidates);
+
+		// when
+		List<AiNoteRetrievalResult> results = aiNoteRetrievalService.retrieve(userId, "검색어", null);
+
+		// then
+		assertThat(results)
+				.hasSize(5)
+				.extracting(AiNoteRetrievalResult::noteId)
+				.containsExactly(1L, 2L, 3L, 4L, 5L);
+	}
+
+	@Test
+	@DisplayName("excerpt가 길면 citation에 사용할 수 있도록 잘라서 반환한다")
+	void truncatesLongExcerpt() {
+		// given
+		String longExcerpt = "a".repeat(501);
+		given(aiNoteChunkRepository.searchRelevantChunks(1L, "검색어", null, 20))
+				.willReturn(List.of(view(1L, "긴 노트", longExcerpt)));
+
+		// when
+		List<AiNoteRetrievalResult> results = aiNoteRetrievalService.retrieve(1L, "검색어", null);
+
+		// then
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).excerpt())
+				.hasSize(515)
+				.endsWith("\n...(truncated)");
+	}
+
+	private AiNoteRetrievalView view(Long noteId, String title, String excerpt) {
+		return new AiNoteRetrievalView() {
+			@Override
+			public Long getNoteId() {
+				return noteId;
+			}
+
+			@Override
+			public String getTitle() {
+				return title;
+			}
+
+			@Override
+			public String getExcerpt() {
+				return excerpt;
+			}
+		};
+	}
+}

--- a/src/test/java/com/keepgoing/keepgoing/ai/service/AiPanelServiceTest.java
+++ b/src/test/java/com/keepgoing/keepgoing/ai/service/AiPanelServiceTest.java
@@ -2,12 +2,16 @@ package com.keepgoing.keepgoing.ai.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.keepgoing.keepgoing.ai.service.dto.AiCitationSourceType;
+import com.keepgoing.keepgoing.ai.service.dto.AiNoteRetrievalResult;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageCommand;
 import com.keepgoing.keepgoing.ai.service.dto.AiPanelMessageResult;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
@@ -15,6 +19,7 @@ import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.service.NoteService;
 import com.keepgoing.keepgoing.note.service.dto.NoteDetailResult;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +48,9 @@ class AiPanelServiceTest {
 	@Mock
 	NoteService noteService;
 
+	@Mock
+	AiNoteRetrievalService aiNoteRetrievalService;
+
 	@InjectMocks
 	AiPanelService aiPanelService;
 
@@ -51,6 +59,7 @@ class AiPanelServiceTest {
 		lenient().when(aiPanelChatClient.prompt()).thenReturn(chatClientRequestSpec);
 		lenient().when(chatClientRequestSpec.user(anyString())).thenReturn(chatClientRequestSpec);
 		lenient().when(chatClientRequestSpec.call()).thenReturn(callResponseSpec);
+		lenient().when(aiNoteRetrievalService.retrieve(any(), anyString(), any())).thenReturn(List.of());
 	}
 
 	@Test
@@ -66,10 +75,14 @@ class AiPanelServiceTest {
 		verify(chatClientRequestSpec).user(promptCaptor.capture());
 		assertThat(promptCaptor.getValue())
 				.contains("요약해줘")
-				.doesNotContain("회의록");
+				.contains("[답변 규칙]")
+				.doesNotContain("회의록")
+				.doesNotContain("[검색된 관련 노트]");
 		assertThat(result.assistantMessage()).isEqualTo("응답");
 		assertThat(result.contextNoteId()).isNull();
 		assertThat(result.contextAttached()).isFalse();
+		assertThat(result.citations()).isEmpty();
+		verify(aiNoteRetrievalService).retrieve(userId, "요약해줘", null);
 		verifyNoInteractions(noteService);
 	}
 
@@ -104,7 +117,12 @@ class AiPanelServiceTest {
 		assertThat(result.assistantMessage()).isEqualTo("AI 응답");
 		assertThat(result.contextNoteId()).isEqualTo(noteId);
 		assertThat(result.contextAttached()).isTrue();
+		assertThat(result.citations()).hasSize(1);
+		assertThat(result.citations().get(0).noteId()).isEqualTo(noteId);
+		assertThat(result.citations().get(0).title()).isEqualTo("회의록");
+		assertThat(result.citations().get(0).sourceType()).isEqualTo(AiCitationSourceType.CONTEXT_NOTE);
 		verify(noteService).getNote(userId, noteId);
+		verify(aiNoteRetrievalService).retrieve(userId, "이 노트를 요약해줘", noteId);
 	}
 
 	@Test
@@ -173,6 +191,79 @@ class AiPanelServiceTest {
 		assertThat(result.assistantMessage()).isEqualTo("응답");
 		assertThat(result.contextNoteId()).isEqualTo(noteId);
 		assertThat(result.contextAttached()).isTrue();
+		assertThat(result.citations()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("검색된 관련 노트가 있으면 프롬프트와 citation에 포함한다")
+	void includesRetrievedNotesInPromptAndCitations() {
+		// given
+		Long userId = 1L;
+		AiPanelMessageCommand command = new AiPanelMessageCommand(null, "배포 일정 알려줘");
+		given(aiNoteRetrievalService.retrieve(userId, "배포 일정 알려줘", null))
+				.willReturn(List.of(
+						new AiNoteRetrievalResult(20L, "배포 회의", "금요일에 배포하기로 했다"),
+						new AiNoteRetrievalResult(21L, "QA 메모", "목요일까지 QA를 완료한다")
+				));
+		given(callResponseSpec.content()).willReturn("검색 기반 응답");
+
+		// when
+		AiPanelMessageResult result = aiPanelService.sendMessage(userId, command);
+
+		// then
+		ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+		verify(chatClientRequestSpec).user(promptCaptor.capture());
+		assertThat(promptCaptor.getValue())
+				.contains("[검색된 관련 노트]")
+				.contains("배포 회의")
+				.contains("금요일에 배포하기로 했다")
+				.contains("QA 메모")
+				.contains("[답변 규칙]")
+				.contains("노트에서 확인되지 않습니다")
+				.contains("배포 일정 알려줘");
+
+		assertThat(result.assistantMessage()).isEqualTo("검색 기반 응답");
+		assertThat(result.contextAttached()).isFalse();
+		assertThat(result.citations())
+				.hasSize(2)
+				.extracting("noteId")
+				.containsExactly(20L, 21L);
+		assertThat(result.citations())
+				.allSatisfy(citation -> assertThat(citation.sourceType()).isEqualTo(AiCitationSourceType.RETRIEVED_NOTE));
+	}
+
+	@Test
+	@DisplayName("현재 노트와 검색 노트가 함께 있으면 context citation을 먼저 반환한다")
+	void returnsContextCitationBeforeRetrievedCitations() {
+		// given
+		Long userId = 1L;
+		Long noteId = 10L;
+		AiPanelMessageCommand command = new AiPanelMessageCommand(noteId, "결정사항 알려줘");
+		NoteDetailResult note = new NoteDetailResult(
+				noteId,
+				null,
+				userId,
+				"현재 노트",
+				"현재 노트 내용",
+				NoteVisibility.PRIVATE,
+				true,
+				null,
+				null
+		);
+		given(noteService.getNote(userId, noteId)).willReturn(note);
+		given(aiNoteRetrievalService.retrieve(userId, "결정사항 알려줘", noteId))
+				.willReturn(List.of(new AiNoteRetrievalResult(20L, "관련 노트", "관련 내용")));
+		given(callResponseSpec.content()).willReturn("응답");
+
+		// when
+		AiPanelMessageResult result = aiPanelService.sendMessage(userId, command);
+
+		// then
+		assertThat(result.citations()).hasSize(2);
+		assertThat(result.citations().get(0).noteId()).isEqualTo(noteId);
+		assertThat(result.citations().get(0).sourceType()).isEqualTo(AiCitationSourceType.CONTEXT_NOTE);
+		assertThat(result.citations().get(1).noteId()).isEqualTo(20L);
+		assertThat(result.citations().get(1).sourceType()).isEqualTo(AiCitationSourceType.RETRIEVED_NOTE);
 	}
 
 	@Test
@@ -187,6 +278,7 @@ class AiPanelServiceTest {
 		assertThatThrownBy(() -> aiPanelService.sendMessage(userId, command))
 				.isSameAs(exception);
 		verify(noteService).getNote(userId, noteId);
+		verifyNoMoreInteractions(aiNoteRetrievalService);
 		verifyNoInteractions(aiPanelChatClient);
 	}
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - 기능 추가

  ### 📌 관련 이슈
  - #103

  ### ✨ 반영 브랜치
  feat/103-ai-panel-retrieval-citation -> feat/102-ai-note-indexing

  ### 📝 변경 사항
  - [x] 인덱싱된 AI note chunk를 사용자 메시지 기반으로 조회하는 retrieval 로직을 추가했습니다.
  - [x] retrieval 대상에서 권한 없는 note, 삭제된 note, `aiCollectable=false` note, `COMPLETED` 상태가 아닌 index를
  제외하도록 query 필터를 적용했습니다.
  - [x] 선택한 context note와 retrieved note를 함께 AI 패널 prompt에 주입하도록 `AiPanelService`를 확장했습니다.
  - [x] 근거가 부족할 경우 과장된 답변을 하지 않도록 AI 패널 prompt의 답변 규칙을 보강했습니다.
  - [x] AI 패널 응답에 `citations[]`를 추가하고, 각 citation에 `noteId`, `title`, `excerpt`, `sourceType`을 포함하
  도록 응답 구조를 확장했습니다.
  - [x] 같은 note의 여러 chunk가 retrieval 후보에 포함될 수 있어 service 레벨에서 `noteId` 기준 중복 제거를 적용했
  습니다.
  - [x] retrieval service, repository query, AI 패널 prompt/citation 응답에 대한 테스트를 추가했습니다.

  ### ➕ 추가 메모
  - 이번 PR의 retrieval은 MVP 범위로, embedding/vector search가 아닌 indexed chunk 대상 keyword `LIKE` 검색 기반입
  니다.
  - 검색 품질 고도화는 추후 `pg_trgm`, PostgreSQL FTS, 또는 embedding/vector search 도입으로 확장할 수 있습니다.
  - 같은 note의 여러 chunk는 repository에서 후보로 조회한 뒤, `AiNoteRetrievalService`에서 `noteId` 기준으로 중복
  제거합니다.
  - 이 PR은 #116의 AI note indexing 기반 위에 쌓이는 stack PR입니다. #116 병합 후에는 base를 `develop`으로 변경하거
  나 rebase할 예정입니다.

  ### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
  ```bash
  ./gradlew test --tests 'com.keepgoing.keepgoing.ai.*'