### PR TITLE
feat(note): #132 이미지 처리 상태 조회 API 추가

### DIFF
--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/NoteImageController.java
@@ -2,10 +2,13 @@ package com.keepgoing.keepgoing.note.controller;
 
 import com.keepgoing.keepgoing.global.api.response.ApiResponse;
 import com.keepgoing.keepgoing.note.controller.dto.request.NoteImageUploadRequest;
+import com.keepgoing.keepgoing.note.controller.dto.response.NoteImageStatusResponse;
 import com.keepgoing.keepgoing.note.controller.dto.response.NoteImageUploadResponse;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import jakarta.validation.Valid;
@@ -75,5 +78,20 @@ public class NoteImageController {
 		noteImageService.deleteImage(command);
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/{noteId}/images/{publicId}/status")
+	public ResponseEntity<ApiResponse<NoteImageStatusResponse>> getImageStatus(
+			@PathVariable Long noteId,
+			@PathVariable UUID publicId,
+			@AuthenticationPrincipal Long userId
+	) {
+		NoteImageStatusQuery query = new NoteImageStatusQuery(userId, noteId, publicId);
+
+		NoteImageStatusResult result = noteImageService.getStatus(query);
+
+		return ResponseEntity.ok()
+				.cacheControl(CacheControl.noStore())
+				.body(ApiResponse.success(NoteImageStatusResponse.from(result)));
 	}
 }

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/dto/response/NoteImageStatusResponse.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/controller/dto/response/NoteImageStatusResponse.java
@@ -1,0 +1,17 @@
+package com.keepgoing.keepgoing.note.controller.dto.response;
+
+import com.keepgoing.keepgoing.common.image.domain.ImageProcessingStatus;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusResult;
+import java.util.UUID;
+
+public record NoteImageStatusResponse(
+		UUID publicId,
+		ImageProcessingStatus status
+) {
+	public static NoteImageStatusResponse from(NoteImageStatusResult result) {
+		return new NoteImageStatusResponse(
+				result.publicId(),
+				result.status()
+		);
+	}
+}

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/NoteImageService.java
@@ -16,6 +16,8 @@ import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -164,6 +166,15 @@ public class NoteImageService {
 					e
 			);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public NoteImageStatusResult getStatus(NoteImageStatusQuery query) {
+		NoteImage noteImage = noteImageRepository.findByPublicIdAndNote_Id(query.publicId(), query.noteId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+		noteImage.validateUploader(query.userId());
+
+		return new NoteImageStatusResult(noteImage.getPublicId(), noteImage.getStatus());
 	}
 
 	private NoteImageUploadResult saveNoteImageInfo(

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageStatusQuery.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageStatusQuery.java
@@ -1,0 +1,10 @@
+package com.keepgoing.keepgoing.note.service.dto;
+
+import java.util.UUID;
+
+public record NoteImageStatusQuery(
+		Long userId,
+		Long noteId,
+		UUID publicId
+) {
+}

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageStatusResult.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/note/service/dto/NoteImageStatusResult.java
@@ -1,0 +1,10 @@
+package com.keepgoing.keepgoing.note.service.dto;
+
+import com.keepgoing.keepgoing.common.image.domain.ImageProcessingStatus;
+import java.util.UUID;
+
+public record NoteImageStatusResult(
+		UUID publicId,
+		ImageProcessingStatus status
+) {
+}

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/NoteImageIntegrationTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/NoteImageIntegrationTest.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepgoing.note;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -32,10 +33,13 @@ import com.keepgoing.keepgoing.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -430,6 +434,100 @@ class NoteImageIntegrationTest extends PostgreSqlTestContainerSupport {
 			}
 
 			then(objectStorageClient).should(never()).generatePresignedUrl(any(), any(), any());
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /api/notes/{noteId}/images/{publicId}/status")
+	class GetImageStatus {
+
+		@ParameterizedTest
+		@EnumSource(ImageProcessingStatus.class)
+		@DisplayName("작성자가 {0} 상태 이미지의 상태를 조회하면 200과 해당 상태를 반환하고 Cache-Control: no-store를 설정한다")
+		void returnsStatusForEachState(ImageProcessingStatus status) throws Exception {
+			// given
+			User author = saveUser("status-" + status.name() + "@test.com", "작성자");
+			Note note = saveNote(author, "상태 조회");
+			NoteImage image = saveNoteImage(note, author, "notes/" + note.getId() + "/" + status.name());
+			markStatus(image, status);
+			entityManager.flush();
+			entityManager.clear();
+			mockLoginUser(author.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status",
+							note.getId(), image.getPublicId()))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.publicId").value(image.getPublicId().toString()))
+					.andExpect(jsonPath("$.data.status").value(status.name()))
+					.andExpect(header().string("Cache-Control", containsString("no-store")));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 publicId로 조회하면 404를 반환한다")
+		void returns404WhenImageNotFound() throws Exception {
+			// given
+			User author = saveUser("notfound@test.com", "작성자");
+			Note note = saveNote(author, "없는 이미지");
+			mockLoginUser(author.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status",
+							note.getId(), UUID.randomUUID()))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_NOT_FOUND"));
+		}
+
+		@Test
+		@DisplayName("noteId가 일치하지 않으면 404를 반환한다")
+		void returns404WhenNoteIdMismatch() throws Exception {
+			// given
+			User author = saveUser("mismatch@test.com", "작성자");
+			Note note = saveNote(author, "노트1");
+			Note otherNote = saveNote(author, "노트2");
+			NoteImage image = saveNoteImage(note, author, "notes/" + note.getId() + "/key");
+			mockLoginUser(author.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status",
+							otherNote.getId(), image.getPublicId()))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_NOT_FOUND"));
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 PRIVATE 노트 이미지를 조회하면 403을 반환한다")
+		void returns403WhenNonUploaderOnPrivateNote() throws Exception {
+			// given
+			User author = saveUser("private-author@test.com", "작성자");
+			User requester = saveUser("requester@test.com", "요청자");
+			Note note = saveNote(author, "private 노트", NoteVisibility.PRIVATE);
+			NoteImage image = saveNoteImage(note, author, "notes/" + note.getId() + "/private-key");
+			mockLoginUser(requester.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status",
+							note.getId(), image.getPublicId()))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_ACCESS_DENIED"));
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 PUBLIC 노트 이미지를 조회해도 403을 반환한다")
+		void returns403WhenNonUploaderOnPublicNote() throws Exception {
+			// given
+			User author = saveUser("public-author@test.com", "작성자");
+			User requester = saveUser("public-requester@test.com", "요청자");
+			Note note = saveNote(author, "public 노트", NoteVisibility.PUBLIC);
+			NoteImage image = saveNoteImage(note, author, "notes/" + note.getId() + "/public-key");
+			mockLoginUser(requester.getId());
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status",
+							note.getId(), image.getPublicId()))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.error.code").value("NOTE_IMAGE_ACCESS_DENIED"));
 		}
 	}
 

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/controller/NoteImageControllerTest.java
@@ -24,6 +24,8 @@ import com.keepgoing.keepgoing.global.security.jwt.JwtProvider;
 import com.keepgoing.keepgoing.note.service.NoteImageService;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import java.util.List;
@@ -403,6 +405,92 @@ class NoteImageControllerTest {
 					.andExpect(status().isForbidden())
 					.andExpect(jsonPath("$.success").value(false))
 					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_IMAGE_ACCESS_DENIED.name()));
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /api/notes/{noteId}/images/{publicId}/status")
+	class GetImageStatusTest {
+
+		@Test
+		@DisplayName("인증 사용자가 이미지 상태를 조회하면 200과 publicId/status를 반환하고 Cache-Control: no-store를 설정한다")
+		void returnsImageStatusWithNoStoreCacheControl() throws Exception {
+			// given
+			Long userId = 1L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			NoteImageStatusResult result = new NoteImageStatusResult(publicId, ImageProcessingStatus.SCANNING);
+
+			mockLoginUser(userId);
+			given(noteImageService.getStatus(any(NoteImageStatusQuery.class)))
+					.willReturn(result);
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status", noteId, publicId))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.success").value(true))
+					.andExpect(jsonPath("$.data.publicId").value(publicId.toString()))
+					.andExpect(jsonPath("$.data.status").value(ImageProcessingStatus.SCANNING.name()))
+					.andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("no-store")));
+
+			ArgumentCaptor<NoteImageStatusQuery> captor = ArgumentCaptor.forClass(NoteImageStatusQuery.class);
+			then(noteImageService).should().getStatus(captor.capture());
+
+			NoteImageStatusQuery query = captor.getValue();
+			assertThat(query.userId()).isEqualTo(userId);
+			assertThat(query.noteId()).isEqualTo(noteId);
+			assertThat(query.publicId()).isEqualTo(publicId);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이미지면 404를 반환한다")
+		void returns404WhenImageNotFound() throws Exception {
+			// given
+			Long userId = 1L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			mockLoginUser(userId);
+			given(noteImageService.getStatus(any(NoteImageStatusQuery.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status", noteId, publicId))
+					.andExpect(status().isNotFound())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_IMAGE_NOT_FOUND.name()));
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 조회하면 403을 반환한다")
+		void returns403WhenRequesterIsNotUploader() throws Exception {
+			// given
+			Long userId = 2L;
+			Long noteId = 10L;
+			UUID publicId = UUID.randomUUID();
+			mockLoginUser(userId);
+			given(noteImageService.getStatus(any(NoteImageStatusQuery.class)))
+					.willThrow(new BusinessException(ErrorCode.NOTE_IMAGE_ACCESS_DENIED));
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status", noteId, publicId))
+					.andExpect(status().isForbidden())
+					.andExpect(jsonPath("$.success").value(false))
+					.andExpect(jsonPath("$.error.code").value(ErrorCode.NOTE_IMAGE_ACCESS_DENIED.name()));
+		}
+
+		@Test
+		@DisplayName("유효하지 않은 publicId 형식이면 400을 반환하고 서비스를 호출하지 않는다")
+		void returns400WhenPublicIdIsInvalid() throws Exception {
+			// given
+			Long userId = 1L;
+			Long noteId = 10L;
+			mockLoginUser(userId);
+
+			// when & then
+			mockMvc.perform(get("/api/notes/{noteId}/images/{publicId}/status", noteId, "invalid-uuid"))
+					.andExpect(status().isBadRequest());
+
+			then(noteImageService).shouldHaveNoInteractions();
 		}
 	}
 

--- a/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
+++ b/keepgoing-api/src/test/java/com/keepgoing/keepgoing/note/service/NoteImageServiceTest.java
@@ -35,6 +35,8 @@ import com.keepgoing.keepgoing.note.repository.NoteImageRepository;
 import com.keepgoing.keepgoing.note.repository.NoteRepository;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageDeleteCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImagePresignQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusQuery;
+import com.keepgoing.keepgoing.note.service.dto.NoteImageStatusResult;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadCommand;
 import com.keepgoing.keepgoing.note.service.dto.NoteImageUploadResult;
 import com.keepgoing.keepgoing.user.domain.User;
@@ -747,6 +749,65 @@ class NoteImageServiceTest {
 			assertThatThrownBy(() -> noteImageService.getPresignedUrl(query))
 					.isInstanceOf(BusinessException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+	}
+
+	@Nested
+	@DisplayName("getStatus")
+	class GetStatusTest {
+
+		@Test
+		@DisplayName("각 상태별로 올바른 ImageProcessingStatus를 반환한다")
+		void returnsStatusForEachState() {
+			for (ImageProcessingStatus status : ImageProcessingStatus.values()) {
+				// given
+				Note note = persistedNote(user(UPLOADER_ID));
+				NoteImage noteImage = noteImageWithStatus(note, status);
+				NoteImageStatusQuery query = new NoteImageStatusQuery(UPLOADER_ID, NOTE_ID, noteImage.getPublicId());
+
+				given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+						.willReturn(Optional.of(noteImage));
+
+				// when
+				NoteImageStatusResult result = noteImageService.getStatus(query);
+
+				// then
+				assertThat(result.publicId()).isEqualTo(noteImage.getPublicId());
+				assertThat(result.status()).isEqualTo(status);
+				verify(noteImageRepository).findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID);
+			}
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 이미지면 NOTE_IMAGE_NOT_FOUND를 던진다")
+		void throwsNotFoundWhenImageDoesNotExist() {
+			// given
+			NoteImageStatusQuery query = new NoteImageStatusQuery(UPLOADER_ID, NOTE_ID, UUID.randomUUID());
+			given(noteImageRepository.findByPublicIdAndNote_Id(any(), any()))
+					.willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.getStatus(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("업로더가 아닌 사용자가 조회하면 NOTE_IMAGE_ACCESS_DENIED를 던진다")
+		void throwsAccessDeniedWhenRequesterIsNotUploader() {
+			// given
+			Long otherUserId = 2L;
+			Note note = persistedNote(user(UPLOADER_ID));
+			NoteImage noteImage = noteImageWithStatus(note, ImageProcessingStatus.PENDING);
+			NoteImageStatusQuery query = new NoteImageStatusQuery(otherUserId, NOTE_ID, noteImage.getPublicId());
+
+			given(noteImageRepository.findByPublicIdAndNote_Id(noteImage.getPublicId(), NOTE_ID))
+					.willReturn(Optional.of(noteImage));
+
+			// when & then
+			assertThatThrownBy(() -> noteImageService.getStatus(query))
+					.isInstanceOf(BusinessException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTE_IMAGE_ACCESS_DENIED);
 		}
 	}
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- Closes #132

### ✨ 반영 브랜치
feat/132 -> develop

### 📝 변경 사항
- [x] `GET /api/notes/{noteId}/images/{publicId}/status` 엔드포인트 추가
- [x] `NoteImageService.getStatus()` — publicId + noteId로 NoteImage 조회, uploader 권한 검증, status 반환
- [x] `NoteImageStatusResponse` DTO (`publicId: UUID`, `status: ImageProcessingStatus`)
- [x] `NoteImageStatusQuery` / `NoteImageStatusResult` 서비스 DTO (기존 Query/Result 패턴 따름)
- [x] `Cache-Control: no-store` 응답 헤더 설정 (빠르게 변하는 비동기 처리 상태)
- [x] 기존 `GET /api/notes/{noteId}/images/{publicId}` 302 리디렉션 계약 유지 (Breaking Change 없음)
- [x] 업로더만 조회 가능 (비업로더 → 403 NOTE_IMAGE_ACCESS_DENIED)

**테스트 추가:**
- [x] `NoteImageServiceTest` — 3케이스 (상태별 반환, NOT_FOUND, ACCESS_DENIED)
- [x] `NoteImageControllerTest` (@WebMvcTest) — 4케이스 (성공+Cache-Control, 404, 403, invalid UUID→400)
- [x] `NoteImageIntegrationTest` (@SpringBootTest) — 5케이스 (@ParameterizedTest 4상태+no-store, NOT_FOUND, noteId mismatch, PRIVATE 비업로더 403, PUBLIC 비업로더 403)

### ➕ 추가 메모
- **Cross-Validation 완료 (Codex + Antigravity):** 두 어드바이저 모두 구현/테스트 correctness 확인
  - `Cache-Control: no-store` 폴링 용도로 correct
  - 경로 설계 RESTful, 응답 구조 프로젝트 컨벤션 일치
  - ArgumentCaptor, @EnumSource, @Transactional 격리 패턴 적절
- **SecurityConfig `permitAll` (Codex HIGH):** `GET /api/notes/**`이 `permitAll()`이라 익명 접근 가능하나, 기존 redirect 엔드포인트와 동일한 기존 보안 정책. 별도 이슈에서 분리 필요.
- `isUploader(null)`은 null-safe → 익명 사용자는 NPE가 아닌 403 반환
- `docs/db/keepgoing.erd.json`은 본 PR 범위 외 변경이므로 커밋에서 제외

### 🐛 테스트 결과
```bash
./gradlew :keepgoing-api:test
```
```
BUILD SUCCESSFUL in 37s
7 actionable tasks: 3 executed, 4 up-to-date
```

모든 테스트 통과 (Service 3 + Controller 4 + Integration 5 = 12케이스)