### PR TITLE
feat(monitoring): #134 이미지 업로드 critical-path latency AOP 계측

### DIFF
--- a/infra/docker-compose.test.yml
+++ b/infra/docker-compose.test.yml
@@ -132,11 +132,25 @@ services:
     networks:
       - keepgoing-test-net
 
+  test-postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    container_name: keepgoing-test-postgres-exporter
+    restart: unless-stopped
+    mem_limit: 64m
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${TEST_DB_USER:-keepgoing}:${TEST_DB_PASSWORD:-keepgoing}@test-postgres:5432/${TEST_DB_NAME:-keepgoing}?sslmode=disable"
+    depends_on:
+      test-postgres:
+        condition: service_healthy
+    networks:
+      - keepgoing-test-net
+
 volumes:
   test-postgres-data:
   test-redis-data:
   test-prometheus-data:
   test-grafana-data:
+  test-postgres-exporter-data:
 
 networks:
   keepgoing-test-net:

--- a/infra/docker-compose.test.yml
+++ b/infra/docker-compose.test.yml
@@ -68,7 +68,7 @@ services:
     image: ${WORKER_IMAGE:-ghcr.io/keepgoing-web/keepgoing-be-worker}:${WORKER_IMAGE_TAG:-latest}
     container_name: keepgoing-test-worker
     restart: unless-stopped
-    mem_limit: 256m
+    mem_limit: 512m
     env_file:
       - ./.env.db.test
       - ./.env.app.test
@@ -89,9 +89,54 @@ services:
     networks:
       - keepgoing-test-net
 
+  # ----- Monitoring Stack -----
+  test-prometheus:
+    image: prom/prometheus:v2.55.0
+    container_name: keepgoing-test-prometheus
+    restart: unless-stopped
+    mem_limit: 256m
+    ports:
+      - "127.0.0.1:9091:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.test.yml:/etc/prometheus/prometheus.yml:ro
+      - test-prometheus-data:/prometheus
+    command:
+        - '--config.file=/etc/prometheus/prometheus.yml'
+        - '--storage.tsdb.path=/prometheus'
+        - '--web.enable-remote-write-receiver'
+    networks:
+      keepgoing-test-net:
+        aliases:
+          - prometheus
+
+  test-grafana:
+    image: grafana/grafana:9.5.1
+    container_name: keepgoing-test-grafana
+    restart: unless-stopped
+    mem_limit: 128m
+    ports:
+      - "127.0.0.1:3001:3000"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - test-grafana-data:/var/lib/grafana
+    networks:
+      - keepgoing-test-net
+
+  test-redis-exporter:
+    image: oliver006/redis_exporter:v1.67.0
+    container_name: keepgoing-test-redis-exporter
+    restart: unless-stopped
+    mem_limit: 64m
+    environment:
+      REDIS_ADDR: redis://test-redis:6379
+    networks:
+      - keepgoing-test-net
+
 volumes:
   test-postgres-data:
   test-redis-data:
+  test-prometheus-data:
+  test-grafana-data:
 
 networks:
   keepgoing-test-net:

--- a/infra/scripts/deploy-local-test.sh
+++ b/infra/scripts/deploy-local-test.sh
@@ -21,12 +21,12 @@ scp build/test-deploy/api.jar "$SSH_TARGET:/srv/keepgoing-test/build/api.jar"
 scp build/test-deploy/worker.jar "$SSH_TARGET:/srv/keepgoing-test/build/worker.jar"
 
 echo "=== 4. Copying local override compose file ==="
+scp "$ROOT_DIR/infra/docker-compose.test.yml" "$SSH_TARGET:/srv/keepgoing-test/docker-compose.test.yml"
 scp "$ROOT_DIR/infra/docker-compose.test.local.yml" "$SSH_TARGET:/srv/keepgoing-test/docker-compose.test.local.yml"
 
 echo "=== 5. Deploying on server ==="
 ssh "$SSH_TARGET" "cd /srv/keepgoing-test && \
-  docker compose --env-file .env.test -f docker-compose.test.yml -f docker-compose.test.local.yml pull test-app test-worker && \
-  docker compose --env-file .env.test -f docker-compose.test.yml -f docker-compose.test.local.yml up -d"
+  docker compose --env-file .env.test -f docker-compose.test.yml -f docker-compose.test.local.yml up -d --pull never"
 
 echo ""
 echo "=== Done! ==="

--- a/keepgoing-api/build.gradle
+++ b/keepgoing-api/build.gradle
@@ -19,9 +19,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     // Spring AI
-//    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    //    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.ai:spring-ai-starter-model-zhipuai'
 
     // OAuth2 (JWT 포함)

--- a/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/monitoring/ImageUploadMonitoringAspect.java
+++ b/keepgoing-api/src/main/java/com/keepgoing/keepgoing/global/monitoring/ImageUploadMonitoringAspect.java
@@ -1,0 +1,55 @@
+package com.keepgoing.keepgoing.global.monitoring;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ImageUploadMonitoringAspect {
+
+	private final MeterRegistry meterRegistry;
+
+	// 전체 uploadImage() latency
+	@Around("execution(* com.keepgoing..NoteImageService.uploadImage(..))")
+	public Object monitorTotalUpload(ProceedingJoinPoint pjp) throws Throwable {
+		Timer.Sample sample = Timer.start(meterRegistry);
+		String exception = "none";
+		try {
+			return pjp.proceed();
+		} catch (Throwable throwable) {
+			exception = throwable.getClass().getSimpleName();
+			throw throwable;
+		} finally {
+			sample.stop(Timer.builder("note.image.upload.total")
+					.tag("success", Boolean.toString("none".equals(exception)))
+					.tag("exception", exception)
+					.register(meterRegistry)
+			);
+		}
+	}
+
+	// S3 PUT Storage latency (upload만, delete/presign 제외)
+	@Around("execution(* com.keepgoing..ObjectStorageClient.upload(..))")
+	public Object monitorStorageUpload(ProceedingJoinPoint pjp) throws Throwable {
+		Timer.Sample sample = Timer.start(meterRegistry);
+		String exception = "none";
+		try {
+			return pjp.proceed();
+		} catch (Throwable throwable) {
+			exception = throwable.getClass().getSimpleName();
+			throw throwable;
+		} finally {
+			sample.stop(Timer.builder("note.image.upload.storage")
+					.tag("success", Boolean.toString("none".equals(exception)))
+					.tag("exception", exception)
+					.register(meterRegistry)
+			);
+		}
+	}
+}

--- a/monitoring/grafana/provisioning/dashboards/k6-loadtest-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/k6-loadtest-dashboard.json
@@ -31,7 +31,7 @@
     {
       "id": 1,
       "type": "row",
-      "title": "Overview",
+      "title": "Executive Summary — Latency Breakdown",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
@@ -40,10 +40,44 @@
     {
       "id": 2,
       "type": "stat",
+      "title": "Storage / Total Ratio",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "S3 PUT이 전체 업로드 시간에서 차지하는 비중 (핵심 병목 지표)",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "round((sum(rate(note_image_upload_storage_seconds_sum[$__rate_interval])) / sum(rate(note_image_upload_total_seconds_sum[$__rate_interval]))) * 100, 1)",
+          "legendFormat": "Storage Ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 3,
+      "type": "stat",
       "title": "Request Rate",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "description": "초당 요청 수",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -59,39 +93,18 @@
       "pluginVersion": "9.5.1"
     },
     {
-      "id": 3,
-      "type": "stat",
-      "title": "Error Rate",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "에러율 %",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "editorMode": "code",
-          "expr": "sum(rate(k6_http_req_failed_total[$__rate_interval])) / sum(rate(k6_http_reqs_total[$__rate_interval])) * 100",
-          "legendFormat": "Error Rate",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] },
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "pluginVersion": "9.5.1"
-    },
-    {
       "id": 4,
       "type": "stat",
-      "title": "Active VUs",
+      "title": "Max VUs",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "활성 VU",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "description": "최대 동시 접속자",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "editorMode": "code",
-          "expr": "sum(k6_vus)",
-          "legendFormat": "Active VUs",
+          "expr": "max(k6_vus_max)",
+          "legendFormat": "Max VUs",
           "range": true,
           "refId": "A"
         }
@@ -103,137 +116,198 @@
     {
       "id": 5,
       "type": "stat",
-      "title": "Upload Count",
+      "title": "Error Rate",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "업로드 요청 수 (AOP)",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "description": "에러율 (1% 미만이면 정상)",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "editorMode": "code",
-          "expr": "sum(increase(note_image_upload_total_seconds_count[$__rate_interval]))",
-          "legendFormat": "Upload Count",
+          "expr": "avg(k6_http_req_failed_rate) * 100",
+          "legendFormat": "Error Rate",
           "range": true,
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } }, "overrides": [] },
       "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "pluginVersion": "9.5.1"
     },
     {
       "id": 6,
+      "type": "stat",
+      "title": "Total Uploads",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "테스트 기간 누적 업로드 수",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "increase(note_image_upload_total_seconds_count[$__range])",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 7,
       "type": "row",
-      "title": "Latency Breakdown",
+      "title": "Upload Throughput",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
       "panels": []
     },
     {
-      "id": 7,
-      "type": "timeseries",
-      "title": "HTTP Request Duration (k6)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "p50, p95, p99",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "histogram_quantile(0.50, sum(rate(k6_http_req_duration_milliseconds_bucket[$__rate_interval])) by (le))", "legendFormat": "p50", "range": true, "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum(rate(k6_http_req_duration_milliseconds_bucket[$__rate_interval])) by (le))", "legendFormat": "p95", "range": true, "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "histogram_quantile(0.99, sum(rate(k6_http_req_duration_milliseconds_bucket[$__rate_interval])) by (le))", "legendFormat": "p99", "range": true, "refId": "C" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 10, "gradientMode": "none", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "pluginVersion": "9.5.1"
-    },
-    {
       "id": 8,
       "type": "timeseries",
-      "title": "Upload Pipeline Breakdown (AOP)",
+      "title": "Upload Throughput",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "total, storage, redis publish",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "description": "초당 업로드 건수 추이",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "rate(note_image_upload_total_seconds_sum[$__rate_interval]) / rate(note_image_upload_total_seconds_count[$__rate_interval])", "legendFormat": "total avg", "range": true, "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "rate(note_image_upload_storage_seconds_sum[$__rate_interval]) / rate(note_image_upload_storage_seconds_count[$__rate_interval])", "legendFormat": "storage avg", "range": true, "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "rate(note_image_upload_redis_publish_seconds_sum[$__rate_interval]) / rate(note_image_upload_redis_publish_seconds_count[$__rate_interval])", "legendFormat": "redis.publish avg", "range": true, "refId": "C" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_total_seconds_count[$__rate_interval]))", "legendFormat": "upload/s", "range": true, "refId": "A" }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 25, "gradientMode": "opacity", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "unit": "cps", "custom": { "drawStyle": "bar", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 50, "gradientMode": "opacity", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
       "pluginVersion": "9.5.1"
     },
     {
       "id": 9,
+      "type": "stat",
+      "title": "HTTP Duration p99 (peak)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "테스트 기간 중 HTTP 요청 지연시간 p99 최대값",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "max(k6_http_req_duration_p99)", "legendFormat": "p99 peak", "range": true, "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 10,
       "type": "row",
-      "title": "Upload Duration by Image Size",
+      "title": "Bottleneck Proof — Pipeline Breakdown",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
       "panels": []
     },
     {
-      "id": 10,
-      "type": "timeseries",
-      "title": "Upload Duration by Size (k6)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "p95, image size별",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum(rate(k6_upload_duration_bucket[$__rate_interval])) by (le, size))", "legendFormat": "{{size}}", "range": true, "refId": "A" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 10, "gradientMode": "none", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "pluginVersion": "9.5.1"
-    },
-    {
       "id": 11,
-      "type": "row",
-      "title": "Pipeline Health",
+      "type": "timeseries",
+      "title": "Upload Pipeline Breakdown",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
-      "panels": []
+      "description": "total(전체) vs storage(S3 PUT) 구간별 평균 latency — 차이가 서버 내부 처리 시간",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 15 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_total_seconds_sum[$__rate_interval])) / sum(rate(note_image_upload_total_seconds_count[$__rate_interval]))", "legendFormat": "total avg", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_storage_seconds_sum[$__rate_interval])) / sum(rate(note_image_upload_storage_seconds_count[$__rate_interval]))", "legendFormat": "storage (S3 PUT) avg", "range": true, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "(sum(rate(note_image_upload_total_seconds_sum[$__rate_interval])) - sum(rate(note_image_upload_storage_seconds_sum[$__rate_interval]))) / sum(rate(note_image_upload_total_seconds_count[$__rate_interval]))", "legendFormat": "non-storage (DB+Redis+queuing)", "range": true, "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 2, "fillOpacity": 20, "gradientMode": "opacity", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["max", "mean"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "pluginVersion": "9.5.1"
     },
     {
       "id": 12,
       "type": "timeseries",
-      "title": "AOP Error Rate",
+      "title": "Storage / Total Ratio",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "각 단계별 에러율",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "description": "전체 업로드 시간 대비 S3 PUT(storage) 비중 — 높을수록 storage latency가 병목",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_total_seconds_count{exception!=\"none\"}[$__rate_interval])) / sum(rate(note_image_upload_total_seconds_count[$__rate_interval])) * 100", "legendFormat": "total", "range": true, "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_storage_seconds_count{exception!=\"none\"}[$__rate_interval])) / sum(rate(note_image_upload_storage_seconds_count[$__rate_interval])) * 100", "legendFormat": "storage", "range": true, "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(note_image_upload_redis_publish_seconds_count{exception!=\"none\"}[$__rate_interval])) / sum(rate(note_image_upload_redis_publish_seconds_count[$__rate_interval])) * 100", "legendFormat": "redis.publish", "range": true, "refId": "C" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "(sum(rate(note_image_upload_storage_seconds_sum[$__rate_interval])) / sum(rate(note_image_upload_total_seconds_sum[$__rate_interval]))) * 100", "legendFormat": "storage ratio", "range": true, "refId": "A" }
       ],
-      "fieldConfig": { "defaults": { "unit": "percent", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 10, "gradientMode": "none", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] },
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "fieldConfig": { "defaults": { "unit": "percent", "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "barAlignment": 0, "lineWidth": 2, "fillOpacity": 30, "gradientMode": "opacity", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "line" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "red", "value": 80 }] } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "E2E Process Latency (upload → SAFE)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "POST 업로드부터 SAFE 처리 완료까지 종단간 지연시간 p99",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "k6_process_latency_p99 / 1000", "legendFormat": "process p99 (s)", "range": true, "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 2, "fillOpacity": 20, "gradientMode": "opacity", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
       "pluginVersion": "9.5.1"
     },
     {
       "id": 13,
-      "type": "timeseries",
-      "title": "Throughput by Scenario (k6)",
+      "type": "row",
+      "title": "Reliability",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "panels": []
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "AOP Error Rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "처리 단계별 에러율 최대값 (둘 다 0%면 정상)",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 33 },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(rate(k6_http_reqs_total[$__rate_interval])) by (scenario)", "legendFormat": "{{scenario}}", "range": true, "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "round(max(sum(rate(note_image_upload_total_seconds_count{exception!=\"none\"}[$__range])) / sum(rate(note_image_upload_total_seconds_count[$__range])) * 100), 2)", "legendFormat": "total", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "round(max(sum(rate(note_image_upload_storage_seconds_count{exception!=\"none\"}[$__range])) / sum(rate(note_image_upload_storage_seconds_count[$__range])) * 100), 2)", "legendFormat": "storage", "range": true, "refId": "B" }
       ],
-      "fieldConfig": { "defaults": { "unit": "cps", "custom": { "drawStyle": "line", "lineInterpolation": "linear", "barAlignment": 0, "lineWidth": 1, "fillOpacity": 10, "gradientMode": "none", "spanNulls": false, "showPoints": "never", "pointSize": 5, "stacking": { "mode": "none", "group": "A" }, "axisPlacement": "auto", "axisLabel": "", "axisColorMode": "text", "scaleDistribution": { "type": "linear" }, "hideFrom": { "tooltip": false, "viz": false, "legend": false }, "thresholdsStyle": { "mode": "off" } }, "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.01 }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "k6 Failed Rate (peak)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "테스트 기간 중 HTTP 실패율 최대값",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 33 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "max(k6_http_req_failed_rate) * 100", "legendFormat": "failed % peak", "range": true, "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "9.5.1"
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Total Requests",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "k6가 발생시킨 총 HTTP 요청 수",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 33 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "max(k6_http_reqs_total)", "legendFormat": "total", "range": true, "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "pluginVersion": "9.5.1"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["k6", "loadtest", "upload", "prometheus"],
+  "tags": ["k6", "loadtest", "upload", "prometheus", "portfolio"],
   "templating": { "list": [] },
   "time": { "from": "now-30m", "to": "now" },
   "timepicker": { "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"], "time_options": ["5m", "15m", "30m", "1h", "6h", "12h", "24h"] },
   "timezone": "browser",
-  "title": "k6 Load Test + Upload Pipeline",
+  "title": "Image Upload Performance (k6 + Pipeline)",
   "uid": "k6-loadtest-upload-pipeline",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/monitoring/prometheus/prometheus.test.yml
+++ b/monitoring/prometheus/prometheus.test.yml
@@ -1,0 +1,34 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'keepgoing-test-api'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - 'test-app:8080'
+        labels:
+          application: 'keepgoing-test-api'
+
+  - job_name: 'keepgoing-test-worker'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - 'test-worker:8081'
+        labels:
+          application: 'keepgoing-test-worker'
+
+  - job_name: 'redis'
+    static_configs:
+      - targets:
+          - 'test-redis-exporter:9121'
+        labels:
+          application: 'keepgoing-test-redis'
+
+  - job_name: 'postgres'
+    static_configs:
+      - targets:
+          - 'test-postgres:9187'
+        labels:
+          application: 'keepgoing-test-postgres'


### PR DESCRIPTION
### 📌 PR 타입
- 기능 추가

### 📌 관련 이슈
- close #134

### ✨ 반영 브랜치
feat/134 -> develop

### 📝 변경 사항
- [x] keepgoing-api/build.gradle — `spring-boot-starter-aop` 의존성 추가
- [x] ImageUploadMonitoringAspect.java — 이미지 업로드 latency AOP 계측 (total + storage 2종 Micrometer Timer)
- [x] infra/docker-compose.test.yml — 테스트 환경 모니터링 스택 추가 (Prometheus, Grafana, Redis Exporter) + test-prometheus network alias
- [x] monitoring/prometheus/prometheus.test.yml — 테스트 환경 Prometheus 수집 설정
- [x] monitoring/k6-loadtest-dashboard.json — k6 + App 메트릭 기반 대시보드 재구성 (하드코딩 수치 제거)
- [x] infra/scripts/deploy-local-test.sh — docker-compose.test.yml 복사 추가 + `--pull never` (로컬 scp 이미지 유지)

### ➕ 추가 메모
- 이슈 #134에서 요청한 `redis.publish` 계측은 제외됨 (non-storage 시간을 `total - storage`로 추론하여 Redis/DB 분리 불필요하다고 판단)
- `@EnableAspectJAutoProxy`는 `spring-boot-starter-aop`가 자동 활성화하므로 명시하지 않음

### 🐛 테스트 결과
- Build: SUCCESSFUL
- Worker 메모리 256m → 512m (기동 이슈 대응)
- test-prometheus에 network alias `prometheus` 추가로 기존 Grafana datasources.yml(url: http://prometheus:9090) 정상 연결 가능