### PR TITLE
feat(infra): #127 Worker 컨테이너 분리 배포

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI - Spring Boot Gradle Test
 
 on:
-  push:
-    branches: [ "develop", "feat/**" ]
   pull_request:
     branches: [ "develop" ]
+  push:
+    branches: [ "develop" ]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -1,4 +1,4 @@
-name: Deploy API to OCI
+name: Deploy to OCI
 
 on:
   workflow_dispatch:
@@ -10,12 +10,12 @@ permissions:
   packages: write
 
 concurrency:
-  group: deploy-oci-api
+  group: deploy-oci
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Build image and deploy API
+    name: Build images and deploy API + Worker
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -33,18 +33,26 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Test and build API module
-        run: ./gradlew clean :keepgoing-api:test :keepgoing-api:bootJar --no-daemon
+      - name: Test and build all modules
+        run: ./gradlew clean :keepgoing-api:test :keepgoing-worker:test :keepgoing-api:bootJar :keepgoing-worker:bootJar --no-daemon
 
-      - name: Resolve image metadata
+      - name: Resolve API image metadata
         run: |
           set -euo pipefail
           image_name="ghcr.io/${GITHUB_REPOSITORY_OWNER}/keepgoing-be-api"
           image_name="$(printf '%s' "$image_name" | tr '[:upper:]' '[:lower:]')"
           image_tag="${GITHUB_SHA::12}"
 
-          echo "IMAGE_NAME=$image_name" >> "$GITHUB_ENV"
+          echo "API_IMAGE=$image_name" >> "$GITHUB_ENV"
           echo "IMAGE_TAG=$image_tag" >> "$GITHUB_ENV"
+
+      - name: Resolve Worker image metadata
+        run: |
+          set -euo pipefail
+          worker_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/keepgoing-be-worker"
+          worker_image="$(printf '%s' "$worker_image" | tr '[:upper:]' '[:lower:]')"
+
+          echo "WORKER_IMAGE=$worker_image" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -56,16 +64,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push linux/arm64 image
+      - name: Build and push API linux/arm64 image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
+          target: api-runtime
           platforms: linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.API_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.API_IMAGE }}:latest
+
+      - name: Build and push Worker linux/arm64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: worker-runtime
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.WORKER_IMAGE }}:${{ env.IMAGE_TAG }}
+            ${{ env.WORKER_IMAGE }}:latest
 
       - name: Prepare SSH
         env:
@@ -82,6 +103,21 @@ jobs:
           ssh-keyscan -H "$OCI_HOST" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
+      - name: Sync config files to server
+        env:
+          OCI_HOST: ${{ secrets.OCI_HOST }}
+          OCI_USER: ${{ secrets.OCI_USER }}
+        run: |
+          set -euo pipefail
+          scp -i ~/.ssh/oci_key \
+            docker-compose.prod.yml \
+            "$OCI_USER@$OCI_HOST:/srv/keepgoing/docker-compose.prod.yml"
+          ssh -i ~/.ssh/oci_key "$OCI_USER@$OCI_HOST" \
+            "mkdir -p /srv/keepgoing/infra/scripts"
+          scp -i ~/.ssh/oci_key \
+            infra/scripts/deploy-prod.sh infra/scripts/deploy-prod-tls.sh \
+            "$OCI_USER@$OCI_HOST:/srv/keepgoing/infra/scripts/"
+
       - name: Deploy on OCI
         env:
           OCI_HOST: ${{ secrets.OCI_HOST }}
@@ -89,7 +125,7 @@ jobs:
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/oci_key "$OCI_USER@$OCI_HOST" \
-            "IMAGE_NAME='$IMAGE_NAME' IMAGE_TAG='$IMAGE_TAG' bash -s" <<'REMOTE'
+            "API_IMAGE='$API_IMAGE' WORKER_IMAGE='$WORKER_IMAGE' IMAGE_TAG='$IMAGE_TAG' bash -s" <<'REMOTE'
           set -euo pipefail
 
           cd /srv/keepgoing
@@ -119,8 +155,10 @@ jobs:
             grep -E "^${key}=" .env.prod | tail -n 1 | cut -d= -f2- || true
           }
 
-          set_env APP_IMAGE "$IMAGE_NAME"
+          set_env APP_IMAGE "$API_IMAGE"
           set_env APP_IMAGE_TAG "$IMAGE_TAG"
+          set_env WORKER_IMAGE "$WORKER_IMAGE"
+          set_env WORKER_IMAGE_TAG "$IMAGE_TAG"
 
           compose_files=(-f docker-compose.prod.yml)
           tls_enabled="$(get_env DEPLOY_TLS_ENABLED)"
@@ -132,7 +170,7 @@ jobs:
             compose_files+=(-f docker-compose.prod.tls.yml)
           fi
 
-          docker compose --env-file .env.prod "${compose_files[@]}" pull app
+          docker compose --env-file .env.prod "${compose_files[@]}" pull app worker
           docker compose --env-file .env.prod "${compose_files[@]}" up -d
           docker compose --env-file .env.prod "${compose_files[@]}" ps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,13 @@ COPY keepgoing-common ./keepgoing-common
 
 RUN chmod +x gradlew
 
-RUN ./gradlew :keepgoing-api:bootJar --no-daemon \
-    && cp /workspace/keepgoing-api/build/libs/*.jar /workspace/app.jar
+RUN ./gradlew :keepgoing-api:bootJar :keepgoing-worker:bootJar --no-daemon \
+    && cp /workspace/keepgoing-api/build/libs/*.jar /workspace/api.jar \
+    && cp /workspace/keepgoing-worker/build/libs/*.jar /workspace/worker.jar
 
-FROM eclipse-temurin:21-jre-jammy AS runtime
+
+# ---- API runtime ----
+FROM eclipse-temurin:21-jre-jammy AS api-runtime
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
@@ -24,13 +27,32 @@ RUN apt-get update \
 
 WORKDIR /app
 
-COPY --from=builder /workspace/app.jar /app/app.jar
+COPY --from=builder /workspace/api.jar /app/app.jar
 
 ENV TZ=Asia/Seoul \
     SPRING_PROFILES_ACTIVE=prod \
     JAVA_OPTS="-Xms256m -Xmx1024m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
 
 EXPOSE 8080
+
+USER appuser
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]
+
+
+# ---- Worker runtime ----
+FROM eclipse-temurin:21-jre-jammy AS worker-runtime
+
+RUN groupadd --system appuser \
+    && useradd --system --gid appuser --create-home --home-dir /app appuser
+
+WORKDIR /app
+
+COPY --from=builder /workspace/worker.jar /app/app.jar
+
+ENV TZ=Asia/Seoul \
+    SPRING_PROFILES_ACTIVE=prod \
+    JAVA_OPTS="-Xms128m -Xmx384m -XX:+UseG1GC"
 
 USER appuser
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,27 @@ services:
     networks:
       - keepgoing-net
 
+  redis:
+    image: redis:7-alpine
+    container_name: keepgoing-redis
+    restart: unless-stopped
+    mem_limit: 256m
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+    volumes:
+      - ${REDIS_DATA_DIR:-./var/redis-data}:/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - keepgoing-net
+
   app:
     image: ${APP_IMAGE:-ghcr.io/keepgoing-web/keepgoing-be-api}:${APP_IMAGE_TAG:-latest}
     container_name: keepgoing-app
@@ -36,8 +57,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       TZ: ${TZ:-Asia/Seoul}
+      REDIS_HOST: redis
+      IMAGE_PROCESSING_STREAMS_ENABLED: "true"
     expose:
       - "8080"
     healthcheck:
@@ -68,6 +93,30 @@ services:
       - "${NGINX_HTTP_PORT:-80}:80"
     volumes:
       - ./infra/nginx/keepgoing.conf:/etc/nginx/templates-http/default.conf.template:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - keepgoing-net
+
+  worker:
+    image: ${WORKER_IMAGE:-ghcr.io/keepgoing-web/keepgoing-be-worker}:${WORKER_IMAGE_TAG:-latest}
+    container_name: keepgoing-worker
+    restart: unless-stopped
+    mem_limit: 512m
+    env_file:
+      - ./.env.db
+      - ./.env.app
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      TZ: ${TZ:-Asia/Seoul}
+      REDIS_HOST: redis
+      IMAGE_PROCESSING_STREAMS_ENABLED: "true"
+    stop_grace_period: 60s
     logging:
       driver: json-file
       options:

--- a/infra/scripts/deploy-prod-tls.sh
+++ b/infra/scripts/deploy-prod-tls.sh
@@ -25,7 +25,7 @@ docker compose \
   --env-file "$ENV_FILE" \
   -f "$BASE_COMPOSE_FILE" \
   -f "$TLS_COMPOSE_FILE" \
-  pull app
+  pull app worker
 
 docker compose \
   --env-file "$ENV_FILE" \

--- a/infra/scripts/deploy-prod.sh
+++ b/infra/scripts/deploy-prod.sh
@@ -25,6 +25,6 @@ if grep -Ev '^\s*#|^\s*$' "$ENV_FILE" "$APP_ENV_FILE" "$DB_ENV_FILE" | grep -Eq 
   exit 1
 fi
 
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull app
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull app worker
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps

--- a/keepgoing-worker/src/main/resources/application.yml
+++ b/keepgoing-worker/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: keepgoing-worker
   main:
     web-application-type: none
+  lifecycle:
+    timeout-per-shutdown-phase: 50s
   data:
     redis:
       host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
- #127

### ✨ 반영 브랜치
feat/127 -> develop

### 📝 변경 사항
- [x] Dockerfile multi-target build 전환 (builder → api-runtime / worker-runtime)
- [x] docker-compose.prod.yml에 Redis + Worker 서비스 추가
- [x] Worker graceful shutdown 설정 (`spring.lifecycle.timeout-per-shutdown-phase: 50s`)
- [x] CD 워크플로우에 Worker 이미지 빌드/푸시/배포 및 config 동기화 step 추가
- [x] CI concurrency 추가 및 feat/** push 트리거 제거 (중복 실행 방지)
- [x] API 서버 Redis 네트워킹 보강 (REDIS_HOST, depends_on redis, STREAMS_ENABLED)
- [x] Redis 데이터 영속성 볼륨 추가
- [x] 배포 스크립트 worker 이미지 pull 대응 (deploy-prod.sh, deploy-prod-tls.sh)

### ➕ 추가 메모
- Worker `web-application-type: none` — HTTP healthcheck 불필요, restart: unless-stopped로 복구
- Antigravity + Codex 교차검증 완료 (4건 지적 반영: REDIS_HOST 명시, Redis 볼륨, API Redis 의존성, deploy-prod-tls.sh)
- 최초 배포 시 서버에서 `docker compose down && docker compose up -d` 필요 (신규 redis/worker 서비스 인식)
- MinIO는 운영 환경에서 외부 S3-compatible storage 사용 (설계 의도)

### 🐛 테스트 결과
- `./gradlew clean test` 통과
- Docker build 검증: `docker build --target api-runtime .`, `docker build --target worker-runtime .`