### PR TITLE
[Feature] 노트 이미지 publicId 기반 조회/삭제 API 추가

### DIFF
--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/config/S3Config.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/config/S3Config.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +29,20 @@ public class S3Config {
 						AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())
 				))
 				.forcePathStyle(true)
+				.build();
+	}
+
+	@Bean
+	public S3Presigner s3Presigner() {
+		return S3Presigner.builder()
+				.region(Region.of(properties.region()))
+				.endpointOverride(URI.create(properties.endpoint()))
+				.credentialsProvider(StaticCredentialsProvider.create(
+						AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())
+				))
+				.serviceConfiguration(S3Configuration.builder()
+						.pathStyleAccessEnabled(true)
+						.build())
 				.build();
 	}
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClient.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClient.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepgoing.global.storage;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,14 +10,18 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Service
 @RequiredArgsConstructor
 public class MinioObjectStorageClient implements ObjectStorageClient {
 
 	private final S3Client s3Client;
+	private final S3Presigner s3Presigner;
 	private final StorageProperties properties;
 
 	@Override
@@ -52,6 +57,24 @@ public class MinioObjectStorageClient implements ObjectStorageClient {
 			s3Client.deleteObject(deleteObjectRequest);
 		} catch (S3Exception | SdkClientException e) {
 			throw new ObjectStorageException("MinIO 파일 삭제 실패: " + storageKey, e);
+		}
+	}
+
+	@Override
+	public String generatePresignedUrl(String bucketName, String key, Duration duration) {
+		try {
+			GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+					.bucket(bucketName)
+					.key(key)
+					.build();
+
+			PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(r -> r
+					.signatureDuration(duration)
+					.getObjectRequest(getObjectRequest));
+
+			return presignedRequest.url().toString();
+		} catch (S3Exception | SdkClientException e) {
+			throw new ObjectStorageException("Presigned URL 생성 실패: " + key, e);
 		}
 	}
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClient.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClient.java
@@ -61,6 +61,20 @@ public class MinioObjectStorageClient implements ObjectStorageClient {
 	}
 
 	@Override
+	public void delete(String bucketName, String storageKey) {
+		try {
+			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+					.bucket(bucketName)
+					.key(storageKey)
+					.build();
+
+			s3Client.deleteObject(deleteObjectRequest);
+		} catch (S3Exception | SdkClientException e) {
+			throw new ObjectStorageException("MinIO 파일 삭제 실패: " + storageKey, e);
+		}
+	}
+
+	@Override
 	public String generatePresignedUrl(String bucketName, String key, Duration duration) {
 		try {
 			GetObjectRequest getObjectRequest = GetObjectRequest.builder()

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/ObjectStorageClient.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/ObjectStorageClient.java
@@ -20,6 +20,8 @@ public interface ObjectStorageClient {
 
 	void delete(String storageKey);
 
+	void delete(String bucketName, String storageKey);
+
 	/**
 	 * 지정된 버킷의 객체에 대한 Presigned GET URL을 생성한다.
 	 *

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/ObjectStorageClient.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/storage/ObjectStorageClient.java
@@ -1,5 +1,7 @@
 package com.keepgoing.keepgoing.global.storage;
 
+import java.time.Duration;
+
 public interface ObjectStorageClient {
 
 	/**
@@ -18,4 +20,13 @@ public interface ObjectStorageClient {
 
 	void delete(String storageKey);
 
+	/**
+	 * 지정된 버킷의 객체에 대한 Presigned GET URL을 생성한다.
+	 *
+	 * @param bucketName 버킷 이름
+	 * @param key        객체 키 (storageKey)
+	 * @param duration   URL 만료 시간
+	 * @return Presigned GET URL
+	 */
+	String generatePresignedUrl(String bucketName, String key, Duration duration);
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
@@ -4,6 +4,7 @@ import com.keepgoing.keepgoing.global.api.response.ApiResponse;
 import com.keepgoing.keepgoing.note.controller.dto.request.NoteImageUploadRequest;
 import com.keepgoing.keepgoing.note.controller.dto.response.NoteImageUploadResponse;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,5 +63,17 @@ public class NoteImageController {
 				.location(URI.create(presignedUrl))
 				.cacheControl(CacheControl.noCache())
 				.build();
+	}
+
+	@DeleteMapping("/{noteId}/images/{publicId}")
+	public ResponseEntity<Void> deleteImage(
+			@PathVariable Long noteId,
+			@PathVariable UUID publicId,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteImageDeleteCommand command = new NoteImageDeleteCommand(userId, noteId, publicId);
+		noteImageService.deleteImage(command);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
@@ -4,14 +4,19 @@ import com.keepgoing.keepgoing.global.api.response.ApiResponse;
 import com.keepgoing.keepgoing.note.controller.dto.request.NoteImageUploadRequest;
 import com.keepgoing.keepgoing.note.controller.dto.response.NoteImageUploadResponse;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
+import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,5 +45,21 @@ public class NoteImageController {
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 				.body(ApiResponse.success(NoteImageUploadResponse.from(result)));
+	}
+
+	@GetMapping("/{noteId}/images/{publicId}")
+	public ResponseEntity<Void> redirectToImage(
+			@PathVariable Long noteId,
+			@PathVariable UUID publicId,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteImagePresignQuery query = new NoteImagePresignQuery(userId, noteId, publicId);
+
+		String presignedUrl = noteImageService.getPresignedUrl(query);
+
+		return ResponseEntity.status(HttpStatus.FOUND)
+				.location(URI.create(presignedUrl))
+				.cacheControl(CacheControl.noCache())
+				.build();
 	}
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/repository/NoteImageRepository.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/repository/NoteImageRepository.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepgoing.note.repository;
 import com.keepgoing.keepgoing.note.domain.NoteImage;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,9 @@ public interface NoteImageRepository extends JpaRepository<NoteImage, Long> {
 	int softDeleteByNoteId(@Param("noteId") Long noteId);
 
 	Optional<NoteImage> findByPublicId(UUID publicId);
+
+
+	@EntityGraph(attributePaths = "note")
+	Optional<NoteImage> findByPublicIdAndNote_Id(UUID publicId, Long noteId);
+
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
@@ -14,6 +14,7 @@ import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.event.NoteImageProcessingRequestPublisher;
 import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
@@ -22,6 +23,7 @@ import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,9 +66,19 @@ public class NoteImageService {
 
 	@Transactional
 	public void applyProcessingResult(ImageProcessingResultEvent event) {
-		NoteImage noteImage = noteImageRepository.findByPublicId(event.publicId())
-				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+		Optional<NoteImage> optional = noteImageRepository.findByPublicId(event.publicId());
+		if (optional.isEmpty()) {
+			if (event.status() == ImageProcessingStatus.SAFE && event.secureStorageKey() != null) {
+				objectStorageClient.delete(
+						storageProperties.bucketNames().secure(),
+						event.secureStorageKey()
+				);
+			}
+			log.info("이미지가 삭제되었으므로 스킵: {}", event.publicId());
+			return;
+		}
 
+		NoteImage noteImage = optional.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
 		if (noteImage.getStatus().isTerminal()) {
 			log.info("Skipped processing result for image {}: already {}", event.publicId(), noteImage.getStatus());
 			return;
@@ -104,6 +116,30 @@ public class NoteImageService {
 				noteImage.getStorageKey(),
 				duration
 		);
+	}
+
+	/*
+		Hard delete 진행.
+		이는 사용자가 명시적으로 삭제하기 때문에 Hard delete가 적절하다고 판단.
+	 */
+	@Transactional
+	public void deleteImage(NoteImageDeleteCommand command) {
+		NoteImage noteImage = noteImageRepository.findByPublicIdAndNote_Id(command.publicId(), command.noteId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+
+		noteImage.validateUploader(command.userId());
+
+		switch (noteImage.getStatus()) {
+			case PENDING, SCANNING -> objectStorageClient.delete(
+					storageProperties.bucketNames().quarantine(),
+					noteImage.getStorageKey()
+			);
+			case SAFE -> objectStorageClient.delete(
+					storageProperties.bucketNames().secure(),
+					noteImage.getStorageKey()
+			);
+		}
+		noteImageRepository.delete(noteImage);
 	}
 
 	private void publishProcessingRequest(

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
@@ -1,21 +1,26 @@
 package com.keepgoing.keepgoing.note.service;
 
+import com.keepgoing.keepgoing.common.image.domain.ImageProcessingStatus;
 import com.keepgoing.keepgoing.common.image.event.ImageProcessingRequestedEvent;
 import com.keepgoing.keepgoing.common.image.event.ImageProcessingResultEvent;
 import com.keepgoing.keepgoing.global.common.error.BusinessException;
 import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.global.storage.ObjectStorageClient;
 import com.keepgoing.keepgoing.global.storage.ObjectStorageException;
+import com.keepgoing.keepgoing.global.storage.StorageProperties;
 import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteImage;
+import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.event.NoteImageProcessingRequestPublisher;
 import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +41,7 @@ public class NoteImageService {
 	private final ObjectStorageClient objectStorageClient;
 	private final TransactionTemplate transactionTemplate;
 	private final NoteImageProcessingRequestPublisher requestPublisher;
+	private final StorageProperties storageProperties;
 
 	public NoteImageUploadResult uploadImage(Long uploaderId, NoteImageUploadCommand command) {
 		Long noteId = command.noteId();
@@ -72,6 +78,32 @@ public class NoteImageService {
 			case REJECTED -> noteImage.markRejected();
 			case PENDING -> throw new BusinessException(ErrorCode.INVALID_INPUT);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public String getPresignedUrl(NoteImagePresignQuery query) {
+		Long userId = query.userId();
+		NoteImage noteImage = noteImageRepository.findByPublicIdAndNote_Id(query.publicId(), query.noteId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+		Note note = noteImage.getNote();
+
+		if (!note.isAuthor(userId) && note.getVisibility() != NoteVisibility.PUBLIC) {
+			throw new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+
+		if (noteImage.getStatus() != ImageProcessingStatus.SAFE) {
+			throw new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+
+		Duration duration = note.isAuthor(userId)
+				? Duration.ofMinutes(15)
+				: Duration.ofHours(1);
+
+		return objectStorageClient.generatePresignedUrl(
+				storageProperties.bucketNames().secure(),
+				noteImage.getStorageKey(),
+				duration
+		);
 	}
 
 	private void publishProcessingRequest(

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageDeleteCommand.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageDeleteCommand.java
@@ -1,0 +1,10 @@
+package com.keepgoing.keepgoing.note.service.dto;
+
+import java.util.UUID;
+
+public record NoteImageDeleteCommand(
+		Long userId,
+		Long noteId,
+		UUID publicId
+) {
+}

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImagePresignQuery.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImagePresignQuery.java
@@ -1,0 +1,10 @@
+package com.keepgoing.keepgoing.note.service.dto;
+
+import java.util.UUID;
+
+public record NoteImagePresignQuery(
+		Long userId,
+		Long noteId,
+		UUID publicId
+) {
+}

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientIntegrationTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientIntegrationTest.java
@@ -6,6 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -20,13 +24,17 @@ import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Testcontainers
 class MinioObjectStorageClientIntegrationTest {
@@ -48,6 +56,7 @@ class MinioObjectStorageClientIntegrationTest {
 					.waitingFor(Wait.forHttp("/minio/health/ready").forPort(9000));
 
 	private S3Client s3Client;
+	private S3Presigner s3Presigner;
 	private MinioObjectStorageClient minioClient;
 
 	@BeforeEach
@@ -68,7 +77,17 @@ class MinioObjectStorageClientIntegrationTest {
 				.region(Region.of(REGION))
 				.forcePathStyle(true)
 				.build();
-		minioClient = new MinioObjectStorageClient(s3Client, properties);
+		s3Presigner = S3Presigner.builder()
+				.endpointOverride(URI.create(endpoint))
+				.credentialsProvider(StaticCredentialsProvider.create(
+						AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)
+				))
+				.region(Region.of(REGION))
+				.serviceConfiguration(S3Configuration.builder()
+						.pathStyleAccessEnabled(true)
+						.build())
+				.build();
+		minioClient = new MinioObjectStorageClient(s3Client, s3Presigner, properties);
 
 		createBucketIfAbsent(QUARANTINE_BUCKET);
 		createBucketIfAbsent(SECURE_BUCKET);
@@ -78,6 +97,9 @@ class MinioObjectStorageClientIntegrationTest {
 	void tearDown() {
 		if (s3Client != null) {
 			s3Client.close();
+		}
+		if (s3Presigner != null) {
+			s3Presigner.close();
 		}
 	}
 
@@ -122,6 +144,33 @@ class MinioObjectStorageClientIntegrationTest {
 
 		// then
 		assertThatObjectDoesNotExist(QUARANTINE_BUCKET, savedKey);
+	}
+
+	@Test
+	@DisplayName("실제 MinIO secure 객체에 대한 path-style Presigned URL을 생성하고 조회할 수 있다")
+	void generatePresignedUrlForSecureObject() throws Exception {
+		// given
+		String secureKey = "notes/1/safe-image-key";
+		byte[] content = "safe-image-content".getBytes(StandardCharsets.UTF_8);
+		s3Client.putObject(PutObjectRequest.builder()
+				.bucket(SECURE_BUCKET)
+				.key(secureKey)
+				.contentType("image/png")
+				.build(), RequestBody.fromBytes(content));
+
+		// when
+		String presignedUrl = minioClient.generatePresignedUrl(SECURE_BUCKET, secureKey, Duration.ofMinutes(5));
+		HttpResponse<byte[]> response = HttpClient.newHttpClient().send(
+				HttpRequest.newBuilder(URI.create(presignedUrl)).GET().build(),
+				HttpResponse.BodyHandlers.ofByteArray()
+		);
+
+		// then
+		URI uri = URI.create(presignedUrl);
+		assertThat(uri.getPath()).isEqualTo("/" + SECURE_BUCKET + "/" + secureKey);
+		assertThat(uri.getQuery()).contains("X-Amz-Signature=");
+		assertThat(response.statusCode()).isEqualTo(200);
+		assertThat(response.body()).isEqualTo(content);
 	}
 
 	@Test

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientTest.java
@@ -199,6 +199,25 @@ class MinioObjectStorageClientTest {
 	}
 
 	@Test
+	@DisplayName("버킷을 지정해 파일을 삭제하면 지정한 버킷과 키로 S3Client의 deleteObject를 호출한다")
+	void deleteSuccessfullyFromSpecifiedBucket() {
+		// given
+		String bucketName = "secure-bucket";
+		String storageKey = "notes/1/safe-image-key";
+
+		// when
+		minioClient.delete(bucketName, storageKey);
+
+		// then
+		ArgumentCaptor<DeleteObjectRequest> requestCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(s3Client).deleteObject(requestCaptor.capture());
+
+		DeleteObjectRequest request = requestCaptor.getValue();
+		assertThat(request.bucket()).isEqualTo(bucketName);
+		assertThat(request.key()).isEqualTo(storageKey);
+	}
+
+	@Test
 	@DisplayName("삭제 중 SdkClientException 발생 시 ObjectStorageException으로 래핑하여 던진다")
 	void deleteThrowsExceptionOnFailure() {
 		// given
@@ -223,6 +242,21 @@ class MinioObjectStorageClientTest {
 
 		// when & then
 		assertThatThrownBy(() -> minioClient.delete(storageKey))
+				.isInstanceOf(ObjectStorageException.class)
+				.hasMessageContaining("MinIO 파일 삭제 실패")
+				.hasCauseInstanceOf(S3Exception.class);
+	}
+
+	@Test
+	@DisplayName("버킷 지정 삭제 중 S3Exception 발생 시 ObjectStorageException으로 래핑하여 던진다")
+	void deleteFromSpecifiedBucketThrowsExceptionOnS3Failure() {
+		// given
+		String storageKey = "notes/1/safe-image-key";
+		given(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+				.willThrow(S3Exception.builder().message("delete s3 error").build());
+
+		// when & then
+		assertThatThrownBy(() -> minioClient.delete("secure-bucket", storageKey))
 				.isInstanceOf(ObjectStorageException.class)
 				.hasMessageContaining("MinIO 파일 삭제 실패")
 				.hasCauseInstanceOf(S3Exception.class);

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/global/storage/MinioObjectStorageClientTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,12 +17,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @ExtendWith(MockitoExtension.class)
 class MinioObjectStorageClientTest {
@@ -31,6 +38,9 @@ class MinioObjectStorageClientTest {
 
 	@Mock
 	private S3Client s3Client;
+
+	@Mock
+	private S3Presigner s3Presigner;
 
 	private StorageProperties properties;
 	private MinioObjectStorageClient minioClient;
@@ -44,7 +54,7 @@ class MinioObjectStorageClientTest {
 				"us-east-1",
 				new StorageProperties.BucketNames(QUARANTINE_BUCKET, "secure-bucket")
 		);
-		minioClient = new MinioObjectStorageClient(s3Client, properties);
+		minioClient = new MinioObjectStorageClient(s3Client, s3Presigner, properties);
 	}
 
 	@Test
@@ -141,6 +151,33 @@ class MinioObjectStorageClientTest {
 		// then
 		assertThat(savedKey).startsWith(DIRECTORY + "/");
 		assertThat(savedKey).doesNotContain(".");
+	}
+
+	@Test
+	@DisplayName("Presigned GET URL 생성 시 secure bucket과 path-style key를 포함한다")
+	void generatePresignedUrlUsesPathStyleSecureBucketUrl() {
+		// given
+		String key = "notes/1/safe-image-key";
+		try (S3Presigner realPresigner = S3Presigner.builder()
+				.region(Region.of("us-east-1"))
+				.endpointOverride(URI.create("http://localhost:9000"))
+				.credentialsProvider(StaticCredentialsProvider.create(
+						AwsBasicCredentials.create("access", "secret")
+				))
+				.serviceConfiguration(S3Configuration.builder()
+						.pathStyleAccessEnabled(true)
+						.build())
+				.build()) {
+			MinioObjectStorageClient client = new MinioObjectStorageClient(s3Client, realPresigner, properties);
+
+			// when
+			String presignedUrl = client.generatePresignedUrl("secure-bucket", key, Duration.ofMinutes(5));
+
+			// then
+			assertThat(presignedUrl).startsWith("http://localhost:9000/secure-bucket/notes/1/safe-image-key?");
+			assertThat(presignedUrl).contains("X-Amz-Expires=300");
+			assertThat(presignedUrl).contains("X-Amz-Signature=");
+		}
 	}
 
 	@Test

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/NoteImageIntegrationTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/NoteImageIntegrationTest.java
@@ -7,7 +7,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,6 +30,7 @@ import com.keepgoing.keepgoing.user.domain.User;
 import com.keepgoing.keepgoing.user.domain.UserRole;
 import com.keepgoing.keepgoing.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @Transactional
-class NoteImageUploadIntegrationTest extends PostgreSqlTestContainerSupport {
+class NoteImageIntegrationTest extends PostgreSqlTestContainerSupport {
 
 	private static final String IMAGE_NAME = "image.png";
 	private static final String CONTENT_TYPE = MediaType.IMAGE_PNG_VALUE;
@@ -317,12 +320,129 @@ class NoteImageUploadIntegrationTest extends PostgreSqlTestContainerSupport {
 		}
 	}
 
+	@Nested
+	@DisplayName("GET /api/notes/{noteId}/images/{publicId}")
+	class GetImage {
+
+		@Test
+		@DisplayName("작성자가 PRIVATE SAFE 이미지를 조회하면 secure bucket Presigned URL로 redirect한다")
+		void redirectsAuthorToPrivateSafeImagePresignedUrl() throws Exception {
+			// given
+			User author = saveUser("author-image-read@test.com", "작성자");
+			Note note = saveNote(author, "작성자 private 이미지", NoteVisibility.PRIVATE);
+			String secureStorageKey = "secure/notes/" + note.getId() + "/safe-image-key";
+			NoteImage image = saveSafeNoteImage(note, author, secureStorageKey);
+			String presignedUrl = "https://storage.example.com/test-secure-bucket/" + secureStorageKey;
+			mockLoginUser(author.getId());
+
+			ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+			given(objectStorageClient.generatePresignedUrl(
+					eq("test-secure-bucket"),
+					eq(secureStorageKey),
+					any(Duration.class)
+			)).willReturn(presignedUrl);
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", note.getId(), image.getPublicId()))
+					.andExpect(status().isFound())
+					.andExpect(header().string("Location", presignedUrl));
+
+			then(objectStorageClient).should().generatePresignedUrl(
+					eq("test-secure-bucket"),
+					eq(secureStorageKey),
+					durationCaptor.capture()
+			);
+			assertThat(durationCaptor.getValue()).isEqualTo(Duration.ofMinutes(15));
+		}
+
+		@Test
+		@DisplayName("익명 사용자가 PUBLIC SAFE 이미지를 조회하면 secure bucket Presigned URL로 redirect한다")
+		void redirectsAnonymousToPublicSafeImagePresignedUrl() throws Exception {
+			// given
+			User author = saveUser("public-author@test.com", "공개 작성자");
+			Note note = saveNote(author, "public 이미지", NoteVisibility.PUBLIC);
+			String secureStorageKey = "secure/notes/" + note.getId() + "/public-safe-image-key";
+			NoteImage image = saveSafeNoteImage(note, author, secureStorageKey);
+			String presignedUrl = "https://storage.example.com/test-secure-bucket/" + secureStorageKey;
+
+			ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+			given(objectStorageClient.generatePresignedUrl(
+					eq("test-secure-bucket"),
+					eq(secureStorageKey),
+					any(Duration.class)
+			)).willReturn(presignedUrl);
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", note.getId(), image.getPublicId()))
+					.andExpect(status().isFound())
+					.andExpect(header().string("Location", presignedUrl));
+
+			then(objectStorageClient).should().generatePresignedUrl(
+					eq("test-secure-bucket"),
+					eq(secureStorageKey),
+					durationCaptor.capture()
+			);
+			assertThat(durationCaptor.getValue()).isEqualTo(Duration.ofHours(1));
+		}
+
+		@Test
+		@DisplayName("비작성자가 PRIVATE SAFE 이미지를 조회하면 404를 반환하고 storage URL을 생성하지 않는다")
+		void returnsNotFoundWhenNonAuthorReadsPrivateSafeImage() throws Exception {
+			// given
+			User author = saveUser("private-author@test.com", "작성자");
+			User requester = saveUser("private-requester@test.com", "요청자");
+			Note note = saveNote(author, "타인 private 이미지", NoteVisibility.PRIVATE);
+			String secureStorageKey = "secure/notes/" + note.getId() + "/private-safe-image-key";
+			NoteImage image = saveSafeNoteImage(note, author, secureStorageKey);
+			mockLoginUser(requester.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", note.getId(), image.getPublicId()))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_NOT_FOUND"));
+
+			then(objectStorageClient).should(never()).generatePresignedUrl(any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("작성자라도 SAFE가 아닌 이미지를 조회하면 404를 반환하고 storage URL을 생성하지 않는다")
+		void returnsNotFoundWhenAuthorReadsNonSafeImage() throws Exception {
+			// given
+			User author = saveUser("nonsafe-author@test.com", "작성자");
+			Note note = saveNote(author, "처리 중 이미지", NoteVisibility.PRIVATE);
+			mockLoginUser(author.getId());
+
+			for (ImageProcessingStatus status : List.of(
+					ImageProcessingStatus.PENDING,
+					ImageProcessingStatus.SCANNING,
+					ImageProcessingStatus.REJECTED
+			)) {
+				String storageKey = "notes/" + note.getId() + "/" + status.name().toLowerCase();
+				NoteImage image = saveNoteImage(note, author, storageKey);
+				markStatus(image, status);
+				entityManager.flush();
+				entityManager.clear();
+
+				mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", note.getId(), image.getPublicId()))
+						.andExpect(status().isNotFound())
+						.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_NOT_FOUND"));
+			}
+
+			then(objectStorageClient).should(never()).generatePresignedUrl(any(), any(), any());
+		}
+	}
+
 	private User saveUser(String email, String name) {
 		return userRepository.saveAndFlush(User.create(email, name));
 	}
 
 	private Note saveNote(User author, String title) {
-		Note note = Note.create(author, null, title, "본문", NoteVisibility.PRIVATE, false);
+		return saveNote(author, title, NoteVisibility.PRIVATE);
+	}
+
+	private Note saveNote(User author, String title, NoteVisibility visibility) {
+		Note note = Note.create(author, null, title, "본문", visibility, false);
 		return noteRepository.saveAndFlush(note);
 	}
 
@@ -336,6 +456,23 @@ class NoteImageUploadIntegrationTest extends PostgreSqlTestContainerSupport {
 				(long) IMAGE_CONTENT.length
 		);
 		return noteImageRepository.saveAndFlush(noteImage);
+	}
+
+
+	private NoteImage saveSafeNoteImage(Note note, User uploader, String secureStorageKey) {
+		NoteImage noteImage = saveNoteImage(note, uploader, "notes/" + note.getId() + "/quarantine-image-key");
+		noteImage.markSafe(secureStorageKey, CONTENT_TYPE, (long) IMAGE_CONTENT.length);
+		return noteImageRepository.saveAndFlush(noteImage);
+	}
+
+	private void markStatus(NoteImage image, ImageProcessingStatus status) {
+		switch (status) {
+			case PENDING -> {
+			}
+			case SCANNING -> image.markScanning();
+			case REJECTED -> image.markRejected();
+			case SAFE -> image.markSafe(image.getStorageKey(), CONTENT_TYPE, (long) IMAGE_CONTENT.length);
+		}
 	}
 
 	private MockMultipartFile imageFile() {

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
@@ -7,7 +7,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,6 +21,7 @@ import com.keepgoing.keepgoing.global.config.JacksonConfig;
 import com.keepgoing.keepgoing.global.security.cookie.CookieConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
+import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import java.util.List;
@@ -271,6 +274,67 @@ class NoteImageControllerTest {
 					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_ACCESS_DENIED.name()));
 
 			then(noteImageService).should().uploadImage(eq(userId), any(NoteImageUploadCommand.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /api/notes/{noteId}/images/{publicId}")
+	class RedirectToImageTest {
+
+		@Test
+		@DisplayName("PUBLIC SAFE 이미지 조회 시 302 Found로 Presigned URL로 redirect한다")
+		void redirectsToPresignedUrl() throws Exception {
+			// given
+			UUID publicId = UUID.randomUUID();
+			String presignedUrl = "https://minio/secure/key?X-Amz-Signature=abc";
+			given(noteImageService.getPresignedUrl(any(NoteImagePresignQuery.class)))
+					.willReturn(presignedUrl);
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", 1L, publicId))
+					.andExpect(status().isFound())
+					.andExpect(header().string("Location", presignedUrl))
+					.andExpect(header().string(
+							"Cache-Control",
+							org.hamcrest.Matchers.containsString("no-cache"))
+					);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이미지 조회 시 404를 반환한다")
+		void returns404WhenImageNotFound() throws Exception {
+			// given
+			UUID publicId = UUID.randomUUID();
+			given(noteImageService.getPresignedUrl(any(NoteImagePresignQuery.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", 1L, publicId))
+					.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("익명 사용자가 PUBLIC SAFE 이미지를 조회하면 302로 redirect한다")
+		void redirectsAnonymousUserForPublicImage() throws Exception {
+			UUID publicId = UUID.randomUUID();
+			given(noteImageService.getPresignedUrl(any(NoteImagePresignQuery.class)))
+					.willReturn("https://minio/secure/key?X-Amz-Signature=abc");
+
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", 1L, publicId))
+					.andExpect(status().isFound())
+					.andExpect(header().exists("Location"));
+		}
+
+		// #6: 잘못된 noteId → 404
+		@Test
+		@DisplayName("유효한 publicId + 잘못된 noteId로 조회하면 404를 반환한다")
+		void returns404WhenNoteIdMismatch() throws Exception {
+			UUID publicId = UUID.randomUUID();
+			given(noteImageService.getPresignedUrl(any(NoteImagePresignQuery.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", 999L, publicId))
+					.andExpect(status().isNotFound());
 		}
 	}
 

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -21,6 +22,7 @@ import com.keepgoing.keepgoing.global.config.JacksonConfig;
 import com.keepgoing.keepgoing.global.security.cookie.CookieConfig;
 import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
@@ -335,6 +337,72 @@ class NoteImageControllerTest {
 
 			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}", 999L, publicId))
 					.andExpect(status().isNotFound());
+		}
+	}
+
+	@Nested
+	@DisplayName("DELETE /api/notes/{noteId}/images/{publicId}")
+	class DeleteImageTest {
+
+		@Test
+		@DisplayName("인증 사용자가 이미지 삭제를 요청하면 204를 반환하고 삭제 커맨드를 전달한다")
+		void deletesImageSuccessfully() throws Exception {
+			// given
+			Long userId = 1L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(delete("/api/notes/{noteId}/images/{publicId}", noteId, publicId))
+					.andExpect(status().isNoContent());
+
+			ArgumentCaptor<NoteImageDeleteCommand> captor =
+					ArgumentCaptor.forClass(NoteImageDeleteCommand.class);
+			then(noteImageService).should().deleteImage(captor.capture());
+
+			NoteImageDeleteCommand command = captor.getValue();
+			assertThat(command.userId()).isEqualTo(userId);
+			assertThat(command.noteId()).isEqualTo(noteId);
+			assertThat(command.publicId()).isEqualTo(publicId);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이미지 삭제 요청이면 404를 반환한다")
+		void returns404WhenImageNotFound() throws Exception {
+			// given
+			Long userId = 1L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			mockLoginUser(userId);
+			willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND))
+					.given(noteImageService)
+					.deleteImage(any(NoteImageDeleteCommand.class));
+
+			// when & then
+			mockMvc.perform(delete("/api/notes/{noteId}/images/{publicId}", noteId, publicId))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_IMAGE_NOT_FOUND.name()));
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 이미지 삭제를 요청하면 403을 반환한다")
+		void returns403WhenRequesterIsNotUploader() throws Exception {
+			// given
+			Long userId = 2L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			mockLoginUser(userId);
+			willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_ACCESS_DENIED))
+					.given(noteImageService)
+					.deleteImage(any(NoteImageDeleteCommand.class));
+
+			// when & then
+			mockMvc.perform(delete("/api/notes/{noteId}/images/{publicId}", noteId, publicId))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_IMAGE_ACCESS_DENIED.name()));
 		}
 	}
 

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
@@ -33,6 +33,7 @@ import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.event.NoteImageProcessingRequestPublisher;
 import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
@@ -378,19 +379,37 @@ class NoteImageServiceTest {
 		}
 
 		@Test
-		@DisplayName("존재하지 않는 이미지 처리 결과면 NOTE_IMAGE_NOT_FOUND 예외를 던진다")
-		void throwsWhenImageNotFound() {
+		@DisplayName("삭제된 이미지의 SAFE 결과가 늦게 도착하면 secure 객체를 정리하고 결과 반영을 건너뛴다")
+		void cleansUpSecureObjectWhenSafeResultArrivesAfterImageDeletion() {
 			// given
 			UUID publicId = UUID.randomUUID();
 			ImageProcessingResultEvent event = processingResultEvent(publicId, ImageProcessingStatus.SAFE);
 			given(noteImageRepository.findByPublicId(publicId)).willReturn(Optional.empty());
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.secure()).willReturn("secure-bucket");
 
-			// when & then
-			assertThatThrownBy(() -> noteImageService.applyProcessingResult(event))
-					.isInstanceOf(BusinessException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+			// when
+			noteImageService.applyProcessingResult(event);
 
+			// then
 			verify(noteImageRepository).findByPublicId(publicId);
+			verify(objectStorageClient).delete("secure-bucket", event.secureStorageKey());
+		}
+
+		@Test
+		@DisplayName("삭제된 이미지의 SAFE 외 결과가 늦게 도착하면 스토리지 정리 없이 결과 반영을 건너뛴다")
+		void skipsNonSafeResultWhenImageWasDeleted() {
+			// given
+			UUID publicId = UUID.randomUUID();
+			ImageProcessingResultEvent event = processingResultEvent(publicId, ImageProcessingStatus.SCANNING);
+			given(noteImageRepository.findByPublicId(publicId)).willReturn(Optional.empty());
+
+			// when
+			noteImageService.applyProcessingResult(event);
+
+			// then
+			verify(noteImageRepository).findByPublicId(publicId);
+			verifyNoInteractions(objectStorageClient, storageProperties);
 		}
 
 		@Test
@@ -484,6 +503,129 @@ class NoteImageServiceTest {
 			// then
 			assertThat(noteImage.getStatus()).isEqualTo(ImageProcessingStatus.REJECTED);
 			verify(noteImageRepository).findByPublicId(noteImage.getPublicId());
+		}
+	}
+
+	@Nested
+	@DisplayName("deleteImage")
+	class DeleteImageTest {
+
+		@Test
+		@DisplayName("PENDING 이미지를 삭제하면 quarantine 객체를 삭제하고 이미지 레코드를 hard delete한다")
+		void deletesPendingImageFromQuarantineBucket() {
+			// given
+			NoteImage noteImage = noteImageWithStatus(ImageProcessingStatus.PENDING);
+			NoteImageDeleteCommand command =
+					new NoteImageDeleteCommand(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.quarantine()).willReturn("quarantine-bucket");
+
+			// when
+			noteImageService.deleteImage(command);
+
+			// then
+			InOrder inOrder = inOrder(noteImageRepository, objectStorageClient);
+			inOrder.verify(noteImageRepository).findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID);
+			inOrder.verify(objectStorageClient).delete("quarantine-bucket", STORAGE_KEY);
+			inOrder.verify(noteImageRepository).delete(noteImage);
+			verify(bucketNames, never()).secure();
+		}
+
+		@Test
+		@DisplayName("SCANNING 이미지를 삭제하면 quarantine 객체를 삭제하고 이미지 레코드를 hard delete한다")
+		void deletesScanningImageFromQuarantineBucket() {
+			// given
+			NoteImage noteImage = noteImageWithStatus(ImageProcessingStatus.SCANNING);
+			NoteImageDeleteCommand command =
+					new NoteImageDeleteCommand(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.quarantine()).willReturn("quarantine-bucket");
+
+			// when
+			noteImageService.deleteImage(command);
+
+			// then
+			verify(objectStorageClient).delete("quarantine-bucket", STORAGE_KEY);
+			verify(noteImageRepository).delete(noteImage);
+			verify(bucketNames, never()).secure();
+		}
+
+		@Test
+		@DisplayName("SAFE 이미지를 삭제하면 secure 객체를 삭제하고 이미지 레코드를 hard delete한다")
+		void deletesSafeImageFromSecureBucket() {
+			// given
+			NoteImage noteImage = noteImageWithStatus(ImageProcessingStatus.SAFE);
+			NoteImageDeleteCommand command =
+					new NoteImageDeleteCommand(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.secure()).willReturn("secure-bucket");
+
+			// when
+			noteImageService.deleteImage(command);
+
+			// then
+			verify(objectStorageClient).delete("secure-bucket", STORAGE_KEY);
+			verify(noteImageRepository).delete(noteImage);
+			verify(bucketNames, never()).quarantine();
+		}
+
+		@Test
+		@DisplayName("REJECTED 이미지를 삭제하면 스토리지 삭제 없이 이미지 레코드만 hard delete한다")
+		void deletesRejectedImageWithoutStorageCleanup() {
+			// given
+			NoteImage noteImage = noteImageWithStatus(ImageProcessingStatus.REJECTED);
+			NoteImageDeleteCommand command =
+					new NoteImageDeleteCommand(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+
+			// when
+			noteImageService.deleteImage(command);
+
+			// then
+			verify(noteImageRepository).delete(noteImage);
+			verifyNoInteractions(objectStorageClient, storageProperties);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이미지를 삭제하면 NOTE_IMAGE_NOT_FOUND 예외를 던진다")
+		void throwsWhenImageNotFound() {
+			// given
+			UUID publicId = UUID.randomUUID();
+			NoteImageDeleteCommand command = new NoteImageDeleteCommand(UPLOADER_ID, NOTE_ID, publicId);
+			given(noteImageRepository.findByPublicIdAndNote_Id(publicId, NOTE_ID))
+					.willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.deleteImage(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+
+			verifyNoInteractions(objectStorageClient, storageProperties);
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 이미지를 삭제하면 NOTE_IMAGE_ACCESS_DENIED 예외를 던진다")
+		void throwsWhenRequesterIsNotUploader() {
+			// given
+			NoteImage noteImage = noteImageWithStatus(ImageProcessingStatus.PENDING);
+			NoteImageDeleteCommand command =
+					new NoteImageDeleteCommand(2L, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.deleteImage(command))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_ACCESS_DENIED);
+
+			verifyNoInteractions(objectStorageClient, storageProperties);
 		}
 	}
 

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
@@ -26,12 +26,14 @@ import com.keepgoing.keepgoing.global.common.error.ErrorCode;
 import com.keepgoing.keepgoing.global.storage.InputStreamSupplier;
 import com.keepgoing.keepgoing.global.storage.ObjectStorageClient;
 import com.keepgoing.keepgoing.global.storage.ObjectStorageException;
+import com.keepgoing.keepgoing.global.storage.StorageProperties;
 import com.keepgoing.keepgoing.note.domain.Note;
 import com.keepgoing.keepgoing.note.domain.NoteImage;
 import com.keepgoing.keepgoing.note.domain.NoteVisibility;
 import com.keepgoing.keepgoing.note.event.NoteImageProcessingRequestPublisher;
 import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
+import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -39,6 +41,7 @@ import com.keepgoing.keepgoing.user.repository.UserRepository;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,8 +50,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.InOrder;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -90,6 +93,12 @@ class NoteImageServiceTest {
 
 	@InjectMocks
 	NoteImageService noteImageService;
+
+	@Mock
+	StorageProperties storageProperties;
+
+	@Mock
+	StorageProperties.BucketNames bucketNames;
 
 	@Nested
 	@DisplayName("uploadImage")
@@ -478,6 +487,127 @@ class NoteImageServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("getPresignedUrl")
+	class GetPresignedUrlTest {
+
+		@Test
+		@DisplayName("작성자가 PRIVATE SAFE 이미지를 조회하면 Presigned URL을 반환한다")
+		void returnsPresignedUrlForAuthor() {
+			// given
+			Note note = persistedNote(user(UPLOADER_ID));
+			NoteImage noteImage = noteImageWithStatus(note, ImageProcessingStatus.SAFE);
+			String expectedUrl = "https://minio/secure/key?X-Amz-Signature=abc";
+			NoteImagePresignQuery query = new NoteImagePresignQuery(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.secure()).willReturn("secure-bucket");
+			given(objectStorageClient.generatePresignedUrl(
+					eq("secure-bucket"),
+					eq(noteImage.getStorageKey()),
+					any(Duration.class)
+			)).willReturn(expectedUrl);
+
+			// when
+			String result = noteImageService.getPresignedUrl(query);
+
+			// then
+			assertThat(result).isEqualTo(expectedUrl);
+			verify(noteImageRepository).findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID);
+			verify(objectStorageClient).generatePresignedUrl(
+					eq("secure-bucket"),
+					eq(noteImage.getStorageKey()),
+					any(Duration.class)
+			);
+		}
+
+		@Test
+		@DisplayName("익명 사용자가 PUBLIC SAFE 이미지를 조회하면 Presigned URL을 반환한다")
+		void returnsPresignedUrlForAnonymousPublic() {
+			// given
+			Note note = persistedNote(user(2L), NoteVisibility.PUBLIC);
+			NoteImage noteImage = noteImageWithStatus(note, ImageProcessingStatus.SAFE);
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+			given(storageProperties.bucketNames()).willReturn(bucketNames);
+			given(bucketNames.secure()).willReturn("secure-bucket");
+			given(objectStorageClient.generatePresignedUrl(any(), any(), any()))
+					.willReturn("url");
+
+			// when
+			String result = noteImageService.getPresignedUrl(
+					new NoteImagePresignQuery(null, NOTE_ID, noteImage.getPublicId())
+			);
+
+			// then
+			assertThat(result).isEqualTo("url");
+		}
+
+		@Test
+		@DisplayName("비작성자가 PRIVATE 이미지를 조회하면 404를 반환한다")
+		void throws404WhenNonAuthorAccessesPrivate() {
+			// given
+			Note note = persistedNote(user(2L));  // UPLOADER_ID(1L)가 아님
+			NoteImage noteImage = noteImageWithStatus(note, ImageProcessingStatus.SAFE);
+			NoteImagePresignQuery query = new NoteImagePresignQuery(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.getPresignedUrl(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("PENDING 이미지를 조회하면 404를 반환한다")
+		void throws404WhenImageIsPending() {
+			assertNotFoundWhenImageStatusIsNotSafe(ImageProcessingStatus.PENDING);
+		}
+
+		@Test
+		@DisplayName("SCANNING 이미지를 조회하면 404를 반환한다")
+		void throws404WhenImageIsScanning() {
+			assertNotFoundWhenImageStatusIsNotSafe(ImageProcessingStatus.SCANNING);
+		}
+
+		@Test
+		@DisplayName("REJECTED 이미지를 조회하면 404를 반환한다")
+		void throws404WhenImageIsRejected() {
+			assertNotFoundWhenImageStatusIsNotSafe(ImageProcessingStatus.REJECTED);
+		}
+
+		private void assertNotFoundWhenImageStatusIsNotSafe(ImageProcessingStatus status) {
+			// given
+			Note note = persistedNote(user(UPLOADER_ID));
+			NoteImage noteImage = noteImageWithStatus(note, status);
+			NoteImagePresignQuery query = new NoteImagePresignQuery(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.getPresignedUrl(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 publicId로 조회하면 404를 반환한다")
+		void throws404WhenImageNotFound() {
+			// given
+			NoteImagePresignQuery query = new NoteImagePresignQuery(UPLOADER_ID, NOTE_ID, UUID.randomUUID());
+			given(noteImageRepository.findByPublicIdAndNote_Id(any(), any()))
+					.willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.getPresignedUrl(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+	}
+
 	private static NoteImageUploadCommand uploadCommand(Long noteId, String contentType) {
 		InputStreamSupplier supplier = () -> new ByteArrayInputStream("img".getBytes(StandardCharsets.UTF_8));
 		return new NoteImageUploadCommand(
@@ -491,6 +621,12 @@ class NoteImageServiceTest {
 
 	private static Note persistedNote(User author) {
 		Note note = Note.create(author, null, "제목", "본문", NoteVisibility.PRIVATE, false);
+		ReflectionTestUtils.setField(note, "id", NOTE_ID);
+		return note;
+	}
+
+	private static Note persistedNote(User author, NoteVisibility visibility) {
+		Note note = Note.create(author, null, "제목", "본문", visibility, false);
 		ReflectionTestUtils.setField(note, "id", NOTE_ID);
 		return note;
 	}
@@ -534,6 +670,15 @@ class NoteImageServiceTest {
 
 	private static NoteImage noteImageWithStatus(ImageProcessingStatus status) {
 		NoteImage image = noteImage();
+		ReflectionTestUtils.setField(image, "status", status);
+		return image;
+	}
+
+	private static NoteImage noteImageWithStatus(Note note, ImageProcessingStatus status) {
+		User uploader = user(note.getAuthorId());
+		NoteImage image = NoteImage.create(
+				note, uploader, STORAGE_KEY, ORIGINAL_FILE_NAME, CONTENT_TYPE, FILE_SIZE
+		);
 		ReflectionTestUtils.setField(image, "status", status);
 		return image;
 	}

--- a/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/application/port/out/QuarantineObjectNotFoundException.java
+++ b/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/application/port/out/QuarantineObjectNotFoundException.java
@@ -1,0 +1,7 @@
+package com.keepgoing.keepgoing.worker.application.port.out;
+
+public class QuarantineObjectNotFoundException extends ImageStorageException {
+	public QuarantineObjectNotFoundException(String storageKey, Throwable cause) {
+		super("quarantine object not found: " + storageKey, cause);
+	}
+}

--- a/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/application/service/ImageProcessingService.java
+++ b/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/application/service/ImageProcessingService.java
@@ -9,6 +9,7 @@ import com.keepgoing.keepgoing.worker.application.port.out.ImageMediaTypeDetecto
 import com.keepgoing.keepgoing.worker.application.port.out.ImageProcessingResultPublisherPort;
 import com.keepgoing.keepgoing.worker.application.port.out.ImageSanitizerPort;
 import com.keepgoing.keepgoing.worker.application.port.out.ImageStoragePort;
+import com.keepgoing.keepgoing.worker.application.port.out.QuarantineObjectNotFoundException;
 import com.keepgoing.keepgoing.worker.domain.ImageMediaTypeValidator;
 import com.keepgoing.keepgoing.worker.domain.ImageValidationFailureReason;
 import com.keepgoing.keepgoing.worker.domain.ImageValidationResult;
@@ -36,7 +37,13 @@ public class ImageProcessingService implements ImageProcessingUseCase {
 		String storageKey = command.storageKey();
 		String requestedContentType = command.contentType();
 
-		byte[] imageBytes = imageStoragePort.readQuarantineObject(storageKey);
+		byte[] imageBytes;
+		try {
+			imageBytes = imageStoragePort.readQuarantineObject(storageKey);
+		} catch (QuarantineObjectNotFoundException e) {
+			log.warn("이미 삭제된 파일, 처리 생략: publicId={}, storageKey={}", publicId, storageKey);
+			return;
+		}
 
 		publishScanningEvent(command);
 

--- a/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/infrastructure/adapter/out/storage/MinioImageStorageAdapter.java
+++ b/keepgoing-worker/src/main/java/com/keepgoing/keepgoing/worker/infrastructure/adapter/out/storage/MinioImageStorageAdapter.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepgoing.worker.infrastructure.adapter.out.storage;
 
 import com.keepgoing.keepgoing.worker.application.port.out.ImageStorageException;
 import com.keepgoing.keepgoing.worker.application.port.out.ImageStoragePort;
+import com.keepgoing.keepgoing.worker.application.port.out.QuarantineObjectNotFoundException;
 import com.keepgoing.keepgoing.worker.infrastructure.config.storage.StorageProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
@@ -33,6 +35,8 @@ public class MinioImageStorageAdapter implements ImageStoragePort {
 			ResponseBytes<GetObjectResponse> response
 					= s3Client.getObjectAsBytes(request);
 			return response.asByteArray();
+		} catch (NoSuchKeyException e) {
+			throw new QuarantineObjectNotFoundException(storageKey, e);
 		} catch (AwsServiceException | SdkClientException e) {
 			throw new ImageStorageException(
 					"quarantine object 읽기 실패: " + storageKey, e

--- a/keepgoing-worker/src/test/java/com/keepgoing/keepgoing/worker/application/service/ImageProcessingServiceTest.java
+++ b/keepgoing-worker/src/test/java/com/keepgoing/keepgoing/worker/application/service/ImageProcessingServiceTest.java
@@ -21,6 +21,7 @@ import com.keepgoing.keepgoing.worker.application.port.out.ImageProcessingResult
 import com.keepgoing.keepgoing.worker.application.port.out.ImageSanitizerPort;
 import com.keepgoing.keepgoing.worker.application.port.out.ImageStorageException;
 import com.keepgoing.keepgoing.worker.application.port.out.ImageStoragePort;
+import com.keepgoing.keepgoing.worker.application.port.out.QuarantineObjectNotFoundException;
 import com.keepgoing.keepgoing.worker.domain.ImageValidationFailureReason;
 import java.time.Clock;
 import java.time.Instant;
@@ -205,6 +206,26 @@ class ImageProcessingServiceTest {
 		then(imageSanitizer).shouldHaveNoInteractions();
 		then(imageStorage).should(never())
 				.putSecureObject(anyString(), any(), anyString());
+	}
+
+	@Test
+	@DisplayName("이미 삭제된 quarantine object면 처리 결과를 발행하지 않고 조용히 생략한다")
+	void skipsProcessingWhenQuarantineObjectWasAlreadyDeleted() {
+		// given
+		ImageProcessingCommand command = command(IMAGE_PNG);
+		given(imageStorage.readQuarantineObject(command.storageKey()))
+				.willThrow(new QuarantineObjectNotFoundException(command.storageKey(), new RuntimeException()));
+
+		// when
+		imageProcessingService.process(command);
+
+		// then
+		then(imageStorage).should().readQuarantineObject(command.storageKey());
+		then(resultPublisher).shouldHaveNoInteractions();
+		then(imageMediaTypeDetector).shouldHaveNoInteractions();
+		then(imageSanitizer).shouldHaveNoInteractions();
+		then(imageStorage).should(never()).deleteQuarantineObject(command.storageKey());
+		then(imageStorage).should(never()).putSecureObject(anyString(), any(), anyString());
 	}
 
 	@Test


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- closes #125
- 선행 PR: #126

### ✨ 반영 브랜치
feat/125 -> feat/115

> #126(`feat/115`) 위에 쌓인 stacked PR입니다. #126 병합 후 base를 `develop`으로 변경하거나, #126과 함께 순차 병합하는 전제입니다.

### 📝 변경 사항
- [x] `GET /api/notes/{noteId}/images/{publicId}` 기반 노트 이미지 Presigned URL redirect API를 추가했습니다.
- [x] `DELETE /api/notes/{noteId}/images/{publicId}` 기반 에디터 업로드 이미지 삭제 API를 추가했습니다.
- [x] `PENDING/SCANNING` 이미지는 quarantine bucket, `SAFE` 이미지는 secure bucket에서 삭제하도록 상태별 storage 정리 정책을 분리했습니다.
- [x] 삭제된 이미지에 worker 결과가 늦게 도착하는 경우를 정상 경합으로 처리하고, 늦은 `SAFE` 결과의 secure object를 정리하도록 보강했습니다.
- [x] worker가 이미 삭제된 quarantine object를 읽으려는 경우 처리 결과 발행 없이 생략하도록 보강했습니다.
- [x] controller/service/storage/worker 단위 테스트를 추가했습니다.

### ➕ 추가 메모
- 이 삭제 API는 에디터에서 잘못 올린 이미지를 사용자가 본문에서 제거하는 경우를 위한 명시적 폐기 API입니다.
- FE Tiptap 이미지 노드 삭제 감지 및 API 호출 연결, 저장된 Markdown의 orphan image batch cleanup은 이번 PR 범위에서 제외했습니다.
- 운영 storage는 기존 S3-compatible 설정을 그대로 사용합니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
```bash
./gradlew :keepgoing-api:test \
  --tests com.keepgoing.keepgoing.note.service.NoteImageServiceTest \
  --tests com.keepgoing.keepgoing.note.controller.NoteImageControllerTest \
  --tests com.keepgoing.keepgoing.global.storage.MinioObjectStorageClientTest \
  :keepgoing-worker:test \
  --tests com.keepgoing.keepgoing.worker.application.service.ImageProcessingServiceTest
```

```text
BUILD SUCCESSFUL
```

```bash
git diff --check
```

```text
통과
```

참고: 전체 `:keepgoing-api:test`, `:keepgoing-worker:test`는 현재 로컬 Docker/Testcontainers 환경 부재로 기존 통합 테스트들이 실패했습니다. 실패 원인은 `Could not find a valid Docker environment`입니다.
